### PR TITLE
Log TTS synthesis failures instead of silently going native

### DIFF
--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -146,7 +146,7 @@ export const SETTING_DEFAULTS: { [K in SettingKey]: SettingValue<K> } = {
   voiceTranscriptionModel: "whisper-1",
   voiceOutputEnabled: true,
   soundFxEnabled: true,
-  voiceTtsModel: "tts-1",
+  voiceTtsModel: "gpt-4o-mini-tts",
   locationEnabled: false,
   remoteImagesAutoLoad: false,
   bgMusicEnabled: false,

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -463,7 +463,7 @@ export default function SettingsPanel({
                           type="text"
                           value={settings.voiceTtsModel}
                           onChange={(e) => onUpdate({ voiceTtsModel: e.target.value })}
-                          placeholder="tts-1"
+                          placeholder="gpt-4o-mini-tts"
                           autoComplete="off"
                         />
                       </label>

--- a/src/hooks/useSpeak.ts
+++ b/src/hooks/useSpeak.ts
@@ -6,6 +6,15 @@ interface SpeakCallbacks {
   onEnd?: () => void;
 }
 
+// Mirrors into userData/debug.log (via the main process) in addition to the browser
+// console — see electron/main/devLog.ts. Without this, a synthesis failure (bad Voice
+// API key, wrong voiceApiUrl for the provider, unsupported model) falls back to browser
+// speechSynthesis with zero trace, which reads as "the voice setting doesn't do anything."
+function devLog(...args: unknown[]): void {
+  console.log(...args);
+  if (hasAgentsAPI()) window.agentsAPI.dev.log(...args);
+}
+
 /** Speaks replies via the configured AI TTS model (OpenRouter /audio/speech, see
  * synthesizeSpeech in electron/main/ai/provider.ts), falling back to the browser's
  * speechSynthesis if synthesis is unavailable or the request fails — mirrors the
@@ -67,11 +76,15 @@ export function useSpeak() {
           el.onerror = () => {
             setSpeaking(false);
             audioRef.current = null;
+            devLog("[speak] audio playback failed, falling back to browser TTS");
             speakWithBrowserTts(text, callbacks);
           };
           void el.play();
         })
-        .catch(() => speakWithBrowserTts(text, callbacks));
+        .catch((error: unknown) => {
+          devLog("[speak] synth failed, falling back to browser TTS", error instanceof Error ? error.message : String(error));
+          speakWithBrowserTts(text, callbacks);
+        });
     },
     [speakWithBrowserTts]
   );

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_ORCHESTRATOR_MODEL = "gpt-4.1-mini";
 export const DEFAULT_VOICE_TRANSCRIPTION_MODEL = "whisper-1";
-export const DEFAULT_VOICE_TTS_MODEL = "tts-1";
+export const DEFAULT_VOICE_TTS_MODEL = "gpt-4o-mini-tts";
 export const DEFAULT_VOICE_TTS_VOICE = "alloy";
 export const VOICE_TTS_VOICE_OPTIONS = ["alloy", "echo", "fable", "onyx", "nova", "shimmer"] as const;
 export const DEFAULT_AGENT_RUN_TIMEOUT_SECONDS = 60;


### PR DESCRIPTION
## What changed
When AI voice synthesis fails — a bad or unset Voice API key, a `voiceApiUrl` pointed at a provider that doesn't implement `/audio/speech`, an unsupported model — the app now logs the failure to `debug.log` before falling back to the browser's native `speechSynthesis`. Previously this fell back completely silently, which made a broken Voice provider config look identical to "the voice picker setting doesn't work" (the native fallback never reads `voiceTtsVoice` at all). Also updates the default `voiceTtsModel` from `tts-1` to `gpt-4o-mini-tts`, OpenAI's current default TTS model.

## Root cause
`useSpeak.ts`'s `.catch()` on synthesis failure swallowed the error with no logging, breaking the project's own logging convention used everywhere else in the codebase.

## Testing
- Unit/integration: 891 passed / 97 files (includes the settings-defaults parity test, confirming the new `voiceTtsModel` default stays in sync between main and renderer)
- E2E: not configured
- Manual: sandboxed the app via `run-openorbit`, ran the real onboarding flow with a deliberately invalid API key, and confirmed `debug.log` now shows `[speak] synth failed, falling back to browser TTS Error ... Speech synthesis failed (401): ...` — previously nothing was logged at all.

## Notes
No colocated test exists for `useSpeak.ts` — consistent with every other `window.agentsAPI`-wrapping hook in this codebase, none of which have tests. Didn't introduce new test infrastructure for this one hook alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)