### PR TITLE
Add a run-openorbit skill for driving the app, and track skills in git

### DIFF
--- a/.claude/skills/run-openorbit/SKILL.md
+++ b/.claude/skills/run-openorbit/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: run-openorbit
+description: Build, run and drive the OpenOrbit Electron app. Use when asked to start the app, screenshot it, click through its UI, or confirm a change works in the real app rather than only in the test suite.
+---
+
+OpenOrbit is an Electron desktop app. Drive it through the Playwright REPL at
+`.claude/skills/run-openorbit/driver.mjs`. Launch takes ~5s, so the REPL beats relaunching per
+interaction.
+
+Paths below are relative to the repo root. On macOS no xvfb is needed; on headless Linux prefix
+with `xvfb-run -a`.
+
+## Read this first — the sandbox is not optional
+
+`app.getPath("userData")` resolves to `~/Library/Application Support/OpenOrbit` **from every
+checkout and every git worktree**. There is no per-branch data directory. Launching the app to
+try something out therefore writes into the developer's real database: settings, chat history,
+agents, and encrypted API keys.
+
+The driver always passes `--user-data-dir` and **aborts the launch** if `app.getPath("userData")`
+doesn't land inside the sandbox. Don't remove that check, and don't launch the app by hand from a
+worktree to "just have a look".
+
+Sandbox defaults to `/tmp/orbit-run/userdata` — override with `ORBIT_USER_DATA`. Because it
+starts empty, the first launch is a genuine fresh install: onboarding, empty database. That is
+usually what you want for testing defaults; `reset` gets you back to it.
+
+## Build
+
+```bash
+npm install          # once per worktree — node_modules is not shared
+npm run build        # main is dist-electron/main/index.js; the driver checks it exists
+```
+
+## Run
+
+```bash
+node .claude/skills/run-openorbit/driver.mjs
+```
+
+Wrapped in tmux, which is how an agent should drive it:
+
+```bash
+tmux new-session -d -s orbit -x 200 -y 50
+tmux send-keys -t orbit 'node .claude/skills/run-openorbit/driver.mjs' Enter
+timeout 20 bash -c 'until tmux capture-pane -t orbit -p | grep -q "orbit>"; do sleep 0.2; done'
+tmux send-keys -t orbit 'launch' Enter
+timeout 90 bash -c 'until tmux capture-pane -t orbit -p | grep -qE "launched|ABORT|ERROR"; do sleep 0.2; done'
+tmux send-keys -t orbit 'ss landing' Enter
+tmux capture-pane -t orbit -p
+```
+
+Then **open the screenshot**. A blank frame is a failed launch, however clean the log looks.
+
+Screenshots land in `/tmp/orbit-run/shots` (override: `SCREENSHOT_DIR`).
+
+### Commands
+
+| command | what it does |
+|---|---|
+| `launch` | launch into the sandbox; aborts if isolation didn't take |
+| `reset` | delete the sandbox so the next launch is a fresh install (quit first) |
+| `ss [name]` | screenshot → `/tmp/orbit-run/shots/<name>.png` |
+| `click <sel>` / `click-text <text>` | click via DOM |
+| `type <text>` / `press <key>` | keyboard input |
+| `wait <sel>` | wait for a selector, 10s timeout |
+| `eval <js>` / `text [sel]` | evaluate in the page / print innerText |
+| `settings` | dump every setting through the real `settings:get` IPC |
+| `set <json>` | write through `settings:update`, printing sent vs stored per key |
+| `sql-set <name> <raw>` | write a raw `setting_value` straight into SQLite (quit first) |
+| `sql-dump` | print the settings rows unparsed, as they sit on disk |
+| `log [grep]` | tail/filter `debug.log` — where read-side rejections surface |
+| `windows` | list windows and webContents |
+| `quit` | close the app (REPL stays up) |
+
+`set` prints **sent vs stored**, which is the quickest way to see the settings schema refuse a
+value — a rejected write shows the old value still in place rather than throwing.
+
+`sql-set` exists because the interesting failure modes can't be produced through the UI. Rows
+holding malformed JSON, out-of-range numbers, or values from an older build are exactly what the
+read-side guards are for, and this is the only way to create them.
+
+## A worked example
+
+Confirming the settings guards behave in the real app:
+
+```
+launch
+set {"userName":"Ada","systemStatsPollIntervalMs":1,"nonsenseKey":"x"}
+    userName: sent "Ada" → stored "Ada"
+    systemStatsPollIntervalMs: sent 1 → stored undefined      ← below the 500 floor
+    nonsenseKey: sent "x" → stored undefined                  ← not a known setting
+sql-dump                     # only the valid row is on disk
+quit
+sql-set appSettings.agentName {not json
+launch                       # app still starts; the bad row is skipped, not fatal
+log skipping                 # [db] skipping appSettings.agentName: value is not valid JSON (9 bytes)
+settings                     # agentName absent; everything else intact
+```
+
+## Gotchas
+
+- **Don't launch without the sandbox.** See the top of this file. The driver enforces it; a
+  hand-rolled `_electron.launch()` does not.
+- **`npm run build` first.** `main` points at `dist-electron/main/index.js`, and the dev script
+  (`npm run dev`) deletes that directory before starting electron-vite. The driver checks and
+  tells you rather than hanging for 60s.
+- **`node_modules` is per-worktree** and untracked, so a fresh worktree needs `npm install`
+  (~minutes: it builds `better-sqlite3` natively and runs `electron-builder install-app-deps`).
+- **Wait for `window.agentsAPI`, not a fixed sleep.** The renderer renders nothing until settings
+  have loaded, so the bridge appearing is the real ready signal.
+- **`[aria-label*="Close"]` quits the app** — it matches the window's X before any modal's close
+  button. Use Escape or a specific selector.
+- **A stale Electron holds port 9222**, so a later CDP-based launch silently gets no debugger.
+  `lsof -ti:9222 | xargs kill -9`.
+- **Placeholders are attributes, not `innerText`.** Checking a default rendered as a placeholder
+  (`agentName` → "Orbit" on the onboarding step) needs `input.placeholder`; scraping `innerText`
+  reports a false failure.
+- **Driver scripts written outside the repo** can't resolve `playwright-core` by walking up from
+  their own path. Use `createRequire(<repo>/package.json)`.
+
+## Troubleshooting
+
+- **`ABORT: userData is …`** — the `--user-data-dir` switch didn't take. Do not work around it by
+  removing the check; find out why first.
+- **Launch times out (60s)** — usually no build. Run `npm run build`.
+- **`ERROR: quit first`** — `sql-set` and `reset` touch files the running app holds open.
+- **App opens on onboarding every time** — expected: the sandbox starts empty. Complete
+  onboarding, or `set {"onboardingDone":true}` to skip past it.

--- a/.claude/skills/run-openorbit/driver.mjs
+++ b/.claude/skills/run-openorbit/driver.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+// REPL driver for the OpenOrbit Electron app.
+//
+// Designed for agents: wrap in tmux, send-keys commands, capture-pane output. Launch is slow
+// (~5s), so a REPL beats relaunching per interaction.
+//
+// SAFETY: always launches against an isolated --user-data-dir. app.getPath("userData") resolves
+// to the same ~/Library/Application Support/OpenOrbit from every checkout and every worktree, so
+// without this a driver run writes into the developer's real database — settings, chat history,
+// agents, encrypted API keys. `launch` refuses to continue if the isolation didn't take.
+import { createRequire } from "node:module";
+import * as readline from "node:readline";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const APP_DIR = path.resolve(import.meta.dirname, "../../..");
+// The driver may be invoked from anywhere; resolve deps against the app, not the cwd.
+const require = createRequire(path.join(APP_DIR, "package.json"));
+const { _electron: electron } = require("playwright-core");
+
+const USER_DATA = process.env.ORBIT_USER_DATA || "/tmp/orbit-run/userdata";
+const SHOT_DIR = process.env.SCREENSHOT_DIR || "/tmp/orbit-run/shots";
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+fs.mkdirSync(USER_DATA, { recursive: true });
+
+// Compare resolved paths, not the strings. On macOS /tmp is a symlink to /private/tmp, so
+// Electron reports the sandbox back as /private/tmp/... and a plain startsWith would read a
+// perfectly good sandbox as an escape. Created above so realpath has something to resolve.
+const USER_DATA_REAL = fs.realpathSync(USER_DATA);
+const isInsideSandbox = (p) => {
+  const real = fs.existsSync(p) ? fs.realpathSync(p) : path.resolve(p);
+  return real === USER_DATA_REAL || real.startsWith(USER_DATA_REAL + path.sep);
+};
+
+const ELECTRON_BIN =
+  process.platform === "darwin"
+    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(APP_DIR, "node_modules/electron/dist/electron");
+
+let app = null;
+let page = null;
+
+function dbPath() {
+  return path.join(USER_DATA, "database/agents.db");
+}
+
+const COMMANDS = {
+  async launch() {
+    if (app) return console.log("already launched");
+    if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
+      return console.log("ERROR: no build — run `npm run build` first (main is dist-electron/main/index.js)");
+    }
+    app = await electron.launch({
+      executablePath: ELECTRON_BIN,
+      args: [APP_DIR, `--user-data-dir=${USER_DATA}`],
+      timeout: 60_000,
+    });
+    page = await app.firstWindow();
+    await page.waitForLoadState("domcontentloaded");
+    // The renderer gates its entire render on settings loading, so the bridge appearing is the
+    // real "ready" signal — better than a fixed sleep.
+    await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
+    await new Promise((r) => setTimeout(r, 3000));
+
+    const resolved = await app.evaluate(({ app }) => app.getPath("userData"));
+    if (!isInsideSandbox(resolved)) {
+      console.log(`ABORT: userData is ${resolved}, expected under ${USER_DATA_REAL}. Closing before anything writes.`);
+      await app.close();
+      app = page = null;
+      return;
+    }
+    console.log("launched. userData:", resolved);
+    for (const w of app.windows()) console.log("  window:", w.url());
+  },
+
+  /** Wipe the sandbox so the next launch is a genuine fresh install (onboarding, empty DB). */
+  reset() {
+    if (app) return console.log("ERROR: quit first");
+    fs.rmSync(USER_DATA, { recursive: true, force: true });
+    console.log("removed", USER_DATA);
+  },
+
+  async ss(name) {
+    if (!page) return console.log("ERROR: launch first");
+    const f = path.join(SHOT_DIR, (name || `ss-${Date.now()}`) + ".png");
+    await page.screenshot({ path: f });
+    console.log("screenshot:", f);
+  },
+
+  // DOM click rather than locator.click(): coordinate-based clicking hits the wrong layer when
+  // content sits under an overlay, and this app is modal-heavy.
+  async click(sel) {
+    if (!page) return console.log("ERROR: launch first");
+    console.log(
+      "click",
+      sel,
+      "→",
+      await page.evaluate((s) => {
+        const el = document.querySelector(s);
+        if (!el) return "NOT_FOUND";
+        el.click();
+        return "OK";
+      }, sel)
+    );
+  },
+
+  async "click-text"(text) {
+    if (!page) return console.log("ERROR: launch first");
+    console.log(
+      "click-text",
+      JSON.stringify(text),
+      "→",
+      await page.evaluate((t) => {
+        const els = [...document.querySelectorAll('button, a, [role="button"]')];
+        const el = els.find((e) => e.textContent?.trim() === t) ?? els.find((e) => e.textContent?.includes(t));
+        if (!el) return "NOT_FOUND";
+        el.click();
+        return "OK: " + el.tagName;
+      }, text)
+    );
+  },
+
+  async type(text) {
+    if (page) await page.keyboard.type(text, { delay: 30 });
+  },
+  async press(key) {
+    if (page) await page.keyboard.press(key);
+  },
+
+  async wait(sel) {
+    if (!page) return console.log("ERROR: launch first");
+    try {
+      await page.waitForSelector(sel, { timeout: 10_000 });
+      console.log("found:", sel);
+    } catch {
+      console.log("TIMEOUT:", sel);
+    }
+  },
+
+  async eval(expr) {
+    if (!page) return console.log("ERROR: launch first");
+    try {
+      console.log(JSON.stringify(await page.evaluate(expr)));
+    } catch (e) {
+      console.log("ERROR:", e.message);
+    }
+  },
+
+  async text(sel) {
+    if (!page) return console.log("ERROR: launch first");
+    console.log(
+      await page.evaluate((s) => (s ? document.querySelector(s) : document.body)?.innerText ?? "(null)", sel || null)
+    );
+  },
+
+  /** Read every app setting through the real IPC. */
+  async settings() {
+    if (!page) return console.log("ERROR: launch first");
+    console.log(JSON.stringify(await page.evaluate(() => window.agentsAPI.settings.get()), null, 2));
+  },
+
+  /** `set {"userName":"Ada"}` — writes through settings:update and prints the authoritative
+   * post-write state, so a value the schema refused is visible as unchanged. */
+  async set(json) {
+    if (!page) return console.log("ERROR: launch first");
+    let patch;
+    try {
+      patch = JSON.parse(json);
+    } catch {
+      return console.log('ERROR: expected JSON, e.g. set {"userName":"Ada"}');
+    }
+    const after = await page.evaluate((p) => window.agentsAPI.settings.update(p), patch);
+    for (const key of Object.keys(patch)) {
+      console.log(`  ${key}: sent ${JSON.stringify(patch[key])} → stored ${JSON.stringify(after[key])}`);
+    }
+  },
+
+  /** `sql-set <name> <raw>` — writes a raw setting_value straight into SQLite, bypassing
+   * settings:update. The only way to create rows the UI cannot: malformed JSON, out-of-range
+   * numbers, values written by older builds. Quit first; SQLite is held open by the app. */
+  "sql-set"(args) {
+    if (app) return console.log("ERROR: quit first — the app holds the database open");
+    const [name, ...rest] = args.split(/\s+/);
+    const raw = rest.join(" ");
+    if (!name || !raw) return console.log("usage: sql-set appSettings.foo <raw setting_value>");
+    if (!fs.existsSync(dbPath())) return console.log("ERROR: no database yet — launch once first");
+    const Database = require("better-sqlite3");
+    const db = new Database(dbPath());
+    db.prepare(
+      `INSERT INTO settings (setting_name, setting_value) VALUES (?, ?)
+       ON CONFLICT(setting_name) DO UPDATE SET setting_value = excluded.setting_value`
+    ).run(name, raw);
+    db.close();
+    console.log(`wrote ${name} = ${raw}`);
+  },
+
+  /** Print the settings rows as they actually sit in SQLite, unparsed. */
+  "sql-dump"() {
+    if (!fs.existsSync(dbPath())) return console.log("ERROR: no database yet — launch once first");
+    const Database = require("better-sqlite3");
+    const db = new Database(dbPath(), { readonly: true });
+    for (const r of db.prepare("SELECT setting_name, setting_value FROM settings ORDER BY setting_name").all()) {
+      console.log(` ${r.setting_name} = ${r.setting_value}`);
+    }
+    db.close();
+  },
+
+  /** The main+renderer log, cleared on every launch. Where read-side rejections surface. */
+  log(grep) {
+    const f = path.join(USER_DATA, "debug.log");
+    if (!fs.existsSync(f)) return console.log("(no debug.log yet)");
+    const lines = fs.readFileSync(f, "utf8").split("\n");
+    for (const line of grep ? lines.filter((l) => l.includes(grep)) : lines.slice(-40)) {
+      if (line.trim()) console.log(line);
+    }
+  },
+
+  async windows() {
+    if (!app) return console.log("ERROR: launch first");
+    for (const w of app.windows()) console.log("  window:", w.url());
+    const wcs = await app.evaluate(({ webContents }) =>
+      webContents.getAllWebContents().map((w) => ({ id: w.id, type: w.getType(), url: w.getURL() }))
+    );
+    for (const w of wcs) console.log(`  [${w.id}] ${w.type}: ${w.url}`);
+  },
+
+  async quit() {
+    if (app) await app.close().catch(() => {});
+    app = page = null;
+    console.log("closed");
+  },
+
+  help() {
+    console.log("commands:", Object.keys(COMMANDS).join(", "));
+  },
+};
+
+/** Runs one command line. Returns false if the driver should stop. */
+async function runCommand(line) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return true;
+  const cmd = trimmed.split(/\s+/)[0];
+  const rest = trimmed.slice(cmd.length).trim();
+  const fn = COMMANDS[cmd];
+  if (!fn) {
+    console.log("unknown:", cmd, "— try: help");
+    return true;
+  }
+  try {
+    await fn(rest);
+  } catch (e) {
+    console.log("ERROR:", e.message);
+  }
+  return !(cmd === "quit" && rest === "exit");
+}
+
+console.log(`OpenOrbit driver — sandbox: ${USER_DATA}`);
+
+if (process.stdin.isTTY) {
+  // Interactive/tmux. Electron steals stdin once launched, so read the raw fd instead.
+  const stdin = fs.createReadStream(null, { fd: fs.openSync("/dev/stdin", "r") });
+  const rl = readline.createInterface({ input: stdin, output: process.stdout, prompt: "orbit> " });
+  console.log('"help" for commands, "launch" to start');
+  rl.on("line", async (line) => {
+    rl.pause();
+    const keepGoing = await runCommand(line);
+    if (!keepGoing) return rl.close();
+    rl.resume();
+    rl.prompt();
+  });
+  rl.on("close", async () => {
+    await COMMANDS.quit();
+    process.exit(0);
+  });
+  rl.prompt();
+} else {
+  // Batch: `printf 'launch\nss shot\n' | node driver.mjs`, or a here-doc. Commands must run
+  // strictly in order, and readline cannot give that — it emits every line of a piped chunk
+  // before an async handler for the first one has resolved, so `set` would race ahead of a
+  // launch still in flight. Read the script up front (before Electron takes stdin) and await
+  // each command in turn. `#` starts a comment.
+  const script = fs.readFileSync(0, "utf8");
+  for (const line of script.split("\n")) {
+    if (line.trim()) console.log(`orbit> ${line.trim()}`);
+    if (!(await runCommand(line))) break;
+  }
+  await COMMANDS.quit();
+  process.exit(0);
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,14 @@
 /0-cowork/
 /MEMORY.md
 
-# Per-machine Claude Code settings. The shared config belongs in CLAUDE.md;
-# anything under .claude/ that ends in .local.json is one developer's only.
+# Per-machine Claude Code state — settings.local.json, and the worktrees/ checkouts each
+# feature branch gets. None of it belongs to anyone but the developer who made it.
 .claude/*
+# Skills are the exception: they're shared tooling, versioned with the code they drive, and
+# referenced from CLAUDE.md — a tracked file pointing at an ignored one helps nobody. The
+# negation needs the directory re-included explicitly, because git will not re-include a file
+# whose parent directory is excluded.
+!.claude/skills/
 
 # Dependencies
 /node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - **Build**: `npm run build` (`tsc -b && electron-vite build`) · **Package**: `npm run package`
 - **Test**: `npm test` (`vitest run`) · watch: `npm run test:watch`
 - **Lint**: `npm run lint`
+- **Drive the running app** (screenshots, clicking through the UI, confirming a change works for real rather than only in vitest): the `run-openorbit` skill — `.claude/skills/run-openorbit/SKILL.md`, a Playwright REPL over the built app.
+- ⚠ **Never launch the app from a worktree without `--user-data-dir`.** `app.getPath("userData")` resolves to the same `~/Library/Application Support/OpenOrbit` from *every* checkout and worktree, so an exploratory launch writes into the real database — settings, chat history, agents, encrypted API keys. The `run-openorbit` driver sandboxes it and aborts if the isolation doesn't take; use it rather than launching by hand.
 - **Env required**: none at runtime. Credentials are entered in-app and stored encrypted in SQLite — chat/voice API key + base URL under `appSettings.*` (`ai/provider.ts`), per-connector OAuth client id/secret in the `connectors` table (`connectors/registry.ts`, migration 26). Optional at build time: `GITHUB_RELEASE_REPO` (`scripts/releaseInfo.ts`); `PORT` overrides the dev renderer port.
 
 ## Conventions


### PR DESCRIPTION
Captures the app-launching knowledge from validating [#16](https://github.com/maneja81/OpenOrbit/pull/16)/[#17](https://github.com/maneja81/OpenOrbit/pull/17)/[#18](https://github.com/maneja81/OpenOrbit/pull/18) as a reusable skill, so it isn't rediscovered every time.

## Why

Validating a change in the real app meant working out two things each time. One is mechanical — how to launch an Electron build under Playwright. The other is a trap:

> `app.getPath("userData")` resolves to the same `~/Library/Application Support/OpenOrbit` **from every checkout and every git worktree.**

There is no per-branch data directory. So launching the app from a feature branch to "just have a look" writes into the developer's real database — settings, chat history, agents, encrypted API keys. That's 85 MB of real data reachable by accident from any worktree.

## What's here

**`.claude/skills/run-openorbit/driver.mjs`** — a Playwright REPL over the built app. It always passes `--user-data-dir` and **aborts the launch** if `userData` doesn't resolve inside the sandbox, so the trap can't be walked into.

**`.claude/skills/run-openorbit/SKILL.md`** — the manual: build steps, tmux wrapping, command table, a worked example, and the gotchas that actually cost time.

Beyond generic click/type/screenshot, it carries the commands this app needs:

| command | why it exists |
|---|---|
| `set <json>` | prints **sent vs stored** per key — how you see the settings schema refuse a value, since a rejected write shows the old value rather than throwing |
| `sql-set <name> <raw>` | writes a raw `setting_value` straight into SQLite — the only way to create the malformed / out-of-range rows the read-side guards exist for |
| `sql-dump` | the settings rows unparsed, as they sit on disk |
| `log [grep]` | filters `debug.log`, where those guards report |
| `reset` | wipe the sandbox for a genuine fresh-install run |

## Three bugs found while building it

Each was caught by running the thing rather than reading it:

1. **Piped commands raced.** `readline` emits every line of a chunk before an async handler for the first has resolved, so a scripted `set` ran before `launch` finished. `pause()` doesn't help — the lines are already buffered. Batch mode now reads the script up front and awaits each command in turn; interactive mode keeps readline against the raw stdin fd, since Electron takes stdin once launched.
2. **The safety check false-positived.** `/tmp` is a symlink to `/private/tmp` on macOS, so Electron reported the sandbox back under a different path and a good sandbox read as an escape. Now compared after `realpath`.
3. **…and would have under-caught.** A plain `startsWith` without a trailing separator accepts `/tmp/orbit-run/userdata-evil`. Verified the guard now accepts both symlink forms, and rejects both the real userData and the sibling-prefix trick.

## `.gitignore`

`.claude/*` ignored everything under `.claude/`, so the skill would have been untracked — and CLAUDE.md, which is tracked, now points at it. A tracked file referencing an ignored one helps nobody.

Adds `!.claude/skills/` so skills are versioned with the code they drive. `settings.local.json` and `worktrees/` stay ignored — verified both ways with `git check-ignore`. The directory has to be un-excluded explicitly because git won't re-include a file whose parent directory is excluded.

⚠ **Conflicts with [#13](https://github.com/maneja81/OpenOrbit/pull/13)**, which is still open and wants to ignore *all* of `.claude/`. These two disagree about exactly this. If #13 lands first this negation needs re-adding on top; happy to close whichever you prefer.

## Verified

The worked example in the SKILL.md is a real transcript, not illustrative:

```
orbit> set {"userName":"Ada","systemStatsPollIntervalMs":1,"nonsenseKey":"x"}
  userName: sent "Ada" → stored "Ada"
  systemStatsPollIntervalMs: sent 1 → stored undefined
  nonsenseKey: sent "x" → stored undefined
orbit> sql-dump
 appSettings.userName = "Ada"
```

Also ran the `sql-set` → `launch` → `log` flow end to end, confirming the read-side guard reports `[db] skipping appSettings.agentName: value is not valid JSON (9 bytes)` and the app starts normally.

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm test` | ✓ 887 passed / 96 files (unchanged — no source touched) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
