### PR TITLE
X2: guard settings JSON parsing so one bad row can't wipe the config

### DIFF
--- a/electron/main/db/settingsStore.test.ts
+++ b/electron/main/db/settingsStore.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "./migrations";
+
+let db: Database.Database;
+
+vi.mock("./index", () => ({
+  getDb: () => db,
+}));
+
+const devLogMock = vi.hoisted(() => vi.fn());
+vi.mock("../devLog", () => ({ devLog: devLogMock }));
+
+import { getSetting, setSetting, getSettingsByPrefix, deleteSettingsByPrefix } from "./settingsStore";
+
+/** Writes a raw string straight into setting_value, bypassing setSetting's JSON.stringify —
+ * the only way to reproduce a row that isn't valid JSON (partial write, hand-edited DB, or a
+ * value written by a path that forgot to stringify). */
+function writeRawValue(name: string, raw: string): void {
+  db.prepare("INSERT INTO settings (setting_name, setting_value) VALUES (?, ?)").run(name, raw);
+}
+
+// A prefix of its own rather than the real "appSettings." — migrations seed rows under that
+// namespace, so asserting on the whole object would break every time a seed is added.
+const PREFIX = "storeTest.";
+
+describe("settingsStore", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    runMigrations(db);
+    devLogMock.mockClear();
+  });
+
+  describe("getSetting", () => {
+    it("round-trips a value through setSetting", () => {
+      setSetting(`${PREFIX}limit`, 20);
+      expect(getSetting(`${PREFIX}limit`, 5)).toBe(20);
+    });
+
+    it("returns the default when the row does not exist", () => {
+      expect(getSetting(`${PREFIX}missing`, "fallback")).toBe("fallback");
+    });
+
+    it("overwrites on a second write rather than inserting twice", () => {
+      setSetting(`${PREFIX}limit`, 20);
+      setSetting(`${PREFIX}limit`, 40);
+      expect(getSetting(`${PREFIX}limit`, 5)).toBe(40);
+      expect(
+        db.prepare("SELECT COUNT(*) AS n FROM settings WHERE setting_name = ?").get(`${PREFIX}limit`)
+      ).toEqual({ n: 1 });
+    });
+
+    it("falls back to the default when the stored value is not valid JSON", () => {
+      writeRawValue(`${PREFIX}broken`, "{not json");
+      expect(getSetting(`${PREFIX}broken`, "fallback")).toBe("fallback");
+    });
+
+    it("does not throw on an unparseable row", () => {
+      writeRawValue(`${PREFIX}broken`, "");
+      expect(() => getSetting(`${PREFIX}broken`, 0)).not.toThrow();
+    });
+
+    it("keeps a stored null distinct from a corrupt row", () => {
+      // `null` is a legitimate stored value, so it must survive as null rather than being
+      // mistaken for "unparseable" and replaced by the default.
+      setSetting(`${PREFIX}explicitNull`, null);
+      expect(getSetting(`${PREFIX}explicitNull`, "fallback")).toBeNull();
+    });
+
+    it("preserves falsy values instead of substituting the default", () => {
+      setSetting(`${PREFIX}off`, false);
+      setSetting(`${PREFIX}zero`, 0);
+      setSetting(`${PREFIX}empty`, "");
+      expect(getSetting(`${PREFIX}off`, true)).toBe(false);
+      expect(getSetting(`${PREFIX}zero`, 99)).toBe(0);
+      expect(getSetting(`${PREFIX}empty`, "x")).toBe("");
+    });
+
+    it("round-trips arrays and objects", () => {
+      setSetting(`${PREFIX}ids`, ["a", "b"]);
+      expect(getSetting<string[]>(`${PREFIX}ids`, [])).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("getSettingsByPrefix", () => {
+    it("returns every matching row keyed with the prefix stripped", () => {
+      setSetting(`${PREFIX}alpha`, 1);
+      setSetting(`${PREFIX}beta`, "two");
+      expect(getSettingsByPrefix(PREFIX)).toEqual({ alpha: 1, beta: "two" });
+    });
+
+    it("excludes rows outside the prefix", () => {
+      setSetting(`${PREFIX}alpha`, 1);
+      setSetting("other.alpha", 2);
+      expect(getSettingsByPrefix(PREFIX)).toEqual({ alpha: 1 });
+    });
+
+    it("skips an unparseable row and still returns the rest", () => {
+      // The whole point of the guard: one bad row used to throw here, which made settings:get
+      // reject, which made the renderer fall back to *every* default — reading as a wiped config.
+      setSetting(`${PREFIX}alpha`, 1);
+      writeRawValue(`${PREFIX}broken`, "{not json");
+      setSetting(`${PREFIX}beta`, "two");
+
+      expect(getSettingsByPrefix(PREFIX)).toEqual({ alpha: 1, beta: "two" });
+    });
+
+    it("omits the bad key entirely rather than setting it to undefined", () => {
+      // mergeWithDefaults spreads this object over the defaults, so an explicit `undefined`
+      // key would override the default it is supposed to fall back to.
+      writeRawValue(`${PREFIX}broken`, "{not json");
+      expect("broken" in getSettingsByPrefix(PREFIX)).toBe(false);
+    });
+
+    it("does not throw when every row is unparseable", () => {
+      writeRawValue(`${PREFIX}a`, "{");
+      writeRawValue(`${PREFIX}b`, "undefined");
+      expect(getSettingsByPrefix(PREFIX)).toEqual({});
+    });
+
+    it("returns an empty object when nothing matches", () => {
+      expect(getSettingsByPrefix(PREFIX)).toEqual({});
+    });
+  });
+
+  describe("logging a skipped row", () => {
+    it("names the key and its size so the row can be found", () => {
+      writeRawValue(`${PREFIX}broken`, "{not json");
+      getSetting(`${PREFIX}broken`, null);
+
+      const line = String(devLogMock.mock.calls.at(-1)?.[0]);
+      expect(line).toContain(`${PREFIX}broken`);
+      expect(line).toContain("9 bytes");
+    });
+
+    it("never echoes the stored value", () => {
+      // devLog writes to userData/debug.log — the file users attach to bug reports. JSON.parse's
+      // own message quotes up to ~30 characters of its input ("Unexpected token 'h',
+      // \"https://ap\"… is not valid JSON"), so a half-written appSettings.chatApiUrl row would
+      // put credentials on disk if the raw error were logged. Assert on a value that looks like
+      // one, so a regression here fails loudly rather than leaking quietly.
+      const secret = "https://api.example.com/v1?api_key=SUPERSECRETVALUE";
+      writeRawValue("appSettings.chatApiUrl", secret);
+
+      getSettingsByPrefix("appSettings.");
+
+      const logged = devLogMock.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(logged).toContain("appSettings.chatApiUrl");
+      expect(logged).not.toContain("SUPERSECRETVALUE");
+      // Not just the secret — no leading fragment of the value either, which is the form
+      // JSON.parse's message actually takes.
+      expect(logged).not.toContain("https://");
+    });
+
+    it("says nothing when every row parses", () => {
+      setSetting(`${PREFIX}fine`, 1);
+      getSettingsByPrefix(PREFIX);
+      expect(devLogMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteSettingsByPrefix", () => {
+    it("removes only the rows under the prefix", () => {
+      setSetting(`${PREFIX}alpha`, 1);
+      setSetting("other.alpha", 2);
+
+      deleteSettingsByPrefix(PREFIX);
+
+      expect(getSettingsByPrefix(PREFIX)).toEqual({});
+      expect(getSetting("other.alpha", null)).toBe(2);
+    });
+
+    it("removes unparseable rows too, so a corrupt row can be cleared", () => {
+      writeRawValue(`${PREFIX}broken`, "{not json");
+      deleteSettingsByPrefix(PREFIX);
+      expect(db.prepare("SELECT COUNT(*) AS n FROM settings WHERE setting_name LIKE ?").get(`${PREFIX}%`)).toEqual({
+        n: 0,
+      });
+    });
+  });
+});

--- a/electron/main/db/settingsStore.ts
+++ b/electron/main/db/settingsStore.ts
@@ -1,4 +1,36 @@
 import { getDb } from "./index";
+import { devLog } from "../devLog";
+
+/** Returned by parseSettingValue when a row's JSON can't be parsed. A plain `null` won't do:
+ * `null` is itself a legitimate stored value, and conflating the two would silently turn a
+ * corrupt row into a real setting. */
+const UNPARSEABLE = Symbol("unparseable");
+
+/**
+ * Parses one row's `setting_value`, degrading to UNPARSEABLE rather than throwing.
+ *
+ * A single malformed row used to take down every settings read: `getSettingsByPrefix` threw,
+ * `settings:get` rejected, and the renderer's useSettings fell back to *all* defaults — so one
+ * bad row read as "my entire configuration was wiped", API keys included, with only a devLog
+ * line to explain it. The decryption step in ipc/settings.ts already degrades per key for
+ * exactly this reason; parsing now matches it.
+ *
+ * Skipping the key (rather than substituting a value here) is what lets each caller apply its
+ * own default, which is the behaviour a missing row already has.
+ */
+function parseSettingValue(name: string, raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // The name and byte count only — never the value, and never JSON.parse's own message,
+    // which echoes up to ~30 characters of its input ("Unexpected token 'h', \"https://ap\"…").
+    // devLog writes to userData/debug.log, the file users are asked to attach to bug reports,
+    // and a half-written appSettings.chatApiUrl row can carry credentials in its query string.
+    // Length is enough to tell "empty row" from "truncated write" without echoing content.
+    devLog(`[settings] skipping ${name}: value is not valid JSON (${raw?.length ?? 0} bytes)`);
+    return UNPARSEABLE;
+  }
+}
 
 export function getSetting<T>(name: string, defaultValue: T): T {
   const db = getDb();
@@ -6,7 +38,8 @@ export function getSetting<T>(name: string, defaultValue: T): T {
     | { setting_value: string }
     | undefined;
   if (!row) return defaultValue;
-  return JSON.parse(row.setting_value) as T;
+  const value = parseSettingValue(name, row.setting_value);
+  return value === UNPARSEABLE ? defaultValue : (value as T);
 }
 
 export function setSetting(name: string, value: unknown): void {
@@ -26,7 +59,11 @@ export function getSettingsByPrefix(prefix: string): Record<string, unknown> {
     .all(`${prefix}%`) as { setting_name: string; setting_value: string }[];
   const result: Record<string, unknown> = {};
   for (const row of rows) {
-    result[row.setting_name.slice(prefix.length)] = JSON.parse(row.setting_value);
+    const value = parseSettingValue(row.setting_name, row.setting_value);
+    // Omit rather than include-as-undefined: mergeWithDefaults spreads this object over the
+    // defaults, and an explicit `undefined` key would override the default it should fall back to.
+    if (value === UNPARSEABLE) continue;
+    result[row.setting_name.slice(prefix.length)] = value;
   }
   return result;
 }


### PR DESCRIPTION
Finding **X2** from the settings review (`0-cowork/fixes/active/initial-fixes.md`). First fix in that worklist.

## Root cause

`getSetting` and `getSettingsByPrefix` (`electron/main/db/settingsStore.ts`) called `JSON.parse` with no `try`/`catch`.

One malformed `setting_value` row — partial write, hand-edited DB, or a value written by a path that forgot to stringify — made `getSettingsByPrefix` throw, which made `settings:get` reject, which made `useSettings` fall back to **every** default. One bad row read as "my entire configuration was wiped", API keys included, with a `devLog` line as the only signal.

The decryption step directly below it already degrades *per key* for exactly this reason, with a comment explaining why. The parse path never got the same treatment.

## What changed

- `parseSettingValue` wraps the parse and returns an `UNPARSEABLE` symbol on failure. A bad row is skipped so the caller applies its own default — the behaviour a *missing* row already has.
- A symbol rather than `null` as the failure marker: `null` is a legitimate stored value, and conflating the two would silently turn a corrupt row into a real setting.
- `getSettingsByPrefix` omits the key entirely rather than setting it to `undefined` — `mergeWithDefaults` spreads this object over the defaults, so an explicit `undefined` would override the default it should fall back to.

### One thing worth a look

The skip is logged with the setting **name and byte count only** — deliberately not `JSON.parse`'s own message, which quotes up to ~30 characters of its input:

```
Unexpected token 'h', "https://ap"... is not valid JSON
```

`devLog` writes to `userData/debug.log`, the file users are asked to attach to bug reports. A half-written `appSettings.chatApiUrl` row carries credentials in its query string, so logging the raw error would put them on disk. A test asserts the value never reaches the log — including no leading fragment, which is the form the message actually takes.

## Reproduced after fix

The new tests were run against the **pre-fix** `settingsStore.ts` (`git checkout origin/develop -- …`): **5 failed, 11 passed**, all five failures being the guard cases, each throwing `SyntaxError` out of `settingsStore.ts:29`. Restored the fix, re-ran: **19/19 pass**.

## Tests

Adds `electron/main/db/settingsStore.test.ts` — 19 tests. This was the **only store in `electron/main/db/` without a test file**. Covers round-trip, missing-row defaults, upsert, falsy-value preservation, stored-`null` vs corrupt-row distinction, prefix isolation, partial-corruption recovery, delete-by-prefix, and the log redaction above.

## Verify

| | |
|---|---|
| `npm run lint` (`src electron scripts`) | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **807 passed / 92 files** (788 / 91 before — +19 in one new file, no existing test touched) |

## Flagged, not fixed here

1. **Same pattern in `agentDataStore.ts:11,32`** — a line-for-line clone of this KV store (`getAgentData` / `listAgentData`). One corrupt `agent_data.value` row throws out of `listAgentData` the same way. Logged as a new finding.
2. **`migrations.ts:556`** (migration 27) parses `setting_value` unguarded. Worse failure mode — it throws *during migration*, so the app can't start — but it's a shipped migration, and the repo convention is never to edit one. Needs a decision.
3. **`eslint.config.mjs` ignores `dist` but not `dist-electron`**, so bare `npm run lint` lints the renderer bundle once you've built, reporting a spurious error. Pre-existing, hits every build-then-lint run. One-line fix, kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)