### PR TITLE
S1: give the main process one source of truth for settings defaults (finishes X3)

### DIFF
--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -29,8 +29,9 @@ import {
 import { formatUserInfoForPrompt, readUserInfoFacts } from "./userInfoStore";
 import defaultAgentsConfig from "./defaultAgents.json";
 import { getDb } from "../db";
-import { getSetting, setSetting } from "../db/settingsStore";
-import { MODEL_ID_PATTERN, validateSettingValue } from "../settingsSchema";
+import { setSetting } from "../db/settingsStore";
+import { MODEL_ID_PATTERN, SETTING_DEFAULTS, validateSettingValue } from "../settingsSchema";
+import { readAppSetting } from "../appSettings";
 import { getCurrentLocation } from "../ipc/location";
 import { encryptSecret } from "../security/secretStorage";
 import { connectMcpServersForAgent } from "./mcp";
@@ -47,13 +48,13 @@ import {
   disconnectConnector,
 } from "../db/connectorsStore";
 
-export const DEFAULT_MODEL = "gpt-4.1-mini";
-const DEFAULT_AGENT_DESCRIPTION = "Your personal AI orchestrator.";
-// Mirrors the same-named private constants in provider.ts (not exported from there,
-// and importing them would pull provider.ts's OpenAI-client setup into this module for
-// no reason) — only used here as get_settings' display defaults, same values.
-const DEFAULT_VOICE_TRANSCRIPTION_MODEL = "whisper-1";
-const DEFAULT_VOICE_TTS_MODEL = "tts-1";
+// Derived rather than re-declared: this used to be a fourth hand-maintained copy of the same
+// string. Still exported because ipc/settings.ts uses it as the "blank means default" fallback
+// when a model field is cleared. (skillDistill.ts keeps its own copy — that's finding S7.)
+export const DEFAULT_MODEL = SETTING_DEFAULTS.orchestratorModel;
+// The agent-description and voice-model defaults that used to live here — duplicated from
+// provider.ts, with a comment saying so — are now read from SETTING_DEFAULTS along with
+// everything else. That duplication is what finding S1 was about.
 
 // Prompts are seeded/imported with {{agentName}}/{{userName}}/{{currentDateTime}}
 // placeholders still in them so a rename doesn't require rewriting stored prompt text —
@@ -281,26 +282,26 @@ const getSettingsTool = tool({
   parameters: z.object({}),
   execute: async () => {
     devLog("[get_settings] called");
-    const agentName = getSetting<string>("appSettings.agentName", "Orbit");
-    const agentDescription = getSetting<string>("appSettings.agentDescription", DEFAULT_AGENT_DESCRIPTION);
-    const userName = getSetting<string>("appSettings.userName", "");
-    const orchestratorModel = getSetting<string>("appSettings.orchestratorModel", DEFAULT_MODEL) || DEFAULT_MODEL;
-    const voiceInputEnabled = getSetting<boolean>("appSettings.voiceInputEnabled", false);
-    const typeAnywhereEnabled = getSetting<boolean>("appSettings.typeAnywhereEnabled", false);
-    const locationEnabled = getSetting<boolean>("appSettings.locationEnabled", false);
-    const bgMusicEnabled = getSetting<boolean>("appSettings.bgMusicEnabled", false);
-    const soundFxEnabled = getSetting<boolean>("appSettings.soundFxEnabled", true);
-    const voiceOutputEnabled = getSetting<boolean>("appSettings.voiceOutputEnabled", true);
-    const voiceTranscriptionModel = getSetting<string>("appSettings.voiceTranscriptionModel", DEFAULT_VOICE_TRANSCRIPTION_MODEL);
-    const voiceTtsModel = getSetting<string>("appSettings.voiceTtsModel", DEFAULT_VOICE_TTS_MODEL);
-    const chatApiUrl = getSetting<string>("appSettings.chatApiUrl", "");
-    const voiceApiUrl = getSetting<string>("appSettings.voiceApiUrl", "");
-    const chatApiKey = getSetting<string | null>("appSettings.chatApiKey", null);
-    const voiceApiKey = getSetting<string | null>("appSettings.voiceApiKey", null);
-    const httpToolApprovalPost = getSetting<boolean>("appSettings.httpToolApprovalPost", true);
-    const httpToolApprovalPutPatch = getSetting<boolean>("appSettings.httpToolApprovalPutPatch", true);
-    const httpToolApprovalDelete = getSetting<boolean>("appSettings.httpToolApprovalDelete", true);
-    const toolApprovalDisplay = getSetting<string>("appSettings.toolApprovalDisplay", "modal");
+    const agentName = readAppSetting("agentName");
+    const agentDescription = readAppSetting("agentDescription");
+    const userName = readAppSetting("userName");
+    const orchestratorModel = readAppSetting("orchestratorModel") || DEFAULT_MODEL;
+    const voiceInputEnabled = readAppSetting("voiceInputEnabled");
+    const typeAnywhereEnabled = readAppSetting("typeAnywhereEnabled");
+    const locationEnabled = readAppSetting("locationEnabled");
+    const bgMusicEnabled = readAppSetting("bgMusicEnabled");
+    const soundFxEnabled = readAppSetting("soundFxEnabled");
+    const voiceOutputEnabled = readAppSetting("voiceOutputEnabled");
+    const voiceTranscriptionModel = readAppSetting("voiceTranscriptionModel");
+    const voiceTtsModel = readAppSetting("voiceTtsModel");
+    const chatApiUrl = readAppSetting("chatApiUrl");
+    const voiceApiUrl = readAppSetting("voiceApiUrl");
+    const chatApiKey = readAppSetting("chatApiKey");
+    const voiceApiKey = readAppSetting("voiceApiKey");
+    const httpToolApprovalPost = readAppSetting("httpToolApprovalPost");
+    const httpToolApprovalPutPatch = readAppSetting("httpToolApprovalPutPatch");
+    const httpToolApprovalDelete = readAppSetting("httpToolApprovalDelete");
+    const toolApprovalDisplay = readAppSetting("toolApprovalDisplay");
     return {
       httpToolApprovalPost,
       httpToolApprovalPutPatch,
@@ -575,7 +576,7 @@ const getCurrentLocationTool = tool({
     "Get the user's approximate last known location (city-level latitude/longitude, from an IP-based lookup — not GPS-precise), if location access is enabled in Settings.",
   parameters: z.object({}),
   execute: async () => {
-    const enabled = getSetting<boolean>("appSettings.locationEnabled", false);
+    const enabled = readAppSetting("locationEnabled");
     if (!enabled) return "Location access is disabled in Settings.";
     const location = getCurrentLocation();
     if (!location) return "No location available yet — the app hasn't captured the user's location this session.";
@@ -585,13 +586,13 @@ const getCurrentLocationTool = tool({
 
 /** Returns the user's saved override if set (via Settings → Agents), else the built-in orchestrator.md template. */
 function getOrchestratorPromptTemplate(): string {
-  const override = getSetting<string>("appSettings.orchestratorPromptOverride", "");
+  const override = readAppSetting("orchestratorPromptOverride");
   return override.trim().length > 0 ? override : orchestratorPrompt;
 }
 
 export function getOrchestratorPrompt(): string {
-  const agentName = getSetting<string>("appSettings.agentName", "Orbit");
-  const userName = getSetting<string>("appSettings.userName", "");
+  const agentName = readAppSetting("agentName");
+  const userName = readAppSetting("userName");
   return renderPrompt(getOrchestratorPromptTemplate(), { agentName, userName, currentDateTime: getCurrentDateTime() });
 }
 
@@ -612,8 +613,8 @@ export interface AgentDisplayRow extends AgentRow {
 // literally (see renderPrompt) — rendered here so the read-only Settings → AI display
 // shows the live name instead of the raw template.
 export function listAgentsForDisplay(): AgentDisplayRow[] {
-  const agentName = getSetting<string>("appSettings.agentName", "Orbit");
-  const userName = getSetting<string>("appSettings.userName", "");
+  const agentName = readAppSetting("agentName");
+  const userName = readAppSetting("userName");
   const currentDateTime = getCurrentDateTime();
   return listAgents().map((row) => ({
     ...row,
@@ -930,15 +931,12 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
   const db = getDb();
   ensureDefaultAgentsSeeded(db);
 
-  const agentName = getSetting<string>("appSettings.agentName", "Orbit");
-  const userName = getSetting<string>("appSettings.userName", "");
-  const orchestratorModel = getSetting<string>("appSettings.orchestratorModel", DEFAULT_MODEL) || DEFAULT_MODEL;
-  const orchestratorMcpServerIds = getSetting<string[]>("appSettings.orchestratorMcpServerIds", []);
-  const orchestratorConnectorIds = getSetting<string[]>("appSettings.orchestratorConnectorIds", []);
-  const orchestratorHttpToolCollectionIds = getSetting<string[]>(
-    "appSettings.orchestratorHttpToolCollectionIds",
-    []
-  );
+  const agentName = readAppSetting("agentName");
+  const userName = readAppSetting("userName");
+  const orchestratorModel = readAppSetting("orchestratorModel") || DEFAULT_MODEL;
+  const orchestratorMcpServerIds = readAppSetting("orchestratorMcpServerIds");
+  const orchestratorConnectorIds = readAppSetting("orchestratorConnectorIds");
+  const orchestratorHttpToolCollectionIds = readAppSetting("orchestratorHttpToolCollectionIds");
   const promptVars = { agentName, userName, currentDateTime: getCurrentDateTime() };
 
   const allConnected: MCPServerStdio[] = [];

--- a/electron/main/ai/provider.ts
+++ b/electron/main/ai/provider.ts
@@ -1,14 +1,12 @@
 import OpenAI from "openai";
 import { setDefaultOpenAIClient } from "@openai/agents";
-import { getSetting, getSettingsByPrefix } from "../db/settingsStore";
+import { getSettingsByPrefix } from "../db/settingsStore";
+import { readAppSetting } from "../appSettings";
 import { decryptSecret } from "../security/secretStorage";
 
 export const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const NAMESPACE = "appSettings.";
-const DEFAULT_VOICE_TRANSCRIPTION_MODEL = "whisper-1";
-const DEFAULT_VOICE_TTS_MODEL = "tts-1";
-const DEFAULT_VOICE_TTS_VOICE = "alloy";
 
 /** Chat and Voice are independent credential slots (Settings → AI Models) — a user can
  * point either at OpenAI (the default), OpenRouter, Ollama, or any other OpenAI-compatible
@@ -30,7 +28,9 @@ function getDecryptedKey(slot: CredentialSlot): string {
  * OpenAI's, same "blank means use the default" pattern as orchestratorModel. */
 function getConfiguredUrl(slot: CredentialSlot): string {
   const settingKey = slot === "chat" ? "chatApiUrl" : "voiceApiUrl";
-  return getSetting<string>(`${NAMESPACE}${settingKey}`, OPENAI_BASE_URL) || OPENAI_BASE_URL;
+  // One of the few places an explicit fallback is right rather than lazy: the schema default for
+  // these is "" (the field is genuinely unset), but an unset URL has to resolve to OpenAI's here.
+  return readAppSetting(settingKey, OPENAI_BASE_URL) || OPENAI_BASE_URL;
 }
 
 export function getDecryptedChatApiKey(): string {
@@ -156,7 +156,7 @@ interface WhisperSegment {
  * OpenAI-compatible surface accepts, so this works unchanged for either default. */
 export async function transcribeAudio(base64Audio: string, format: string): Promise<string> {
   const apiKey = getDecryptedKey("voice");
-  const model = getSetting<string>(`${NAMESPACE}voiceTranscriptionModel`, DEFAULT_VOICE_TRANSCRIPTION_MODEL);
+  const model = readAppSetting("voiceTranscriptionModel");
 
   const audioBuffer = Buffer.from(base64Audio, "base64");
   const formData = new FormData();
@@ -195,7 +195,7 @@ export async function transcribeAudio(base64Audio: string, format: string): Prom
  * useSpeak (renderer) falls back to the browser's speechSynthesis rather than going silent. */
 export async function synthesizeSpeech(text: string): Promise<{ audio: string; format: string }> {
   const apiKey = getDecryptedKey("voice");
-  const model = getSetting<string>(`${NAMESPACE}voiceTtsModel`, DEFAULT_VOICE_TTS_MODEL);
+  const model = readAppSetting("voiceTtsModel");
   const format = "mp3";
 
   const response = await fetch(`${getConfiguredUrl("voice")}/audio/speech`, {
@@ -207,7 +207,7 @@ export async function synthesizeSpeech(text: string): Promise<{ audio: string; f
     body: JSON.stringify({
       model,
       input: text,
-      voice: getSetting<string>(`${NAMESPACE}voiceTtsVoice`, DEFAULT_VOICE_TTS_VOICE),
+      voice: readAppSetting("voiceTtsVoice"),
       response_format: format,
     }),
   });

--- a/electron/main/appSettings.ts
+++ b/electron/main/appSettings.ts
@@ -1,5 +1,5 @@
 import { getSetting } from "./db/settingsStore";
-import { validateSettingValue, type SettingKey } from "./settingsSchema";
+import { SETTING_DEFAULTS, validateSettingValue, type SettingKey, type SettingValue } from "./settingsSchema";
 import { devLog } from "./devLog";
 
 /** Namespace every user-facing setting is stored under. Matches ipc/settings.ts. */
@@ -20,8 +20,17 @@ const NAMESPACE = "appSettings.";
  * Deliberately a separate layer rather than a change to `getSetting`, which is the generic KV
  * accessor and is also used for keys that have no schema entry — `allowedRoots`
  * (ipc/filesystem.ts) and the encryption key (security/secretStorage.ts).
+ *
+ * `fallback` defaults to the setting's canonical default, and callers should almost always let
+ * it. Passing one inline is what let `voiceInputEnabled` end up `true` in the renderer and
+ * `false` here (finding S1) — every call site was its own source of truth, so a disagreement was
+ * invisible until someone compared two files. Pass one only for a genuinely local override, and
+ * say why.
  */
-export function readAppSetting<T>(key: SettingKey, fallback: T): T {
+export function readAppSetting<K extends SettingKey>(
+  key: K,
+  fallback: SettingValue<K> = SETTING_DEFAULTS[key]
+): SettingValue<K> {
   const raw = getSetting<unknown>(NAMESPACE + key, undefined);
   // Absent row: the caller's default is the answer, and that is not worth logging — it is the
   // normal state of a setting the user has never touched.
@@ -34,5 +43,5 @@ export function readAppSetting<T>(key: SettingKey, fallback: T): T {
     devLog(`[settings] ${key} is unusable (${result.reason}) — using the default instead`);
     return fallback;
   }
-  return result.value as T;
+  return result.value as SettingValue<K>;
 }

--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -94,6 +94,76 @@ export const SETTINGS_SCHEMA = {
 
 export type SettingKey = keyof typeof SETTINGS_SCHEMA;
 
+/**
+ * What each setting is when the user has never touched it.
+ *
+ * Must stay identical to `DEFAULT_SETTINGS` in `src/lib/settings.ts`. It cannot import it —
+ * `electron/` and `src/` are separate TypeScript projects and main has no path into the
+ * renderer's tree — so `src/lib/settingsDefaults.test.ts` asserts the two are deep-equal from
+ * the renderer side, where both are reachable. That test is the mechanism; this comment is not.
+ *
+ * Before this existed, every main-side read passed its own default inline
+ * (`getSetting("appSettings.voiceInputEnabled", false)`), and two of them disagreed with the
+ * renderer: `voiceInputEnabled` and `typeAnywhereEnabled` were `true` in `DEFAULT_SETTINGS` and
+ * `false` here. Migrations never seed those rows, so on a fresh install the Settings toggle read
+ * "on" while the orchestrator's own view of the setting was "off" — and the orchestrator was the
+ * one telling the truth about what main would do.
+ */
+/** The runtime type a setting holds, derived from its declared kind — so `readAppSetting` returns
+ * `boolean` for a toggle and `number` for a tunable without every caller re-stating it. Enum and
+ * model kinds are strings; widened deliberately, since the value comes from the database and a
+ * literal union would be a promise this layer can't keep. */
+export type SettingValue<K extends SettingKey> = (typeof SETTINGS_SCHEMA)[K] extends { type: "boolean" }
+  ? boolean
+  : (typeof SETTINGS_SCHEMA)[K] extends { type: "number" }
+    ? number
+    : (typeof SETTINGS_SCHEMA)[K] extends { type: "stringArray" }
+      ? string[]
+      : string;
+
+export const SETTING_DEFAULTS: { [K in SettingKey]: SettingValue<K> } = {
+  chatApiKey: "",
+  chatApiUrl: "",
+  voiceApiKey: "",
+  voiceApiUrl: "",
+  voiceInputEnabled: true,
+  typeAnywhereEnabled: true,
+  onboardingDone: false,
+  tourCompleted: false,
+  agentName: "Orbit",
+  agentDescription: "Your personal AI orchestrator.",
+  orchestratorPromptOverride: "",
+  userName: "",
+  orchestratorModel: "gpt-4.1-mini",
+  orchestratorEnabled: true,
+  orchestratorMcpServerIds: [],
+  orchestratorConnectorIds: [],
+  orchestratorHttpToolCollectionIds: [],
+  httpToolApprovalPost: true,
+  httpToolApprovalPutPatch: true,
+  httpToolApprovalDelete: true,
+  toolApprovalDisplay: "modal",
+  voiceTranscriptionModel: "whisper-1",
+  voiceOutputEnabled: true,
+  soundFxEnabled: true,
+  voiceTtsModel: "tts-1",
+  locationEnabled: false,
+  remoteImagesAutoLoad: false,
+  bgMusicEnabled: false,
+  voiceTtsVoice: "alloy",
+  agentRunTimeoutSeconds: 60,
+  chatHistoryMessageLimit: 20,
+  bgMusicVolume: 0.1,
+  systemStatsPollIntervalMs: 3000,
+  soundVariantSend: 1,
+  soundVariantReceive: 1,
+  soundVariantHandoff: 1,
+  soundVariantComplete: 1,
+  soundVariantStartup: 1,
+  soundVariantAgentCreated: 1,
+  soundVariantAgentDeleted: 1,
+};
+
 export function isSettingKey(key: string): key is SettingKey {
   return Object.prototype.hasOwnProperty.call(SETTINGS_SCHEMA, key);
 }

--- a/src/lib/settingsDefaults.test.ts
+++ b/src/lib/settingsDefaults.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "./settings";
+import { SETTING_DEFAULTS } from "../../electron/main/settingsSchema";
+
+/**
+ * The renderer and the main process each hold their own copy of the settings defaults, because
+ * `electron/` and `src/` are separate TypeScript projects and main has no path into the
+ * renderer's tree. Two copies of the same facts drift, and this pair already had:
+ * `voiceInputEnabled` and `typeAnywhereEnabled` were `true` in DEFAULT_SETTINGS and `false` at
+ * every main-side read. Migrations never seed those rows, so on a fresh install the Settings
+ * toggle showed "on" while the orchestrator's own view was "off" — and the orchestrator was
+ * right about what main would actually do.
+ *
+ * This test is the thing that stops it recurring. It lives on the renderer side because that is
+ * where both are reachable: `settingsSchema.ts` is deliberately dependency-free, so importing it
+ * from here pulls in no Electron surface.
+ */
+describe("settings defaults, renderer vs main", () => {
+  it("agree on every key and value", () => {
+    expect(SETTING_DEFAULTS).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("cover exactly the same keys", () => {
+    // Spelled out separately from the deep-equal above: a missing key and a wrong value fail
+    // very differently, and a key that main has never heard of is silently unwritable rather
+    // than merely wrong.
+    expect(Object.keys(SETTING_DEFAULTS).sort()).toEqual(Object.keys(DEFAULT_SETTINGS).sort());
+  });
+
+  it("still has the two that used to disagree", () => {
+    // The specific regression, named, so a future edit that reintroduces it fails with an
+    // obvious message rather than a diff of forty keys.
+    expect(SETTING_DEFAULTS.voiceInputEnabled).toBe(DEFAULT_SETTINGS.voiceInputEnabled);
+    expect(SETTING_DEFAULTS.typeAnywhereEnabled).toBe(DEFAULT_SETTINGS.typeAnywhereEnabled);
+    expect(SETTING_DEFAULTS.voiceInputEnabled).toBe(true);
+    expect(SETTING_DEFAULTS.typeAnywhereEnabled).toBe(true);
+  });
+
+  it("keeps the security defaults off on both sides", () => {
+    // These are the ones where being wrong is not merely inconsistent.
+    expect(SETTING_DEFAULTS.locationEnabled).toBe(false);
+    expect(SETTING_DEFAULTS.remoteImagesAutoLoad).toBe(false);
+    expect(SETTING_DEFAULTS.httpToolApprovalPost).toBe(true);
+    expect(SETTING_DEFAULTS.httpToolApprovalPutPatch).toBe(true);
+    expect(SETTING_DEFAULTS.httpToolApprovalDelete).toBe(true);
+  });
+});

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -18,5 +18,11 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  // settingsSchema.ts is main-process code, listed here only so
+  // src/lib/settingsDefaults.test.ts can assert that the renderer's DEFAULT_SETTINGS and main's
+  // SETTING_DEFAULTS still agree — the two are separate projects, so nothing else stops them
+  // drifting, and they already had (finding S1). It is deliberately dependency-free, so pulling
+  // it into this program adds no Electron surface. This is not an invitation for renderer code
+  // to import from electron/: everything else there reaches the Electron API.
+  "include": ["src", "electron/main/settingsSchema.ts"]
 }


### PR DESCRIPTION
Closes **S1**, and finishes the part of **X3** that [#17](https://github.com/maneja81/OpenOrbit/pull/17) deliberately left. They're one PR because they rewrite the same 24 lines.

## Root cause

Every main-side read passed its own default inline:

```ts
getSetting<boolean>("appSettings.voiceInputEnabled", false)   // main
DEFAULT_SETTINGS.voiceInputEnabled = true                     // renderer
```

So each call site was its own source of truth, and a disagreement was invisible until someone compared two files. Two had already diverged — `voiceInputEnabled` and `typeAnywhereEnabled`. Migrations never seed those rows, so **on a fresh install the Settings toggle showed "on" while the orchestrator's own view was "off"** — and the orchestrator was the one telling the truth about what main would do.

Those same 24 reads were also still `getSetting<T>`, a type *assertion* rather than a check, which is the remainder of X3.

## What changed

`SETTING_DEFAULTS` in `settingsSchema.ts` holds the defaults once. `readAppSetting` defaults to it, so a call site only names a fallback for a genuinely local override — `provider.ts`'s URL resolution is the one such case left, and says why.

**The guarantee is a test, not a comment.** Main still can't import the renderer's `DEFAULT_SETTINGS`, so `src/lib/settingsDefaults.test.ts` asserts the two are deep-equal from the renderer side, where both are reachable. `settingsSchema.ts` is dependency-free, so `tsconfig.web` lists that one file without pulling in any Electron surface.

**Lint found four dead constants** once the inline defaults went — including `DEFAULT_VOICE_TRANSCRIPTION_MODEL` and `DEFAULT_VOICE_TTS_MODEL` in `agents.ts`, whose own comment admitted they mirrored `provider.ts`. That duplication *was* the finding. `DEFAULT_MODEL` is now derived from `SETTING_DEFAULTS` rather than becoming a fourth copy; `skillDistill.ts` still has its own, which stays S7.

`readAppSetting`'s return type is now derived from the declared kind, so a toggle reads as `boolean` and a tunable as `number` without callers restating it.

## Reproduced after fix

Reintroduced the exact divergence (`voiceInputEnabled: false` in `SETTING_DEFAULTS`) and the new test failed:

```
× agree on every key and value
× still has the two that used to disagree
  AssertionError: expected false to be true
```

Restored: 4/4.

## Validated in the running app

Fresh sandbox, no `agentName` row at all — main must resolve the default through `readAppSetting` and it surfaces in the orchestrator prompt:

```
sql-dump                                    → (no rows)
orchestratorPrompt()                        → "You are Orbit, the user's personal orchestrator…"
sql INSERT … agentName = "Cassini"
orchestratorPrompt().includes('Cassini')    → true
sql UPDATE … agentName = '{not json'
orchestratorPrompt()                        → {cassini: false, orbit: true}
log skipping   [db] skipping appSettings.agentName: value is not valid JSON (9 bytes)
```

Default resolution, stored-value preference, and corrupt-row fallback — all through the migrated path, in the real app.

**Regression pass** over what the rewrite touched: X1's validation still holds (`nonsenseKey` and a 1 ms interval rejected, `voiceTtsVoice: "nova"` accepted through the enum path); `settings:testChat` still fails with `No Chat API key configured` rather than a URL error, so `provider.ts`'s key/URL resolution survived the migration.

**Not observable in the app:** the `voiceInputEnabled` / `typeAnywhereEnabled` values themselves. They're consumed only by ConfigAgent's `get_settings` tool, which needs a live chat turn against a real API key — the same limit as S11. The cross-project test is what guards them.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **891 passed / 97 files** (887 / 96 before — +4) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
