### PR TITLE
X3: validate the numeric settings on read, not just on write

### DIFF
--- a/electron/main/appSettings.test.ts
+++ b/electron/main/appSettings.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Stands in for the settings table. Values are stored already-parsed, which is what
+ * getSetting returns after jsonColumn has done its work. */
+const stored = new Map<string, unknown>();
+
+vi.mock("./db/settingsStore", () => ({
+  getSetting: vi.fn((name: string, fallback: unknown) => (stored.has(name) ? stored.get(name) : fallback)),
+}));
+
+const devLogMock = vi.hoisted(() => vi.fn());
+vi.mock("./devLog", () => ({ devLog: devLogMock }));
+
+import { readAppSetting } from "./appSettings";
+
+function store(key: string, value: unknown): void {
+  stored.set(`appSettings.${key}`, value);
+}
+
+describe("readAppSetting", () => {
+  beforeEach(() => {
+    stored.clear();
+    devLogMock.mockClear();
+  });
+
+  it("returns a stored value that matches its declared shape", () => {
+    store("agentRunTimeoutSeconds", 120);
+    expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(120);
+  });
+
+  it("returns the fallback when the row is absent", () => {
+    expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(60);
+  });
+
+  it("says nothing for an absent row", () => {
+    // The normal state of a setting nobody has touched — logging it would bury the real ones.
+    readAppSetting("agentRunTimeoutSeconds", 60);
+    expect(devLogMock).not.toHaveBeenCalled();
+  });
+
+  describe("a stored value the type annotation lied about", () => {
+    it("falls back when the row holds a string where a number belongs", () => {
+      // getSetting<number> is an assertion, not a check — nothing stopped this before.
+      store("agentRunTimeoutSeconds", "60");
+      expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(60);
+    });
+
+    it("falls back on null", () => {
+      store("chatHistoryMessageLimit", null);
+      expect(readAppSetting("chatHistoryMessageLimit", 20)).toBe(20);
+    });
+
+    it("falls back on NaN and Infinity", () => {
+      store("chatHistoryMessageLimit", Number.NaN);
+      expect(readAppSetting("chatHistoryMessageLimit", 20)).toBe(20);
+      store("chatHistoryMessageLimit", Number.POSITIVE_INFINITY);
+      expect(readAppSetting("chatHistoryMessageLimit", 20)).toBe(20);
+    });
+
+    it("logs which setting was unusable, without the value", () => {
+      store("chatApiUrl", 42);
+      readAppSetting("chatApiUrl", "");
+      const line = String(devLogMock.mock.calls.at(-1)?.[0]);
+      expect(line).toContain("chatApiUrl");
+      expect(line).not.toContain("42");
+    });
+  });
+
+  describe("out-of-range numbers written before the write-side schema existed", () => {
+    it("rejects a poll interval that would peg a core", () => {
+      // 1 ms was reachable through the old settings:update, which validated nothing. Rows like
+      // this survive in databases written by earlier builds.
+      store("systemStatsPollIntervalMs", 1);
+      expect(readAppSetting("systemStatsPollIntervalMs", 3000)).toBe(3000);
+    });
+
+    it("rejects a run timeout below the floor and above the ceiling", () => {
+      store("agentRunTimeoutSeconds", 1);
+      expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(60);
+      store("agentRunTimeoutSeconds", 600_000);
+      expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(60);
+    });
+
+    it("rejects a zero or negative history limit", () => {
+      store("chatHistoryMessageLimit", 0);
+      expect(readAppSetting("chatHistoryMessageLimit", 20)).toBe(20);
+      store("chatHistoryMessageLimit", -5);
+      expect(readAppSetting("chatHistoryMessageLimit", 20)).toBe(20);
+    });
+
+    it("keeps a value that sits exactly on a bound", () => {
+      store("systemStatsPollIntervalMs", 500);
+      expect(readAppSetting("systemStatsPollIntervalMs", 3000)).toBe(500);
+      store("agentRunTimeoutSeconds", 5);
+      expect(readAppSetting("agentRunTimeoutSeconds", 60)).toBe(5);
+    });
+  });
+
+  it("preserves falsy values rather than mistaking them for absent", () => {
+    store("locationEnabled", false);
+    expect(readAppSetting("locationEnabled", true)).toBe(false);
+    store("bgMusicVolume", 0);
+    expect(readAppSetting("bgMusicVolume", 0.1)).toBe(0);
+    store("userName", "");
+    expect(readAppSetting("userName", "fallback")).toBe("");
+  });
+});

--- a/electron/main/appSettings.ts
+++ b/electron/main/appSettings.ts
@@ -1,0 +1,38 @@
+import { getSetting } from "./db/settingsStore";
+import { validateSettingValue, type SettingKey } from "./settingsSchema";
+import { devLog } from "./devLog";
+
+/** Namespace every user-facing setting is stored under. Matches ipc/settings.ts. */
+const NAMESPACE = "appSettings.";
+
+/**
+ * Reads one app setting, checked against its declared shape, falling back to `fallback` if the
+ * stored row is missing or unusable.
+ *
+ * `getSetting<number>(…)` is a type *assertion*, not a check — it tells the compiler what the
+ * row holds and nothing verifies it. That was fine while the only writer validated, but rows
+ * predate the write-side schema (X1), can be hand-edited, and survive a downgrade to a build
+ * that wrote something else. The values this guards are used directly as a `setTimeout` delay,
+ * a history slice size and a `setInterval` period, where a `0`, a negative, a string or a `null`
+ * produces a broken runtime with no error: runs that time out instantly, an empty context
+ * window, or a poll loop that pegs a core.
+ *
+ * Deliberately a separate layer rather than a change to `getSetting`, which is the generic KV
+ * accessor and is also used for keys that have no schema entry — `allowedRoots`
+ * (ipc/filesystem.ts) and the encryption key (security/secretStorage.ts).
+ */
+export function readAppSetting<T>(key: SettingKey, fallback: T): T {
+  const raw = getSetting<unknown>(NAMESPACE + key, undefined);
+  // Absent row: the caller's default is the answer, and that is not worth logging — it is the
+  // normal state of a setting the user has never touched.
+  if (raw === undefined) return fallback;
+
+  const result = validateSettingValue(key, raw);
+  if (!result.ok) {
+    // Never the value itself: this reaches userData/debug.log, which users attach to bug
+    // reports, and the same key set includes API URLs that can carry credentials.
+    devLog(`[settings] ${key} is unusable (${result.reason}) — using the default instead`);
+    return fallback;
+  }
+  return result.value as T;
+}

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -29,10 +29,8 @@ import { extractApprovalMeta, extractRunItemMeta } from "../ai/runItemMeta";
 import { configureChatClient, estimateGenerationCost } from "../ai/provider";
 import { insertTokenUsage, updateTokenUsageCost } from "../db/tokenUsageStore";
 import { getRecentMessages, appendMessage, ChatMessageRecord } from "./chatHistory";
-import { getSetting } from "../db/settingsStore";
+import { readAppSetting } from "../appSettings";
 import { devLog } from "../devLog";
-
-const NAMESPACE = "appSettings.";
 
 // Best-effort extraction of a tool call's name/arguments (tool_called) or its output
 // (tool_output) from a RunItem — the SDK's item shape varies by item type (function call
@@ -63,7 +61,7 @@ const DEFAULT_HISTORY_MESSAGE_LIMIT = 20;
  * context per run — a bigger window costs more tokens but keeps more of a long
  * conversation "in view". Re-read per run for the same reason as getAgentRunTimeoutMs. */
 function getHistoryMessageLimit(): number {
-  return getSetting<number>(`${NAMESPACE}chatHistoryMessageLimit`, DEFAULT_HISTORY_MESSAGE_LIMIT);
+  return readAppSetting("chatHistoryMessageLimit", DEFAULT_HISTORY_MESSAGE_LIMIT);
 }
 
 /** The orchestrator is the only agent given prior turns directly. When it hands off to a
@@ -200,7 +198,7 @@ const DEFAULT_AGENT_RUN_TIMEOUT_SECONDS = 60;
  * handoffs, slow MCP tools, web search) — re-read per run rather than cached so a change
  * takes effect on the next send without an app restart. */
 function getAgentRunTimeoutMs(): number {
-  const seconds = getSetting<number>(`${NAMESPACE}agentRunTimeoutSeconds`, DEFAULT_AGENT_RUN_TIMEOUT_SECONDS);
+  const seconds = readAppSetting("agentRunTimeoutSeconds", DEFAULT_AGENT_RUN_TIMEOUT_SECONDS);
   return seconds * 1000;
 }
 

--- a/electron/main/ipc/systemStats.ts
+++ b/electron/main/ipc/systemStats.ts
@@ -3,10 +3,9 @@ import os from "node:os";
 import { promises as fs } from "node:fs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { getSetting } from "../db/settingsStore";
+import { readAppSetting } from "../appSettings";
 
 const execFileAsync = promisify(execFile);
-const NAMESPACE = "appSettings.";
 
 export interface SystemStats {
   cpuPct: number;
@@ -128,7 +127,7 @@ let broadcastInterval: NodeJS.Timeout | null = null;
 // takes effect on the next app restart, same as most other main-process-only settings here.
 export function startSystemStatsBroadcast() {
   if (broadcastInterval) return;
-  const intervalMs = getSetting<number>(`${NAMESPACE}systemStatsPollIntervalMs`, DEFAULT_POLL_INTERVAL_MS);
+  const intervalMs = readAppSetting("systemStatsPollIntervalMs", DEFAULT_POLL_INTERVAL_MS);
   broadcastInterval = setInterval(async () => {
     const stats = await collectStats();
     for (const win of BrowserWindow.getAllWindows()) {


### PR DESCRIPTION
Finding **X3** from the settings review worklist (`0-cowork/fixes/active/initial-fixes.md`). Third of the six P1s.

## Root cause

`getSetting<number>(…)` is a **type assertion, not a check**. It tells the compiler what the row holds; nothing verifies it. The three numeric settings went straight from SQLite to their consumers:

| Setting | Used as | Read at |
|---|---|---|
| `agentRunTimeoutSeconds` | `setTimeout` delay (`× 1000`) | `ipc/agent.ts:203` |
| `chatHistoryMessageLimit` | history slice size | `ipc/agent.ts:66` |
| `systemStatsPollIntervalMs` | `setInterval` period | `ipc/systemStats.ts:131` |

[#16](https://github.com/maneja81/OpenOrbit/pull/16) closed the write side, but **rows predate it**. A database written by an earlier build can hold `systemStatsPollIntervalMs = 1` — the old `settings:update` validated nothing, and `min=` on a number input only ever bound the spinner. Rows can also be hand-edited, or written by a build the user has since downgraded from.

None of those produce an error. They produce runs that time out instantly, an empty context window, or a poll loop that pegs a core.

## What changed

**`electron/main/appSettings.ts`** — `readAppSetting(key, fallback)` reads a setting, checks it against the shape `settingsSchema` already declares, and falls back to the caller's default when the row is unusable.

A separate layer rather than a change to `getSetting`, deliberately: that's the generic KV accessor and also serves keys with no schema entry — `allowedRoots` (`ipc/filesystem.ts`) and the encryption key (`security/secretStorage.ts`). Narrowing it would have broken both.

Logging is asymmetric on purpose. An **absent row is silent** — that's the normal state of a setting nobody has touched, and logging it would bury the real failures. An **unusable row logs the key and the reason, never the value**: the same key set includes API URLs that can carry credentials in a query string, and `debug.log` is what users attach to bug reports.

The diff is net **−3 lines** in the call sites; `NAMESPACE` and the `getSetting` import became dead in both files and were removed (lint caught them).

## Reproduced after fix

The usual trick doesn't apply here — the module is new, so there's no pre-fix version to run the tests against. Instead I wrote a throwaway test exercising the **old** read path directly, confirming it hands back whatever the row holds:

```
stored: agentRunTimeoutSeconds = "60"   → getSetting<number> returns typeof "string"
stored: systemStatsPollIntervalMs = 1   → returns 1
stored: chatHistoryMessageLimit = null  → returns null
stored: agentRunTimeoutSeconds = NaN    → returns NaN
```

All four pass through untouched. `seconds * 1000` coerces `"60"` to `60000`, which is why this never failed loudly. The same four rows through `readAppSetting` all yield the default. The throwaway file was deleted before committing.

## Tests

`appSettings.test.ts` — 12 tests: matching values pass through, absent rows fall back silently, wrong types / `null` / `NaN` / `Infinity` fall back, out-of-range values written before the write-side schema are rejected, values sitting exactly on a bound are kept, and falsy values (`false`, `0`, `""`) are preserved rather than mistaken for absent.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **875 passed / 96 files** (863 / 95 before — +12) |

## Flagged, not fixed here

The other ~24 `getSetting<T>` reads — 20 in `ai/agents.ts`, 4 in `ai/provider.ts` — have the same hollow assertion, just less dramatic consequences (a corrupt `toolApprovalDisplay` renders neither approval prompt, leaving a paused run unanswerable).

Kept out of this PR because migrating them is the *same edit* finding **S1** needs: those call sites each pass their own default inline, which is how `voiceInputEnabled` ended up `true` in the renderer and `false` in main. Routing them through `readAppSetting` and unifying their defaults should happen together, in one pass, rather than touching the same 24 lines twice. Noted on both findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
