### PR TITLE
X8: ignore generated directories in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,13 @@ import tseslint from "typescript-eslint";
 import { globalIgnores } from "eslint/config";
 
 export default tseslint.config(
-  globalIgnores(["dist", "node_modules", "build"]),
+  // Every generated directory in .gitignore, not just `dist` — electron-vite writes all three
+  // bundles (main, preload, renderer) to dist-electron, and vitest writes coverage/. Without
+  // them, `npm run lint` is clean on a fresh checkout and fails the moment anyone runs
+  // `npm run build`, reporting missing-rule errors and unused-disable warnings from bundled
+  // third-party code. A lint stage whose answer depends on whether a build has run is worse
+  // than no lint stage.
+  globalIgnores(["dist", "dist-electron", "coverage", "node_modules", "build"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [js.configs.recommended, ...tseslint.configs.recommended],


### PR DESCRIPTION
Finding **X8** from the settings review worklist (`0-cowork/fixes/active/initial-fixes.md`). Found by running the verify gate for X2, not by the original review.

## Root cause

`eslint.config.mjs:9` — `globalIgnores(["dist", "node_modules", "build"])` misses `dist-electron/`, which is where electron-vite actually writes all three bundles (main, preload, renderer). `dist` alone only covers `npm run build:web`. `.gitignore:22` covers `dist-electron`; eslint didn't.

The result is a lint stage that gives a different answer depending on whether a build has run:

| | `npm run lint` |
|---|---|
| Fresh checkout | ✓ clean |
| After `npm run build` | ✗ 1 error, 2 warnings |

All three come from inside the 1.6 MB bundled renderer (`dist-electron/renderer/assets/index-*.js`), not from source — a missing-rule error for `redos-detector/no-unsafe-regex` and two unused-`eslint-disable` warnings from third-party code.

This is why `eslint src electron` rather than `npm run lint` had become the habit — the workaround was already in use, just undocumented.

## What changed

One line. Adds `dist-electron` and `coverage` so the ignore list matches the generated directories in `.gitignore`. `coverage/` has the identical problem the first time anyone runs vitest coverage — same line, same reason, so it belongs here rather than in a follow-up.

## Reproduced after fix

Before, with `dist-electron/` present: `npm run lint` → **exit 1**, 3 problems.
After: **exit 0**.

**Adjacent path checked** — that the ignore didn't over-broaden and silence source linting: appending an unused variable to `electron/main/devLog.ts` is still reported. Reverted after the check.

## Verify

| | |
|---|---|
| `npm run lint` (bare, with `dist-electron` present) | ✓ exit 0 |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ 807 passed / 92 files (unchanged — config-only) |

## Noticed, not changed

`/wiki/` is also gitignored and not in the eslint ignore list. Left alone: it's a local clone of the GitHub wiki rather than output this project generates, so it isn't the same class of problem and won't exist for most checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)