### PR TITLE
Ignore all of .claude/, not just settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@
 /0-cowork/
 /MEMORY.md
 
-# Per-machine Claude Code settings. The shared config belongs in CLAUDE.md;
-# anything under .claude/ that ends in .local.json is one developer's only.
-.claude/settings.local.json
+# Claude Code's per-machine state — settings.local.json and, more importantly,
+# .claude/worktrees/, which holds full checkouts of this repo. Those nest a .git
+# file inside the working tree, so a `git add -A` records them as gitlinks. The
+# shared config belongs in CLAUDE.md, so nothing under .claude/ is project config.
+.claude/
 
 # Dependencies
 /node_modules/
@@ -41,5 +43,4 @@
 
 # Claude
 Claude.md
-./claude
 MEMORY.md


### PR DESCRIPTION
## Problem

`.claude/worktrees/` holds full checkouts of this repo, created by Claude Code's worktree
support. There are three right now, each ~50 MB of `public/bg.mp4` alone. Every one nests a
`.git` file inside the working tree, so a `git add -A` from the repo root records them as
gitlinks.

`.gitignore:44` already tried to cover this:

```
./claude
```

Gitignore patterns have no `./` prefix support, so that line matched nothing. `.claude/` has
been untracked-but-uncovered the whole time.

## Fix

Replace the dead pattern with a real `.claude/` entry, folded into the existing Claude Code
block so there's one authoritative rule instead of two contradictory ones.

```diff
-# Per-machine Claude Code settings. The shared config belongs in CLAUDE.md;
-# anything under .claude/ that ends in .local.json is one developer's only.
-.claude/settings.local.json
+# Claude Code's per-machine state — settings.local.json and, more importantly,
+# .claude/worktrees/, which holds full checkouts of this repo. Those nest a .git
+# file inside the working tree, so a `git add -A` records them as gitlinks. The
+# shared config belongs in CLAUDE.md, so nothing under .claude/ is project config.
+.claude/

 # Claude
 Claude.md
-./claude
 MEMORY.md
```

## Tradeoff

This ignores **all** of `.claude/`, so a shared `.claude/settings.json` could not be
committed later without a `!` exception. The old comment implied non-`.local.json` files
under `.claude/` were meant to be shareable — but nothing under `.claude/` has ever been
tracked (`git ls-files .claude/` is empty), and CLAUDE.md is where shared config actually
lives, so nothing is lost today.

## Verification

- `git check-ignore -v` confirms `.claude/`, `.claude/settings.local.json`, and
  `.claude/worktrees/foo` all now match `.gitignore:14`.
- `git ls-files .claude/` is empty, so no currently-tracked file changes tracking state.
- `git status --short` in the branch shows only `.gitignore`.

Not run: eslint, tsc, build, tests. `.gitignore` is not an input to any of them —
`eslint.config.mjs:11` scopes linting to `**/*.{ts,tsx}`.

## Scope discovered — NOT fixed here

`.gitignore:43` is `Claude.md`. This repo has `core.ignorecase=true` (macOS default), so
that pattern **matches the tracked `CLAUDE.md`**:

```
$ git check-ignore -v --no-index CLAUDE.md
.gitignore:43:Claude.md   CLAUDE.md
```

It's inert only because `.gitignore` doesn't apply to already-tracked files. If `CLAUDE.md`
were ever removed from the index, `git add CLAUDE.md` would silently fail. Line 45 also
duplicates line 8's `/MEMORY.md`.

Left alone deliberately — out of scope for this change, and worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
