### PR TITLE
Add a sql command to the run driver

### DIFF
--- a/.claude/skills/run-openorbit/SKILL.md
+++ b/.claude/skills/run-openorbit/SKILL.md
@@ -68,6 +68,7 @@ Screenshots land in `/tmp/orbit-run/shots` (override: `SCREENSHOT_DIR`).
 | `settings` | dump every setting through the real `settings:get` IPC |
 | `set <json>` | write through `settings:update`, printing sent vs stored per key |
 | `sql-set <name> <raw>` | write a raw `setting_value` straight into SQLite (quit first) |
+| `sql <statement>` | arbitrary SQL against the sandbox DB — SELECT prints rows, else the change count (quit first) |
 | `sql-dump` | print the settings rows unparsed, as they sit on disk |
 | `log [grep]` | tail/filter `debug.log` — where read-side rejections surface |
 | `windows` | list windows and webContents |
@@ -79,6 +80,21 @@ value — a rejected write shows the old value still in place rather than throwi
 `sql-set` exists because the interesting failure modes can't be produced through the UI. Rows
 holding malformed JSON, out-of-range numbers, or values from an older build are exactly what the
 read-side guards are for, and this is the only way to create them.
+
+`sql` is the general form, for tables `sql-set` doesn't cover. Two things it unlocks:
+
+- **`agent_data`** — the per-agent KV store has the same guards as settings, reachable through
+  `window.agentsAPI.agentData.*`.
+- **Replaying a migration.** Migrations are selected by *absence* from `schema_migrations`, so
+  deleting a row makes that one migration re-run on the next launch — the only way to exercise a
+  migration's behaviour against a database state you've constructed.
+
+```
+sql DELETE FROM schema_migrations WHERE id = '00000000000027'
+```
+
+Legacy numeric versions are the id zero-padded to 14 characters; migrations added since use
+`YYYYMMDDHHMMSS` directly.
 
 ## A worked example
 

--- a/.claude/skills/run-openorbit/driver.mjs
+++ b/.claude/skills/run-openorbit/driver.mjs
@@ -194,6 +194,36 @@ const COMMANDS = {
     console.log(`wrote ${name} = ${raw}`);
   },
 
+  /** `sql <statement>` — run arbitrary SQL against the sandbox database. Quit first.
+   *
+   * `sql-set` only covers the settings table; the read-side guards live on other tables too
+   * (agent_data), and some paths can only be reached by editing schema_migrations to make a
+   * migration replay. A SELECT prints its rows; anything else prints the change count. Safe
+   * because the sandbox check has already confined this to a throwaway database — never point
+   * ORBIT_USER_DATA at the real one. */
+  sql(statement) {
+    if (app) return console.log("ERROR: quit first — the app holds the database open");
+    if (!statement) return console.log("usage: sql SELECT * FROM schema_migrations LIMIT 5");
+    if (!fs.existsSync(dbPath())) return console.log("ERROR: no database yet — launch once first");
+    const Database = require("better-sqlite3");
+    const db = new Database(dbPath());
+    try {
+      const stmt = db.prepare(statement);
+      if (stmt.reader) {
+        const rows = stmt.all();
+        if (!rows.length) console.log("(no rows)");
+        for (const row of rows) console.log(" ", JSON.stringify(row));
+      } else {
+        const { changes } = stmt.run();
+        console.log(`${changes} row(s) changed`);
+      }
+    } catch (e) {
+      console.log("SQL ERROR:", e.message);
+    } finally {
+      db.close();
+    }
+  },
+
   /** Print the settings rows as they actually sit in SQLite, unparsed. */
   "sql-dump"() {
     if (!fs.existsSync(dbPath())) return console.log("ERROR: no database yet — launch once first");


### PR DESCRIPTION
Follow-up to [#19](https://github.com/maneja81/OpenOrbit/pull/19). Adds the one command that was missing to validate X6 and X7 in the real app rather than only in vitest.

## Why

`sql-set` only reaches the `settings` table, which left two things unverifiable:

- **`agent_data`** carries the same read-side guards as settings ([#11](https://github.com/maneja81/OpenOrbit/pull/11)) but lives in its own table.
- **A migration's behaviour** can only be exercised by making it replay. Migrations are selected by *absence* from `schema_migrations`, so that means deleting a ledger row — which `sql-set` can't do.

Both were needed to close X6 and X7 with an actual app run, and both are the kind of thing the next read-side guard will want too.

## What it does

`SELECT` prints its rows; anything else prints the change count. No extra risk: it refuses while the app holds the database open, and the launch-time sandbox check already confines everything to a throwaway database.

`SKILL.md` documents the migration-replay trick, including that legacy numeric versions are the id zero-padded to 14 characters — not something you'd guess from looking at the ledger.

## Used in anger

**X6** — corrupt `agent_data` row alongside two good ones, through the real IPC:

```
eval window.agentsAPI.agentData.list('configAgent')
{"currency":"USD","timezone":"UTC"}          ← bad key omitted, neighbours intact
eval window.agentsAPI.agentData.get('configAgent','monthly_budget')
null                                          ← default, not a throw
[db] skipping agent_data configAgent/monthly_budget: value is not valid JSON (9 bytes)
```

**X7** — planted a corrupt `chatApiKey`, dropped migration 27 from the ledger, relaunched. With the fix: app starts, corrupt row cleared, ledger back to 36. Then reverted `migrations.ts` to its pre-[#12](https://github.com/maneja81/OpenOrbit/pull/12) state, rebuilt, and repeated with the identical database — **the app died on startup, exit code 1**:

```
at runMigrations (dist-electron/main/index.js:651:5)
at getDb (…:745:3)
at getSetting (…:761:15)
at readAppSetting (…:1233:15)
at startSystemStatsBroadcast (…:1324:22)
process did exit: exitCode=1
```

That's the counterfactual X7 claimed, demonstrated in the app rather than inferred from a unit test.

| | |
|---|---|
| `npm run lint` | ✓ clean |
| tests | unchanged — no source touched, skill only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)