### PR TITLE
X6: guard agent_data JSON parsing, sharing the helper with settingsStore

### DIFF
--- a/electron/main/db/agentDataStore.test.ts
+++ b/electron/main/db/agentDataStore.test.ts
@@ -7,6 +7,7 @@ let db: Database.Database;
 vi.mock("./index", () => ({
   getDb: () => db,
 }));
+vi.mock("../devLog", () => ({ devLog: () => {} }));
 
 import { deleteAgentData, getAgentData, listAgentData, setAgentData } from "./agentDataStore";
 
@@ -14,6 +15,13 @@ function seedAgent(id: string) {
   db.prepare(
     `INSERT INTO agents (id, name, prompt, model) VALUES (?, ?, 'You are a test agent.', 'gpt-4.1-mini')`
   ).run(id, id);
+}
+
+/** Writes a raw string straight into the value column, bypassing setAgentData's JSON.stringify —
+ * the only way to reproduce a row that isn't valid JSON (partial write, hand-edited DB, or a
+ * value written by a path that forgot to stringify). */
+function writeRawValue(agentId: string, key: string, raw: string): void {
+  db.prepare("INSERT INTO agent_data (agent_id, key, value) VALUES (?, ?, ?)").run(agentId, key, raw);
 }
 
 describe("agentDataStore", () => {
@@ -63,5 +71,49 @@ describe("agentDataStore", () => {
     setAgentData("budget-agent", "monthly_budget", "1200");
     db.prepare("DELETE FROM agents WHERE id = ?").run("budget-agent");
     expect(listAgentData("budget-agent")).toEqual({});
+  });
+
+  describe("a row that isn't valid JSON", () => {
+    it("falls back to the default rather than throwing out of getAgentData", () => {
+      writeRawValue("budget-agent", "monthly_budget", "{not json");
+      expect(getAgentData("budget-agent", "monthly_budget", "fallback")).toBe("fallback");
+    });
+
+    it("is skipped by listAgentData, which still returns the rest", () => {
+      // One corrupt row used to throw here and take down every read for that agent.
+      setAgentData("budget-agent", "currency", "USD");
+      writeRawValue("budget-agent", "monthly_budget", "{not json");
+      setAgentData("budget-agent", "timezone", "UTC");
+
+      expect(listAgentData("budget-agent")).toEqual({ currency: "USD", timezone: "UTC" });
+    });
+
+    it("is omitted from listAgentData rather than set to undefined", () => {
+      writeRawValue("budget-agent", "monthly_budget", "{not json");
+      expect("monthly_budget" in listAgentData("budget-agent")).toBe(false);
+    });
+
+    it("does not throw when every row for the agent is corrupt", () => {
+      writeRawValue("budget-agent", "a", "{");
+      writeRawValue("budget-agent", "b", "undefined");
+      expect(listAgentData("budget-agent")).toEqual({});
+    });
+
+    it("does not affect a different agent's rows", () => {
+      writeRawValue("budget-agent", "monthly_budget", "{not json");
+      setAgentData("other-agent", "monthly_budget", "9999");
+      expect(listAgentData("other-agent")).toEqual({ monthly_budget: "9999" });
+    });
+
+    it("can still be cleared with deleteAgentData", () => {
+      writeRawValue("budget-agent", "monthly_budget", "{not json");
+      deleteAgentData("budget-agent", "monthly_budget");
+      expect(listAgentData("budget-agent")).toEqual({});
+    });
+
+    it("keeps a stored null distinct from a corrupt row", () => {
+      setAgentData("budget-agent", "explicit_null", null);
+      expect(getAgentData("budget-agent", "explicit_null", "fallback")).toBeNull();
+    });
   });
 });

--- a/electron/main/db/agentDataStore.ts
+++ b/electron/main/db/agentDataStore.ts
@@ -1,4 +1,5 @@
 import { getDb } from "./index";
+import { parseJsonColumn, UNPARSEABLE } from "./jsonColumn";
 
 /** Per-agent key/value store, scoped by agent_id — see migrations.ts v24 (agent_data table). */
 
@@ -8,7 +9,8 @@ export function getAgentData<T>(agentId: string, key: string, defaultValue: T): 
     | { value: string }
     | undefined;
   if (!row) return defaultValue;
-  return JSON.parse(row.value) as T;
+  const value = parseJsonColumn(`agent_data ${agentId}/${key}`, row.value);
+  return value === UNPARSEABLE ? defaultValue : (value as T);
 }
 
 export function setAgentData(agentId: string, key: string, value: unknown): void {
@@ -29,7 +31,11 @@ export function listAgentData(agentId: string): Record<string, unknown> {
   }[];
   const result: Record<string, unknown> = {};
   for (const row of rows) {
-    result[row.key] = JSON.parse(row.value);
+    const value = parseJsonColumn(`agent_data ${agentId}/${row.key}`, row.value);
+    // Omit rather than include-as-undefined, so a caller spreading this over its own defaults
+    // doesn't have the bad key override the default it should fall back to.
+    if (value === UNPARSEABLE) continue;
+    result[row.key] = value;
   }
   return result;
 }

--- a/electron/main/db/jsonColumn.test.ts
+++ b/electron/main/db/jsonColumn.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const devLogMock = vi.hoisted(() => vi.fn());
+vi.mock("../devLog", () => ({ devLog: devLogMock }));
+
+import { parseJsonColumn, UNPARSEABLE } from "./jsonColumn";
+
+describe("parseJsonColumn", () => {
+  beforeEach(() => {
+    devLogMock.mockClear();
+  });
+
+  it("returns the parsed value for valid JSON", () => {
+    expect(parseJsonColumn("x", '{"a":1}')).toEqual({ a: 1 });
+    expect(parseJsonColumn("x", "[1,2]")).toEqual([1, 2]);
+    expect(parseJsonColumn("x", '"str"')).toBe("str");
+  });
+
+  it("preserves falsy values rather than treating them as failures", () => {
+    expect(parseJsonColumn("x", "false")).toBe(false);
+    expect(parseJsonColumn("x", "0")).toBe(0);
+    expect(parseJsonColumn("x", '""')).toBe("");
+  });
+
+  it("keeps a stored null distinct from a parse failure", () => {
+    // The reason UNPARSEABLE is a symbol and not null: null is a legitimate stored value, and
+    // returning it on failure would turn a corrupt row into a real one.
+    expect(parseJsonColumn("x", "null")).toBeNull();
+    expect(parseJsonColumn("x", "null")).not.toBe(UNPARSEABLE);
+  });
+
+  it("returns UNPARSEABLE instead of throwing on malformed input", () => {
+    expect(parseJsonColumn("x", "{not json")).toBe(UNPARSEABLE);
+    expect(parseJsonColumn("x", "")).toBe(UNPARSEABLE);
+    expect(parseJsonColumn("x", "undefined")).toBe(UNPARSEABLE);
+  });
+
+  it("logs the label and byte count so the row can be found", () => {
+    parseJsonColumn("appSettings.broken", "{not json");
+    const line = String(devLogMock.mock.calls.at(-1)?.[0]);
+    expect(line).toContain("appSettings.broken");
+    expect(line).toContain("9 bytes");
+  });
+
+  it("never echoes the value it failed to parse", () => {
+    // devLog writes to userData/debug.log — the file users attach to bug reports. JSON.parse's
+    // own message quotes up to ~30 characters of its input ("Unexpected token 'h',
+    // \"https://ap\"… is not valid JSON"), so logging the raw error would put a half-written
+    // appSettings.chatApiUrl's credentials on disk.
+    parseJsonColumn("appSettings.chatApiUrl", "https://api.example.com/v1?api_key=SUPERSECRETVALUE");
+
+    const line = String(devLogMock.mock.calls.at(-1)?.[0]);
+    expect(line).toContain("appSettings.chatApiUrl");
+    expect(line).not.toContain("SUPERSECRETVALUE");
+    // Not just the secret — no leading fragment either, which is the form the message takes.
+    expect(line).not.toContain("https://");
+  });
+
+  it("stays silent when the value parses", () => {
+    parseJsonColumn("x", "1");
+    expect(devLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/db/jsonColumn.ts
+++ b/electron/main/db/jsonColumn.ts
@@ -1,0 +1,33 @@
+import { devLog } from "../devLog";
+
+/** Returned by parseJsonColumn when a column's JSON can't be parsed. A plain `null` won't do:
+ * `null` is itself a legitimate stored value, and conflating the two would silently turn a
+ * corrupt row into a real one. */
+export const UNPARSEABLE = Symbol("unparseable");
+
+/**
+ * Parses a JSON-encoded column value, degrading to UNPARSEABLE rather than throwing.
+ *
+ * The key/value stores here hold JSON.stringify'd content in a TEXT column, so a row that
+ * isn't valid JSON is always possible — a partial write, a hand-edited database, or a value
+ * written by a path that forgot to stringify. Parsing inline meant one such row took down
+ * every read of the whole table: settingsStore's getSettingsByPrefix threw, `settings:get`
+ * rejected, and the renderer fell back to *all* defaults, so one bad row read as "my entire
+ * configuration was wiped".
+ *
+ * Skipping the row (rather than substituting a value here) is what lets each caller apply its
+ * own default, which is the behaviour a missing row already has.
+ */
+export function parseJsonColumn(label: string, raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // The label and byte count only — never the value, and never JSON.parse's own message,
+    // which echoes up to ~30 characters of its input ("Unexpected token 'h', \"https://ap\"…").
+    // devLog writes to userData/debug.log, the file users are asked to attach to bug reports,
+    // and a half-written appSettings.chatApiUrl row can carry credentials in its query string.
+    // Length is enough to tell "empty row" from "truncated write" without echoing content.
+    devLog(`[db] skipping ${label}: value is not valid JSON (${raw?.length ?? 0} bytes)`);
+    return UNPARSEABLE;
+  }
+}

--- a/electron/main/db/settingsStore.ts
+++ b/electron/main/db/settingsStore.ts
@@ -1,36 +1,5 @@
 import { getDb } from "./index";
-import { devLog } from "../devLog";
-
-/** Returned by parseSettingValue when a row's JSON can't be parsed. A plain `null` won't do:
- * `null` is itself a legitimate stored value, and conflating the two would silently turn a
- * corrupt row into a real setting. */
-const UNPARSEABLE = Symbol("unparseable");
-
-/**
- * Parses one row's `setting_value`, degrading to UNPARSEABLE rather than throwing.
- *
- * A single malformed row used to take down every settings read: `getSettingsByPrefix` threw,
- * `settings:get` rejected, and the renderer's useSettings fell back to *all* defaults — so one
- * bad row read as "my entire configuration was wiped", API keys included, with only a devLog
- * line to explain it. The decryption step in ipc/settings.ts already degrades per key for
- * exactly this reason; parsing now matches it.
- *
- * Skipping the key (rather than substituting a value here) is what lets each caller apply its
- * own default, which is the behaviour a missing row already has.
- */
-function parseSettingValue(name: string, raw: string): unknown {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    // The name and byte count only — never the value, and never JSON.parse's own message,
-    // which echoes up to ~30 characters of its input ("Unexpected token 'h', \"https://ap\"…").
-    // devLog writes to userData/debug.log, the file users are asked to attach to bug reports,
-    // and a half-written appSettings.chatApiUrl row can carry credentials in its query string.
-    // Length is enough to tell "empty row" from "truncated write" without echoing content.
-    devLog(`[settings] skipping ${name}: value is not valid JSON (${raw?.length ?? 0} bytes)`);
-    return UNPARSEABLE;
-  }
-}
+import { parseJsonColumn, UNPARSEABLE } from "./jsonColumn";
 
 export function getSetting<T>(name: string, defaultValue: T): T {
   const db = getDb();
@@ -38,7 +7,7 @@ export function getSetting<T>(name: string, defaultValue: T): T {
     | { setting_value: string }
     | undefined;
   if (!row) return defaultValue;
-  const value = parseSettingValue(name, row.setting_value);
+  const value = parseJsonColumn(name, row.setting_value);
   return value === UNPARSEABLE ? defaultValue : (value as T);
 }
 
@@ -59,7 +28,7 @@ export function getSettingsByPrefix(prefix: string): Record<string, unknown> {
     .all(`${prefix}%`) as { setting_name: string; setting_value: string }[];
   const result: Record<string, unknown> = {};
   for (const row of rows) {
-    const value = parseSettingValue(row.setting_name, row.setting_value);
+    const value = parseJsonColumn(row.setting_name, row.setting_value);
     // Omit rather than include-as-undefined: mergeWithDefaults spreads this object over the
     // defaults, and an explicit `undefined` key would override the default it should fall back to.
     if (value === UNPARSEABLE) continue;


### PR DESCRIPTION
Finding **X6** from the settings review worklist (`0-cowork/fixes/active/initial-fixes.md`). Found by X2's recurrence check.

## Root cause

`electron/main/db/agentDataStore.ts:11,32` — `getAgentData` and `listAgentData` are a line-for-line copy of `settingsStore`'s `getSetting` / `getSettingsByPrefix` as they stood before [#8](https://github.com/maneja81/OpenOrbit/pull/8): same KV shape, same `JSON.parse` with no `try`/`catch`.

One corrupt `agent_data.value` row throws out of `listAgentData` and takes down every read for that agent. Same mechanism as X2, smaller blast radius — one agent's data rather than the whole settings surface.

## What changed

The guard moves to **`electron/main/db/jsonColumn.ts`** and both stores call it, rather than the fix being copied a second time — the duplication is what produced this finding in the first place.

- `settingsStore.ts` loses 37 lines and gains an import. Behaviour there is unchanged except the log tag, now `[db]` instead of `[settings]`, since the helper is no longer settings-specific.
- `agentDataStore.ts` gets the same treatment, labelling rows `agent_data <agentId>/<key>` so a skipped row is greppable.
- Both list functions **omit** a bad key rather than setting it to `undefined`, so a caller spreading the result over defaults doesn't have the bad key beat the default it should fall back to.
- `UNPARSEABLE` stays a symbol rather than `null` — `null` is a legitimate stored value, and conflating the two would turn a corrupt row into a real one.

Redaction carries over: the log line holds the label and byte count only, never the value and never `JSON.parse`'s own message (which quotes ~30 chars of its input into `userData/debug.log`). That's now asserted at the helper level too, not only through the settings path.

## Reproduced after fix

New tests run against the **pre-fix** `agentDataStore.ts` (`git checkout origin/develop -- …`): **4 failed / 10 passed**, each failure a corruption case throwing `SyntaxError`. Restored: **14/14**.

## Tests

- New `jsonColumn.test.ts` — 7 tests: valid parse, falsy preservation, stored-`null` vs `UNPARSEABLE`, malformed input, log content, log redaction, silence on success.
- `agentDataStore.test.ts` — 7 added: default fallback, partial-corruption recovery, key omission, all-rows-corrupt, cross-agent isolation, delete-still-works, stored-`null`.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean (and clean *after* a build now, thanks to [#10](https://github.com/maneja81/OpenOrbit/pull/10)) |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **821 passed / 93 files** (807 / 92 before — +14, one new file) |

## Flagged, not fixed here

Now that `parseJsonColumn` exists, the remaining unguarded `JSON.parse` calls on DB columns are each a small follow-up rather than a design question. Not in this PR's scope, logged as a finding:

`connectorsStore.ts:46,82,114` · `httpToolsStore.ts:146,268,364` · `mcp.ts:70,138,151` · `agents.ts:520,531` · `scheduler.ts:79` · `ipc/agent.ts:654`

Some already degrade gracefully (`agents.ts:761-779` wrap theirs); these are the ones that don't. `migrations.ts:556` is tracked separately as X7 — it throws during a migration, so the app won't start, and it's a shipped migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)