### PR TITLE
X1: validate every settings write against one shared schema

### DIFF
--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -30,6 +30,7 @@ import { formatUserInfoForPrompt, readUserInfoFacts } from "./userInfoStore";
 import defaultAgentsConfig from "./defaultAgents.json";
 import { getDb } from "../db";
 import { getSetting, setSetting } from "../db/settingsStore";
+import { MODEL_ID_PATTERN, validateSettingValue } from "../settingsSchema";
 import { getCurrentLocation } from "../ipc/location";
 import { encryptSecret } from "../security/secretStorage";
 import { connectMcpServersForAgent } from "./mcp";
@@ -84,7 +85,8 @@ function getCurrentDateTime(): string {
 // Accepts a plain native model id ("gpt-4.1-mini") or an OpenRouter-style "provider/model"
 // id — a loose shape check, not an allowlist of real providers/models, since a user can
 // point the Chat section at OpenAI, OpenRouter, or any other OpenAI-compatible host.
-const MODEL_ID_PATTERN = /^[a-z0-9._-]+(\/[a-z0-9._:-]+)?$/i;
+// Defined in settingsSchema.ts so the settings model fields and an agent's own `model` column
+// are held to one shape rather than two copies of the same regex drifting apart.
 
 // Prompt .md files are statically imported (required by the `?raw` Vite transform,
 // which can't resolve a dynamic path) and looked up here by the `promptKey` each
@@ -223,27 +225,11 @@ const ALLOWED_SETTING_KEYS = [
 ] as const;
 
 const SENSITIVE_SETTING_KEYS = ["chatApiKey", "voiceApiKey"];
-const BOOLEAN_KEYS = [
-  "voiceInputEnabled",
-  "typeAnywhereEnabled",
-  "locationEnabled",
-  "bgMusicEnabled",
-  "soundFxEnabled",
-  "voiceOutputEnabled",
-  "httpToolApprovalPost",
-  "httpToolApprovalPutPatch",
-  "httpToolApprovalDelete",
-];
 
-// Free-form strings are the norm for the other keys, but this one drives a UI branch —
-// an unrecognised value would silently render neither prompt, leaving a paused run with
-// no way to answer it.
-const ENUM_SETTING_VALUES: Record<string, readonly string[]> = {
-  toolApprovalDisplay: ["modal", "inline"],
-};
-// Free-form model-id fields — validated with the same loose "model" or "provider/model"
-// shape as orchestratorModel, since they're the same kind of value.
-const MODEL_ID_KEYS = ["orchestratorModel", "voiceTranscriptionModel", "voiceTtsModel"];
+// What a valid value looks like for each key — booleans, enums like toolApprovalDisplay, and
+// the model-id fields — now lives in settingsSchema.ts, shared with the settings:update IPC
+// handler. The list above stays here because it is this path's own concern: what ConfigAgent is
+// allowed to touch is a much shorter list than what the user can edit in Settings.
 
 const getSettingsTool = tool({
   name: "get_settings",
@@ -308,32 +294,24 @@ const updateSettingTool = tool({
   execute: async ({ key, value }) => {
     const isSensitive = SENSITIVE_SETTING_KEYS.includes(key);
     devLog(`[update_setting] called with key=${key} value=${isSensitive ? "(redacted)" : value}`);
-    if (BOOLEAN_KEYS.includes(key)) {
-      if (typeof value !== "boolean") {
-        throw new Error(`${key} must be true or false.`);
-      }
-      setSetting(`appSettings.${key}`, value);
-      devLog(`[update_setting] appSettings.${key} = ${value}`);
-      return `Updated ${key}.`;
-    }
 
-    if (typeof value !== "string" || value.trim().length === 0) {
+    // One shared definition of a valid value, so a value this path would reject cannot get in
+    // through settings:update instead — which is exactly what used to happen, since that
+    // handler validated nothing at all.
+    const result = validateSettingValue(key, value);
+    if (!result.ok) throw new Error(`${key} ${result.reason}.`);
+
+    // An extra rule for this path only: the schema treats "" as a legal way to clear a field,
+    // but an agent must not be able to blank a setting. Wiping an API key or a prompt is a
+    // deliberate act that belongs in Settings, not something a misread instruction can do.
+    if (typeof result.value === "string" && result.value.length === 0) {
       throw new Error(`${key} cannot be empty.`);
     }
-    const trimmed = value.trim();
 
-    if (MODEL_ID_KEYS.includes(key) && !MODEL_ID_PATTERN.test(trimmed)) {
-      throw new Error(`"${trimmed}" doesn't look like a valid model ID (expected "model" or "provider/model").`);
-    }
-
-    const allowedValues = ENUM_SETTING_VALUES[key];
-    if (allowedValues && !allowedValues.includes(trimmed)) {
-      throw new Error(`${key} must be one of: ${allowedValues.join(", ")}.`);
-    }
-
-    setSetting(`appSettings.${key}`, isSensitive ? encryptSecret(trimmed) : trimmed);
+    const stored = isSensitive && typeof result.value === "string" ? encryptSecret(result.value) : result.value;
+    setSetting(`appSettings.${key}`, stored);
     // Never log the raw value for an API key — only confirm the write happened.
-    devLog(`[update_setting] appSettings.${key} = ${isSensitive ? "(redacted)" : trimmed}`);
+    devLog(`[update_setting] appSettings.${key} = ${isSensitive ? "(redacted)" : result.value}`);
     return `Updated ${key}.`;
   },
 });

--- a/electron/main/ipc/settings.test.ts
+++ b/electron/main/ipc/settings.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+/** Stands in for the settings table. setSetting writes here; getSettingsByPrefix reads back. */
+const stored = new Map<string, unknown>();
+
+vi.mock("../db/settingsStore", () => ({
+  setSetting: vi.fn((name: string, value: unknown) => {
+    stored.set(name, value);
+  }),
+  getSettingsByPrefix: vi.fn((prefix: string) => {
+    const result: Record<string, unknown> = {};
+    for (const [name, value] of stored) {
+      if (name.startsWith(prefix)) result[name.slice(prefix.length)] = value;
+    }
+    return result;
+  }),
+}));
+
+vi.mock("../security/secretStorage", () => ({
+  encryptSecret: (plain: string) => `nodeCrypto:${plain}`,
+  decryptSecret: (blob: string) => blob.replace(/^nodeCrypto:/, ""),
+}));
+
+// Mocked rather than imported: the real modules reach the Electron app object and the agents
+// SDK, neither of which exists here, and neither is what these tests are about.
+vi.mock("../db", () => ({ getDb: vi.fn() }));
+vi.mock("../db/migrations", () => ({ runMigrations: vi.fn() }));
+vi.mock("../ai/agents", () => ({ DEFAULT_MODEL: "gpt-4.1-mini" }));
+vi.mock("../ai/provider", () => ({ testChatConnection: vi.fn(), testVoiceConnection: vi.fn() }));
+
+const devLogMock = vi.hoisted(() => vi.fn());
+vi.mock("../devLog", () => ({ devLog: devLogMock }));
+
+import { ipcMain } from "electron";
+import { registerSettingsHandlers } from "./settings";
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+function handlerFor(channel: string): Handler {
+  registerSettingsHandlers();
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((c) => c[0] === channel);
+  if (!call) throw new Error(`${channel} was never registered`);
+  return call[1] as Handler;
+}
+
+function update(patch: Record<string, unknown>): Record<string, unknown> {
+  return handlerFor("settings:update")(null, patch) as Record<string, unknown>;
+}
+
+describe("settings:update", () => {
+  beforeEach(() => {
+    stored.clear();
+    vi.mocked(ipcMain.handle).mockClear();
+    devLogMock.mockClear();
+  });
+
+  it("rejects a patch that isn't a plain object", () => {
+    expect(() => handlerFor("settings:update")(null, [])).toThrow("plain object");
+    expect(() => handlerFor("settings:update")(null, null)).toThrow("plain object");
+  });
+
+  it("persists a valid value and returns the post-write state", () => {
+    const result = update({ userName: "Ada" });
+    expect(stored.get("appSettings.userName")).toBe("Ada");
+    expect(result.userName).toBe("Ada");
+  });
+
+  describe("keys it has never heard of", () => {
+    it("does not persist them", () => {
+      // The handler used to JSON.stringify anything it was handed straight into the table, so
+      // a typo'd key became a real row that nothing would ever read.
+      update({ someFutureField: "x" });
+      expect(stored.has("appSettings.someFutureField")).toBe(false);
+      expect(stored.size).toBe(0);
+    });
+
+    it("still writes the valid entries alongside them", () => {
+      update({ someFutureField: "x", userName: "Ada" });
+      expect(stored.get("appSettings.userName")).toBe("Ada");
+      expect(stored.has("appSettings.someFutureField")).toBe(false);
+    });
+
+    it("says why in the log", () => {
+      update({ someFutureField: "x" });
+      const logged = devLogMock.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(logged).toContain("refused");
+      expect(logged).toContain("someFutureField");
+    });
+  });
+
+  describe("values of the wrong type", () => {
+    it("refuses a string where a boolean belongs", () => {
+      // "false" is truthy, so persisting it would silently turn the setting on.
+      update({ locationEnabled: "false" });
+      expect(stored.has("appSettings.locationEnabled")).toBe(false);
+    });
+
+    it("refuses a number below the floor the UI claims", () => {
+      update({ systemStatsPollIntervalMs: 1 });
+      expect(stored.has("appSettings.systemStatsPollIntervalMs")).toBe(false);
+    });
+
+    it("refuses a model id that cannot be one", () => {
+      update({ orchestratorModel: "not a model!" });
+      expect(stored.has("appSettings.orchestratorModel")).toBe(false);
+    });
+
+    it("leaves an already-stored value alone when a later write is refused", () => {
+      update({ chatHistoryMessageLimit: 40 });
+      update({ chatHistoryMessageLimit: 100_000 });
+      expect(stored.get("appSettings.chatHistoryMessageLimit")).toBe(40);
+    });
+  });
+
+  describe("API keys", () => {
+    it("encrypts on the way in and decrypts on the way out", () => {
+      const result = update({ chatApiKey: "sk-secret" });
+      expect(stored.get("appSettings.chatApiKey")).toBe("nodeCrypto:sk-secret");
+      expect(result.chatApiKey).toBe("sk-secret");
+    });
+
+    it("never writes the key to the log", () => {
+      update({ chatApiKey: "sk-secret" });
+      expect(devLogMock.mock.calls.map((c) => String(c[0])).join("\n")).not.toContain("sk-secret");
+    });
+
+    it("never writes an API URL to the log either", () => {
+      // devLog lands in userData/debug.log, which users attach to bug reports, and some
+      // OpenAI-compatible hosts carry the credential in the URL's query string.
+      update({ chatApiUrl: "https://host/v1?api_key=SUPERSECRETVALUE" });
+      const logged = devLogMock.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(logged).toContain("chatApiUrl");
+      expect(logged).not.toContain("SUPERSECRETVALUE");
+    });
+  });
+
+  describe("orchestratorModel", () => {
+    it("falls back to the default when cleared", () => {
+      update({ orchestratorModel: "" });
+      expect(stored.get("appSettings.orchestratorModel")).toBe("gpt-4.1-mini");
+    });
+
+    it("trims a valid id", () => {
+      update({ orchestratorModel: "  openai/gpt-4.1-mini  " });
+      expect(stored.get("appSettings.orchestratorModel")).toBe("openai/gpt-4.1-mini");
+    });
+  });
+
+  it("silently drops locked keys", () => {
+    // The orchestrator is singular and cannot be turned off — enforced here, not just greyed
+    // out in the UI, so no caller can reach it.
+    update({ orchestratorEnabled: false });
+    expect(stored.has("appSettings.orchestratorEnabled")).toBe(false);
+  });
+});

--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -6,6 +6,7 @@ import { runMigrations } from "../db/migrations";
 import { DEFAULT_MODEL } from "../ai/agents";
 import { testChatConnection, testVoiceConnection } from "../ai/provider";
 import { devLog } from "../devLog";
+import { validateSettingsPatch } from "../settingsSchema";
 
 const NAMESPACE = "appSettings.";
 // Chat and Voice are independent credential slots (Settings → AI Models), each encrypted
@@ -13,6 +14,9 @@ const NAMESPACE = "appSettings.";
 // Gmail's OAuth client id/secret) live per-connector in the connectors table instead of
 // here — see connectorsStore.saveConnectorSettings.
 const SENSITIVE_KEYS = ["chatApiKey", "voiceApiKey"];
+// Not encrypted, but never written to debug.log either: some OpenAI-compatible hosts carry the
+// credential in the URL's query string, and that file is what users attach to bug reports.
+const REDACTED_VALUE_KEYS = ["chatApiUrl", "voiceApiUrl", "orchestratorPromptOverride"];
 // The orchestrator is singular and can't be turned off — enforced here (not just
 // greyed out in the UI) so the setting can never end up false regardless of caller.
 const LOCKED_KEYS = ["orchestratorEnabled"];
@@ -46,18 +50,38 @@ export function registerSettingsHandlers() {
     if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
       throw new Error("settings:update requires a plain object patch");
     }
-    for (const [key, value] of Object.entries(patch)) {
+
+    // Every entry is checked against settingsSchema before it can reach the database. Until
+    // this existed the handler persisted whatever it was handed: an unknown key became a real
+    // row, and a value of the wrong type landed in a field its consumers assume the type of.
+    // ConfigAgent's update_setting has always validated; this path — the one the entire
+    // Settings UI uses, and the less trusted of the two — did not.
+    const { accepted, rejected } = validateSettingsPatch(patch);
+    for (const failure of rejected) {
+      // Logged rather than thrown: a Settings screen sends one field at a time, so failing the
+      // whole call would discard the good entries alongside the bad one. The handler returns
+      // the authoritative post-write state either way, and useSettings reconciles against it,
+      // so a refused value visibly snaps back instead of appearing to have been saved.
+      devLog(`[settings:update] refused ${NAMESPACE}${failure.key}: ${failure.reason}`);
+    }
+
+    for (const [key, value] of Object.entries(accepted)) {
       if (LOCKED_KEYS.includes(key)) continue;
       if (SENSITIVE_KEYS.includes(key) && typeof value === "string" && value.length > 0) {
         setSetting(NAMESPACE + key, encryptSecret(value));
         devLog(`[settings:update] ${NAMESPACE}${key} = (redacted)`);
       } else if (key === "orchestratorModel") {
-        const trimmed = typeof value === "string" ? value.trim() : "";
-        setSetting(NAMESPACE + key, trimmed.length > 0 ? trimmed : DEFAULT_MODEL);
-        devLog(`[settings:update] ${NAMESPACE}${key} = ${trimmed.length > 0 ? trimmed : DEFAULT_MODEL}`);
+        // Schema validation allows "" here (clearing the field); the fallback to a real model
+        // id is applied on write so no consumer has to treat empty as a special case.
+        const model = typeof value === "string" && value.length > 0 ? value : DEFAULT_MODEL;
+        setSetting(NAMESPACE + key, model);
+        devLog(`[settings:update] ${NAMESPACE}${key} = ${model}`);
       } else {
         setSetting(NAMESPACE + key, value);
-        devLog(`[settings:update] ${NAMESPACE}${key} = ${value}`);
+        // URL fields can carry credentials in a query string, and devLog writes to
+        // userData/debug.log — the file users attach to bug reports. Only the two API *keys*
+        // were redacted before.
+        devLog(`[settings:update] ${NAMESPACE}${key} = ${REDACTED_VALUE_KEYS.includes(key) ? "(redacted)" : value}`);
       }
     }
     return getDecryptedSettings();

--- a/electron/main/settingsSchema.test.ts
+++ b/electron/main/settingsSchema.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { SETTINGS_SCHEMA, isSettingKey, validateSettingValue, validateSettingsPatch } from "./settingsSchema";
+
+/** Narrows the union so a test can read `.value` without re-asserting `ok` each time. */
+function accepted(key: string, value: unknown): unknown {
+  const result = validateSettingValue(key, value);
+  if (!result.ok) throw new Error(`expected ${key} to accept ${JSON.stringify(value)}, got: ${result.reason}`);
+  return result.value;
+}
+
+function rejection(key: string, value: unknown): string {
+  const result = validateSettingValue(key, value);
+  if (result.ok) throw new Error(`expected ${key} to reject ${JSON.stringify(value)}`);
+  return result.reason;
+}
+
+describe("the schema itself", () => {
+  it("covers every setting AgentsSettings declares", () => {
+    // Mirrors src/lib/settings.ts by hand — the two are in separate TypeScript projects and
+    // main has no path into the renderer's tree. This count is the tripwire: add a setting
+    // there without adding it here and it becomes silently unwritable, because an unlisted
+    // key is now refused rather than persisted.
+    expect(Object.keys(SETTINGS_SCHEMA)).toHaveLength(40);
+  });
+
+  it("recognises a real key and refuses anything else", () => {
+    expect(isSettingKey("chatApiKey")).toBe(true);
+    expect(isSettingKey("chatApiKeyy")).toBe(false);
+    expect(isSettingKey("__proto__")).toBe(false);
+    expect(isSettingKey("constructor")).toBe(false);
+  });
+});
+
+describe("validateSettingValue", () => {
+  it("refuses a key it has never heard of", () => {
+    expect(rejection("someFutureField", "x")).toBe("not a known setting");
+  });
+
+  describe("strings", () => {
+    it("accepts and trims", () => {
+      expect(accepted("userName", "  Ada  ")).toBe("Ada");
+    });
+
+    it("keeps empty, which is how the app says unset", () => {
+      // "" clears an API key, and for orchestratorPromptOverride it means "use the built-in".
+      expect(accepted("chatApiKey", "")).toBe("");
+      expect(accepted("orchestratorPromptOverride", "")).toBe("");
+    });
+
+    it("refuses non-strings", () => {
+      expect(rejection("userName", 42)).toBe("must be a string");
+      expect(rejection("userName", null)).toBe("must be a string");
+      expect(rejection("userName", { toString: () => "Ada" })).toBe("must be a string");
+    });
+  });
+
+  describe("booleans", () => {
+    it("accepts real booleans only", () => {
+      expect(accepted("locationEnabled", true)).toBe(true);
+      expect(accepted("locationEnabled", false)).toBe(false);
+    });
+
+    it("refuses the truthy strings a careless caller would send", () => {
+      // "false" is truthy in JS, so persisting it would silently turn the setting on.
+      expect(rejection("locationEnabled", "true")).toBe("must be true or false");
+      expect(rejection("locationEnabled", "false")).toBe("must be true or false");
+      expect(rejection("locationEnabled", 1)).toBe("must be true or false");
+    });
+  });
+
+  describe("numbers", () => {
+    it("enforces the bounds the Settings UI only claims via min", () => {
+      // `min` on a number input constrains the spinner; typed and pasted values ignore it.
+      expect(accepted("systemStatsPollIntervalMs", 500)).toBe(500);
+      expect(rejection("systemStatsPollIntervalMs", 1)).toContain("between 500 and 600000");
+      expect(rejection("agentRunTimeoutSeconds", 1)).toContain("between 5 and 3600");
+      expect(rejection("chatHistoryMessageLimit", 0)).toContain("between 1 and 200");
+    });
+
+    it("enforces a ceiling, which the UI never had at all", () => {
+      expect(rejection("chatHistoryMessageLimit", 100_000)).toContain("between 1 and 200");
+      expect(rejection("agentRunTimeoutSeconds", 600_000)).toContain("between 5 and 3600");
+    });
+
+    it("refuses NaN and Infinity", () => {
+      // Infinity is not NaN, so a !Number.isNaN guard would have let it through.
+      expect(rejection("bgMusicVolume", Number.NaN)).toBe("must be a number");
+      expect(rejection("agentRunTimeoutSeconds", Number.POSITIVE_INFINITY)).toBe("must be a number");
+    });
+
+    it("refuses numeric strings rather than coercing them", () => {
+      expect(rejection("agentRunTimeoutSeconds", "60")).toBe("must be a number");
+    });
+
+    it("allows a fractional volume but not a fractional count", () => {
+      expect(accepted("bgMusicVolume", 0.35)).toBe(0.35);
+      expect(rejection("chatHistoryMessageLimit", 1.5)).toBe("must be a whole number");
+    });
+
+    it("clamps sound variants to the range the picker offers", () => {
+      expect(accepted("soundVariantSend", 5)).toBe(5);
+      expect(rejection("soundVariantSend", 0)).toContain("between 1 and 5");
+      expect(rejection("soundVariantSend", 99)).toContain("between 1 and 5");
+    });
+  });
+
+  describe("enums", () => {
+    it("accepts a listed value and refuses anything else", () => {
+      expect(accepted("toolApprovalDisplay", "inline")).toBe("inline");
+      // An unrecognised value renders neither prompt, leaving a paused run unanswerable.
+      expect(rejection("toolApprovalDisplay", "popup")).toBe("must be one of: modal, inline");
+      expect(rejection("voiceTtsVoice", "ada")).toContain("must be one of: alloy");
+    });
+  });
+
+  describe("model ids", () => {
+    it("accepts both bare and provider-qualified ids", () => {
+      expect(accepted("orchestratorModel", "gpt-4.1-mini")).toBe("gpt-4.1-mini");
+      expect(accepted("orchestratorModel", "openai/gpt-4.1-mini")).toBe("openai/gpt-4.1-mini");
+      expect(accepted("voiceTtsModel", " tts-1 ")).toBe("tts-1");
+    });
+
+    it("refuses something that cannot be a model id", () => {
+      expect(rejection("orchestratorModel", "not a model!")).toContain("look like a model id");
+    });
+
+    it("allows empty, which clears the field back to the default", () => {
+      expect(accepted("orchestratorModel", "")).toBe("");
+    });
+  });
+
+  describe("string arrays", () => {
+    it("accepts an array of strings, including empty", () => {
+      expect(accepted("orchestratorMcpServerIds", [])).toEqual([]);
+      expect(accepted("orchestratorConnectorIds", ["gmail"])).toEqual(["gmail"]);
+    });
+
+    it("refuses a non-array and an array with a non-string in it", () => {
+      expect(rejection("orchestratorMcpServerIds", "gmail")).toBe("must be an array of strings");
+      expect(rejection("orchestratorMcpServerIds", ["ok", 3])).toBe("must be an array of strings");
+      expect(rejection("orchestratorMcpServerIds", null)).toBe("must be an array of strings");
+    });
+  });
+});
+
+describe("validateSettingsPatch", () => {
+  it("splits a patch instead of failing it whole", () => {
+    // A bulk write that failed entirely on one bad entry would discard the good edits with it.
+    const { accepted: ok, rejected } = validateSettingsPatch({
+      userName: "Ada",
+      locationEnabled: "yes",
+      chatHistoryMessageLimit: 40,
+    });
+
+    expect(ok).toEqual({ userName: "Ada", chatHistoryMessageLimit: 40 });
+    expect(rejected).toEqual([{ key: "locationEnabled", reason: "must be true or false" }]);
+  });
+
+  it("rejects unknown keys rather than persisting them", () => {
+    const { accepted: ok, rejected } = validateSettingsPatch({ someFutureField: "x", userName: "Ada" });
+    expect(ok).toEqual({ userName: "Ada" });
+    expect(rejected).toEqual([{ key: "someFutureField", reason: "not a known setting" }]);
+  });
+
+  it("returns empty halves for an empty patch", () => {
+    expect(validateSettingsPatch({})).toEqual({ accepted: {}, rejected: [] });
+  });
+});

--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -1,0 +1,196 @@
+/**
+ * The shape of every persisted app setting, and the one place a value is checked before it
+ * reaches the database.
+ *
+ * There are two write paths — the `settings:update` IPC handler (the whole Settings UI) and
+ * ConfigAgent's `update_setting` tool — and until this module existed only the second one
+ * validated anything. `settings:update` took any key with any value and JSON.stringify'd it
+ * straight into the settings table, so a typo'd key persisted silently, a number could land in
+ * a field every consumer calls string methods on, and nothing stopped a caller from filling the
+ * table with rows the app has never heard of.
+ *
+ * The two paths deliberately keep *different key lists* — the agent may write far fewer keys
+ * than the user can — but they now share one definition of what a valid value looks like, so a
+ * value the agent would be told off for cannot slip in through the UI instead.
+ *
+ * Mirrors `AgentsSettings` in `src/lib/settings.ts`. It cannot import it: `electron/` and `src/`
+ * are separate TypeScript projects and main has no path into the renderer's tree, which is the
+ * same reason main re-declares the defaults it reads (see finding S1). Keep the two in step by
+ * hand — `settingsSchema.test.ts` asserts the key list against the documented count so an added
+ * setting that never reaches here fails loudly rather than being silently unwritable.
+ */
+
+/** How a setting's value is validated. `model` is a string with the loose "model" or
+ * "provider/model" shape; `enum` restricts to a fixed set. */
+export type SettingKind =
+  | { type: "string" }
+  | { type: "model" }
+  | { type: "boolean" }
+  | { type: "number"; min?: number; max?: number; integer?: boolean }
+  | { type: "stringArray" }
+  | { type: "enum"; values: readonly string[] };
+
+const STRING: SettingKind = { type: "string" };
+const BOOLEAN: SettingKind = { type: "boolean" };
+const MODEL: SettingKind = { type: "model" };
+const STRING_ARRAY: SettingKind = { type: "stringArray" };
+
+/** Same loose shape ConfigAgent's update_setting has always applied to model ids: "model" or
+ * "provider/model". Deliberately permissive — the catalogue depends on whichever
+ * OpenAI-compatible host the user pointed at, so this only rejects things that cannot be a
+ * model id at all.
+ *
+ * Exported because agents.ts validates a sub-agent's `model` column against the same shape.
+ * It lives here rather than there so there is one copy: this module has no heavy imports, so
+ * agents.ts can depend on it, and not the other way round. */
+export const MODEL_ID_PATTERN = /^[a-z0-9._-]+(\/[a-z0-9._:-]+)?$/i;
+
+/** Bounds here are the ones the Settings UI already claims via `min` on its number inputs.
+ * `min` constrains a spinner and nothing else — typed and pasted values sail straight past it,
+ * which is findings S2/S3/S4. Enforcing them at the write boundary is what makes the UI's
+ * promise real; clamping on *read* is X3 and still worth doing for rows written before this. */
+export const SETTINGS_SCHEMA = {
+  chatApiKey: STRING,
+  chatApiUrl: STRING,
+  voiceApiKey: STRING,
+  voiceApiUrl: STRING,
+  voiceInputEnabled: BOOLEAN,
+  typeAnywhereEnabled: BOOLEAN,
+  onboardingDone: BOOLEAN,
+  tourCompleted: BOOLEAN,
+  agentName: STRING,
+  agentDescription: STRING,
+  orchestratorPromptOverride: STRING,
+  userName: STRING,
+  orchestratorModel: MODEL,
+  orchestratorEnabled: BOOLEAN,
+  orchestratorMcpServerIds: STRING_ARRAY,
+  orchestratorConnectorIds: STRING_ARRAY,
+  orchestratorHttpToolCollectionIds: STRING_ARRAY,
+  httpToolApprovalPost: BOOLEAN,
+  httpToolApprovalPutPatch: BOOLEAN,
+  httpToolApprovalDelete: BOOLEAN,
+  toolApprovalDisplay: { type: "enum", values: ["modal", "inline"] },
+  voiceTranscriptionModel: MODEL,
+  voiceOutputEnabled: BOOLEAN,
+  soundFxEnabled: BOOLEAN,
+  voiceTtsModel: MODEL,
+  locationEnabled: BOOLEAN,
+  remoteImagesAutoLoad: BOOLEAN,
+  bgMusicEnabled: BOOLEAN,
+  voiceTtsVoice: { type: "enum", values: ["alloy", "echo", "fable", "onyx", "nova", "shimmer"] },
+  agentRunTimeoutSeconds: { type: "number", min: 5, max: 3600, integer: true },
+  chatHistoryMessageLimit: { type: "number", min: 1, max: 200, integer: true },
+  bgMusicVolume: { type: "number", min: 0, max: 1 },
+  systemStatsPollIntervalMs: { type: "number", min: 500, max: 600_000, integer: true },
+  soundVariantSend: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantReceive: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantHandoff: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantComplete: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantStartup: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantAgentCreated: { type: "number", min: 1, max: 5, integer: true },
+  soundVariantAgentDeleted: { type: "number", min: 1, max: 5, integer: true },
+} as const satisfies Record<string, SettingKind>;
+
+export type SettingKey = keyof typeof SETTINGS_SCHEMA;
+
+export function isSettingKey(key: string): key is SettingKey {
+  return Object.prototype.hasOwnProperty.call(SETTINGS_SCHEMA, key);
+}
+
+/** Why a value was refused, phrased for a human — it reaches ConfigAgent's tool error, which
+ * the model relays to the user. */
+export type ValidationFailure = { key: string; reason: string };
+
+function describe(kind: SettingKind): string {
+  switch (kind.type) {
+    case "string":
+      return "a string";
+    case "model":
+      return 'look like a model id ("model" or "provider/model")';
+    case "boolean":
+      return "true or false";
+    case "stringArray":
+      return "an array of strings";
+    case "enum":
+      return `one of: ${kind.values.join(", ")}`;
+    case "number": {
+      const bounds =
+        kind.min !== undefined && kind.max !== undefined ? ` between ${kind.min} and ${kind.max}` : "";
+      return `${kind.integer ? "a whole number" : "a number"}${bounds}`;
+    }
+  }
+}
+
+/**
+ * Checks one value against its key's declared shape, returning the value to persist or a
+ * reason it was refused.
+ *
+ * Strings are trimmed, because every string setting here is a name, URL, model id or prompt —
+ * none of them wants leading whitespace, and a value that differs from the same value with a
+ * stray space is a support question nobody enjoys. Empty strings stay legal: "" is how the app
+ * says "unset" for API keys and for orchestratorPromptOverride ("use the built-in prompt").
+ */
+export function validateSettingValue(key: string, value: unknown): { ok: true; value: unknown } | { ok: false; reason: string } {
+  if (!isSettingKey(key)) return { ok: false, reason: "not a known setting" };
+  const kind: SettingKind = SETTINGS_SCHEMA[key];
+
+  switch (kind.type) {
+    case "string":
+      return typeof value === "string" ? { ok: true, value: value.trim() } : { ok: false, reason: "must be a string" };
+
+    case "model": {
+      if (typeof value !== "string") return { ok: false, reason: "must be a string" };
+      const trimmed = value.trim();
+      // Empty clears the field back to its default; the read side substitutes one.
+      if (trimmed.length === 0) return { ok: true, value: "" };
+      return MODEL_ID_PATTERN.test(trimmed)
+        ? { ok: true, value: trimmed }
+        : { ok: false, reason: `must ${describe(kind)}` };
+    }
+
+    case "boolean":
+      return typeof value === "boolean" ? { ok: true, value } : { ok: false, reason: "must be true or false" };
+
+    case "stringArray":
+      return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+        ? { ok: true, value }
+        : { ok: false, reason: "must be an array of strings" };
+
+    case "enum":
+      return typeof value === "string" && kind.values.includes(value)
+        ? { ok: true, value }
+        : { ok: false, reason: `must be ${describe(kind)}` };
+
+    case "number": {
+      // Number.isFinite rather than !isNaN: Infinity is not NaN but is useless as a timeout,
+      // a row limit or a poll interval.
+      if (typeof value !== "number" || !Number.isFinite(value)) return { ok: false, reason: "must be a number" };
+      if (kind.integer && !Number.isInteger(value)) return { ok: false, reason: "must be a whole number" };
+      if (kind.min !== undefined && value < kind.min) return { ok: false, reason: `must be ${describe(kind)}` };
+      if (kind.max !== undefined && value > kind.max) return { ok: false, reason: `must be ${describe(kind)}` };
+      return { ok: true, value };
+    }
+  }
+}
+
+/**
+ * Splits a patch into the entries safe to persist and the ones refused.
+ *
+ * Refusing per key rather than rejecting the whole patch: a Settings screen sends one field at
+ * a time, and a bulk write that fails entirely because of one bad entry would lose good edits
+ * alongside the bad one.
+ */
+export function validateSettingsPatch(patch: Record<string, unknown>): {
+  accepted: Record<string, unknown>;
+  rejected: ValidationFailure[];
+} {
+  const accepted: Record<string, unknown> = {};
+  const rejected: ValidationFailure[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    const result = validateSettingValue(key, value);
+    if (result.ok) accepted[key] = result.value;
+    else rejected.push({ key, reason: result.reason });
+  }
+  return { accepted, rejected };
+}


### PR DESCRIPTION
Finding **X1** from the settings review worklist (`0-cowork/fixes/active/initial-fixes.md`) — the highest-priority item on it.

## Root cause

`electron/main/ipc/settings.ts:45-64` checked only that the patch was a plain object, then `JSON.stringify`'d every entry straight into the settings table. No allowlist, no type check, no bounds.

Consequences, all silent:

- A typo'd key became a real row that nothing would ever read.
- A string could land in a field whose consumers assume a boolean — and `"false"` is truthy, so it would read as *on*.
- `min=` on the Settings number inputs constrains the spinner and nothing else. Typed and pasted values went straight through, which is how `systemStatsPollIntervalMs: 1` (a 1 ms `setInterval`) was reachable.

Meanwhile `update_setting` — ConfigAgent's tool, sitting in the same codebase — had an enum allowlist, boolean/string type checks and a model-id regex. The path the entire Settings UI uses, and the less trusted of the two, had none of it.

## What changed

**`electron/main/settingsSchema.ts`** declares the shape of all 40 settings and is now the single place a value is checked. Both write paths use it.

They deliberately keep **different key lists** — ConfigAgent may write far fewer keys than the user can, and finding S11 wants that list shorter still — but they now share one definition of *what a valid value looks like*, so a value the agent would be refused cannot slip in through the UI instead.

Number bounds are the ones the UI already claimed and couldn't enforce (S2/S3/S4), plus ceilings it never had:

| Setting | Range |
|---|---|
| `agentRunTimeoutSeconds` | 5 – 3600, integer |
| `chatHistoryMessageLimit` | 1 – 200, integer |
| `systemStatsPollIntervalMs` | 500 – 600000, integer |
| `bgMusicVolume` | 0 – 1 |
| `soundVariant*` | 1 – 5, integer |

Clamping on *read* is still worth doing for rows written before this — that's X3, still open.

**Rejections are logged and skipped, not thrown.** A Settings screen sends one field at a time, so failing the whole call would discard good edits alongside the bad one. The handler returns the authoritative post-write state either way, and `useSettings` reconciles against it, so a refused value visibly snaps back rather than appearing to have saved.

**Also fixed while in here:** `settings:update` wrote every non-sensitive value to `debug.log` raw. Only the two API *keys* were redacted, but some OpenAI-compatible hosts carry the credential in the URL's query string, and that file is what users attach to bug reports. `chatApiUrl`, `voiceApiUrl` and `orchestratorPromptOverride` are now redacted too.

**`agents.ts` shrinks.** `BOOLEAN_KEYS`, `ENUM_SETTING_VALUES` and `MODEL_ID_KEYS` move to the schema, and `MODEL_ID_PATTERN` is imported from it rather than kept as a second copy of the same regex — it's also used for a sub-agent's own `model` column, so one definition now covers both.

## Reproduced after fix

New IPC tests against the **pre-fix** handler (`git checkout origin/develop -- …`): **8 failed / 7 passed**. Restored: **15/15**.

## Tests

Two new files, **38 tests**. The settings IPC surface had no coverage at all.

- `settingsSchema.test.ts` (23) — per-kind validation, `"false"`-is-truthy, `Infinity` passing a `!isNaN` guard, numeric strings not coerced, fractional counts, unknown keys, `__proto__`/`constructor` not treated as keys, and partial-patch splitting. One test asserts the schema holds 40 keys, so adding a setting to `AgentsSettings` without adding it here fails loudly rather than becoming silently unwritable.
- `ipc/settings.test.ts` (15) — unknown keys not persisted, valid entries still written alongside refused ones, wrong types refused, an existing value left intact when a later write is refused, key encryption round-trip, no key *or URL* in the log, `orchestratorModel` default fallback, locked keys dropped.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **863 passed / 95 files** (825 / 93 before — +38) |

## Note on scope

The worklist said this should ship with S19 (`src/lib/settings.test.ts:74-77` asserts unknown keys pass through `mergeWithDefaults`). That was wrong: `mergeWithDefaults` is renderer-side and `electron/` is a separate TypeScript project with no path into `src/`, so nothing here touches it. S19 belongs with X4, which is what actually changes that function. The worklist has been corrected.

## Flagged, not fixed here

`electron/main/ipc/tasks.ts` — 5 handlers, no input validation at all. `tasks:create` and `tasks:update` pass their input straight to the store. Same pattern as this finding on a different surface. Logged as a new item rather than widened into this PR.

(Checked the rest: `mcp.ts`, `httpTools.ts`, `connectors.ts`, `knowledgeBase.ts`, `filesystem.ts` and `agentData.ts` all assert their inputs already.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
