### PR TITLE
S9: stop sending the API keys to the renderer

### DIFF
--- a/electron/main/ipc/settings.test.ts
+++ b/electron/main/ipc/settings.test.ts
@@ -117,10 +117,34 @@ describe("settings:update", () => {
   });
 
   describe("API keys", () => {
-    it("encrypts on the way in and decrypts on the way out", () => {
+    it("encrypts on the way in and never sends the value back", () => {
+      // The key used to come back decrypted on every get and every update, and then sat in
+      // React state for the lifetime of the app. Nothing in the renderer needed it: it was
+      // read in one place, a type="password" input, which renders dots either way.
       const result = update({ chatApiKey: "sk-secret" });
       expect(stored.get("appSettings.chatApiKey")).toBe("nodeCrypto:sk-secret");
-      expect(result.chatApiKey).toBe("sk-secret");
+      expect(result.chatApiKey).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain("sk-secret");
+    });
+
+    it("reports whether a key is set instead", () => {
+      expect((handlerFor("settings:get")(null) as Record<string, unknown>).chatApiKeySet).toBe(false);
+      const after = update({ chatApiKey: "sk-secret" });
+      expect(after.chatApiKeySet).toBe(true);
+      expect(after.voiceApiKeySet).toBe(false);
+    });
+
+    it("reports a key as unset when it decrypts to nothing", () => {
+      // getDecryptedSettings degrades a failed decryption to "", and the flag must follow —
+      // claiming a key is set when the app cannot read it would be the worse lie.
+      stored.set("appSettings.voiceApiKey", "");
+      expect((handlerFor("settings:get")(null) as Record<string, unknown>).voiceApiKeySet).toBe(false);
+    });
+
+    it("still writes a key sent by the renderer", () => {
+      // Only the return trip is masked; the save path is unchanged.
+      update({ voiceApiKey: "sk-voice" });
+      expect(stored.get("appSettings.voiceApiKey")).toBe("nodeCrypto:sk-voice");
     });
 
     it("never writes the key to the log", () => {

--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -21,6 +21,32 @@ const REDACTED_VALUE_KEYS = ["chatApiUrl", "voiceApiUrl", "orchestratorPromptOve
 // greyed out in the UI) so the setting can never end up false regardless of caller.
 const LOCKED_KEYS = ["orchestratorEnabled"];
 
+/**
+ * What the renderer is allowed to see: every setting except the two API keys, which are replaced
+ * by `chatApiKeySet` / `voiceApiKeySet` booleans.
+ *
+ * The keys used to be decrypted and handed over on every `settings:get`, then held in React
+ * state for the lifetime of the app — so anything with renderer script access could read both in
+ * the clear. Nothing in the renderer ever needed the value: it was read in exactly one place,
+ * `value={settings.chatApiKey}` on a `type="password"` input, which renders dots regardless. The
+ * booleans carry the only information that field actually conveyed — whether a key is configured
+ * — and the same shape ConfigAgent's `get_settings` has always used for these two.
+ *
+ * Writes are unaffected. The key still travels renderer → main on save; it is the *return* trip
+ * that stops.
+ */
+function getVisibleSettings(): Record<string, unknown> {
+  const settings = getDecryptedSettings();
+  const visible: Record<string, unknown> = { ...settings };
+  for (const key of SENSITIVE_KEYS) {
+    visible[`${key}Set`] = typeof settings[key] === "string" && settings[key].length > 0;
+    delete visible[key];
+  }
+  return visible;
+}
+
+/** Decrypted, keys included. Main-process use only — never returned over IPC; see
+ * getVisibleSettings, which is what the handlers below hand to the renderer. */
 function getDecryptedSettings(): Record<string, unknown> {
   const settings = getSettingsByPrefix(NAMESPACE);
   for (const sensitiveKey of SENSITIVE_KEYS) {
@@ -41,7 +67,7 @@ function getDecryptedSettings(): Record<string, unknown> {
 }
 
 export function registerSettingsHandlers() {
-  ipcMain.handle("settings:get", (): Record<string, unknown> => getDecryptedSettings());
+  ipcMain.handle("settings:get", (): Record<string, unknown> => getVisibleSettings());
 
   ipcMain.handle("settings:testChat", () => testChatConnection());
   ipcMain.handle("settings:testVoice", () => testVoiceConnection());
@@ -84,7 +110,7 @@ export function registerSettingsHandlers() {
         devLog(`[settings:update] ${NAMESPACE}${key} = ${REDACTED_VALUE_KEYS.includes(key) ? "(redacted)" : value}`);
       }
     }
-    return getDecryptedSettings();
+    return getVisibleSettings();
   });
 
   // Danger Zone: drops every app-owned table (settings, agents, chat history, memory,
@@ -110,6 +136,6 @@ export function registerSettingsHandlers() {
     dropAndReseed();
     db.pragma("foreign_keys = ON");
     runMigrations(db);
-    return getDecryptedSettings();
+    return getVisibleSettings();
   });
 }

--- a/src/components/molecules/ApiKeyField.test.tsx
+++ b/src/components/molecules/ApiKeyField.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ApiKeyField from "./ApiKeyField";
+
+// vitest runs with globals: false, so @testing-library/react cannot register its own auto
+// cleanup — without this every render accumulates and queries match across tests.
+afterEach(cleanup);
+
+function setup(isSet = false) {
+  const onSave = vi.fn();
+  // Queried directly rather than by label: the label's text also contains the "a key is saved"
+  // hint, so getByLabelText matches more than one node. A password input has no implicit role.
+  const { container } = render(<ApiKeyField label="API Key" isSet={isSet} onSave={onSave} />);
+  const input = container.querySelector("input");
+  if (!input) throw new Error("no input rendered");
+  return { onSave, input };
+}
+
+describe("ApiKeyField", () => {
+  it("saves what was typed on blur, once", () => {
+    // Not per keystroke: the response carries no key, so a per-keystroke field would clear
+    // itself after the first character and a key could never be typed.
+    const { onSave, input } = setup();
+    fireEvent.change(input, { target: { value: "sk-abc123" } });
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onSave).toHaveBeenCalledExactlyOnceWith("sk-abc123");
+  });
+
+  it("saves on Enter too", () => {
+    const { onSave, input } = setup();
+    fireEvent.change(input, { target: { value: "sk-abc123" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSave).toHaveBeenCalledExactlyOnceWith("sk-abc123");
+  });
+
+  it("trims what it saves", () => {
+    const { onSave, input } = setup();
+    fireEvent.change(input, { target: { value: "  sk-abc123  " } });
+    fireEvent.blur(input);
+    expect(onSave).toHaveBeenCalledWith("sk-abc123");
+  });
+
+  it("does not save when the field was never touched", () => {
+    // Tabbing through Settings must not wipe a stored key. An empty draft means "unchanged",
+    // not "remove it" — the renderer has no way to tell the difference otherwise, because it
+    // is never given the stored value to compare against.
+    const { onSave, input } = setup(true);
+    fireEvent.blur(input);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("does not save whitespace", () => {
+    const { onSave, input } = setup(true);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("clears the box after saving, so the key is not left on screen", () => {
+    const { input } = setup();
+    fireEvent.change(input, { target: { value: "sk-abc123" } });
+    fireEvent.blur(input);
+    expect(input.value).toBe("");
+  });
+
+  it("says a key is saved when one already is", () => {
+    setup(true);
+    expect(screen.getByText(/A key is saved/i, { selector: "small" })).toBeInTheDocument();
+  });
+
+  it("says nothing of the sort on a fresh install", () => {
+    setup(false);
+    expect(screen.queryByText(/A key is saved/i, { selector: "small" })).not.toBeInTheDocument();
+  });
+
+  it("reports saved immediately after a save, without waiting for a refetch", () => {
+    // isSet arrives from main, so it lags the write by a round trip; without this the field
+    // would briefly claim no key was set right after one was entered.
+    const { input } = setup(false);
+    fireEvent.change(input, { target: { value: "sk-abc123" } });
+    fireEvent.blur(input);
+    expect(screen.getByText(/A key is saved/i, { selector: "small" })).toBeInTheDocument();
+  });
+
+  it("never renders the key as readable text", () => {
+    const { input } = setup(true);
+    fireEvent.change(input, { target: { value: "sk-abc123" } });
+    expect(input.type).toBe("password");
+  });
+});

--- a/src/components/molecules/ApiKeyField.tsx
+++ b/src/components/molecules/ApiKeyField.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+interface ApiKeyFieldProps {
+  label: string;
+  /** Whether a key is already stored. The value itself never reaches the renderer. */
+  isSet: boolean;
+  onSave: (key: string) => void;
+}
+
+/**
+ * An API key input for a value the renderer is never given.
+ *
+ * `settings:get` returns `chatApiKeySet` / `voiceApiKeySet` instead of the keys themselves, so
+ * this field cannot be bound to a stored value the way every other setting is. It keeps what the
+ * user types in local state and commits on blur.
+ *
+ * Local state is not a style choice here. Every other field writes on each keystroke and rebinds
+ * to the authoritative response; with a masked key that response carries no value, so a
+ * per-keystroke field would clear itself after the first character and a key could never be
+ * typed at all. (The per-keystroke write is finding X5, still open — this is a scoped slice of
+ * it, forced by the masking.)
+ *
+ * Committing on blur also means one encrypted write per key entered rather than one per
+ * character — pasting a 164-character key used to be 164 OS-keychain round trips.
+ */
+export default function ApiKeyField({ label, isSet, onSave }: ApiKeyFieldProps) {
+  const [draft, setDraft] = useState("");
+  const [justSaved, setJustSaved] = useState(false);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    // Blurring an untouched field must not clear a stored key — an empty draft means
+    // "unchanged", not "remove it". Clearing is done from the Danger Zone.
+    if (trimmed.length === 0) return;
+    onSave(trimmed);
+    setDraft("");
+    setJustSaved(true);
+  };
+
+  const stored = isSet || justSaved;
+
+  return (
+    <label className="row-field">
+      <span>
+        {label}
+        {stored && <small>A key is saved — type a new one to replace it</small>}
+      </span>
+      <input
+        type="password"
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          setJustSaved(false);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          }
+        }}
+        placeholder={stored ? "••••••••" : "sk-…"}
+        autoComplete="off"
+      />
+    </label>
+  );
+}

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -7,13 +7,14 @@ import SettingsSidebar, { SettingsNavGroup } from "@/components/molecules/Settin
 import AgentAccordion from "@/components/molecules/AgentAccordion";
 import SettingsAccordion from "@/components/molecules/SettingsAccordion";
 import AddAgentForm from "@/components/molecules/AddAgentForm";
+import ApiKeyField from "@/components/molecules/ApiKeyField";
 import FilesAppsTab from "@/components/organisms/FilesAppsTab";
 import McpServersTab from "@/components/organisms/McpServersTab";
 import ConnectorsTab from "@/components/organisms/ConnectorsTab";
 import HttpToolsTab from "@/components/organisms/HttpToolsTab";
 import AboutTab from "@/components/organisms/AboutTab";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
-import { AgentsSettings, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
+import { AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { hasAgentsAPI } from "@/lib/agentsApi";
 import { useMcpServers } from "@/hooks/useMcpServers";
@@ -29,7 +30,7 @@ interface SettingsPanelProps {
   onClose: () => void;
   /** Section to show when the panel opens; defaults to "models" if omitted. */
   initialSection?: SettingsSection;
-  settings: AgentsSettings;
+  settings: SettingsView;
   /** Session age from AgentsApp's existing once-a-minute interval, forwarded to the About
    * section. Timed there rather than here so no component reads the clock during render. */
   sessionElapsedMs: number;
@@ -363,16 +364,11 @@ export default function SettingsPanel({
                   </p>
                   <div className="group">
                     <div className="card">
-                      <label className="row-field">
-                        <span>API Key</span>
-                        <input
-                          type="password"
-                          value={settings.chatApiKey}
-                          onChange={(e) => onUpdate({ chatApiKey: e.target.value })}
-                          placeholder="sk-…"
-                          autoComplete="off"
-                        />
-                      </label>
+                      <ApiKeyField
+                        label="API Key"
+                        isSet={settings.chatApiKeySet}
+                        onSave={(key) => onUpdate({ chatApiKey: key })}
+                      />
                       <label className="row-field">
                         <span>API URL</span>
                         <input
@@ -427,16 +423,11 @@ export default function SettingsPanel({
                   </p>
                   <div className="group">
                     <div className="card">
-                      <label className="row-field">
-                        <span>API Key</span>
-                        <input
-                          type="password"
-                          value={settings.voiceApiKey}
-                          onChange={(e) => onUpdate({ voiceApiKey: e.target.value })}
-                          placeholder="sk-…"
-                          autoComplete="off"
-                        />
-                      </label>
+                      <ApiKeyField
+                        label="API Key"
+                        isSet={settings.voiceApiKeySet}
+                        onSave={(key) => onUpdate({ voiceApiKey: key })}
+                      />
                       <label className="row-field">
                         <span>API URL</span>
                         <input

--- a/src/globals.css
+++ b/src/globals.css
@@ -2051,6 +2051,17 @@ svg#oc {
   color: #d8ecff;
 }
 
+/* A hint under a row-field's label, matching .row-label small above. The API key fields use one
+   to say a key is already stored — without the block display it runs on inline and reads as
+   "API KeyA key is saved — type a new one to replace it". */
+.group .card .row-field span small {
+  display: block;
+  font-size: 10.5px;
+  color: rgba(150, 190, 230, 0.55);
+  font-weight: 400;
+  margin-top: 2px;
+}
+
 .group .card .row-field input,
 .group .card .row-field select {
   background: rgba(0, 4, 12, 0.4);

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { AgentsSettings, DEFAULT_SETTINGS, mergeWithDefaults } from "@/lib/settings";
+import { AgentsSettings, SettingsView, mergeWithDefaults } from "@/lib/settings";
 import { hasAgentsAPI } from "@/lib/agentsApi";
 
 // Mirrors into userData/debug.log (via the main process) in addition to the browser
@@ -11,25 +11,23 @@ function devLog(...args: unknown[]): void {
 }
 
 export function useSettings() {
-  const [settings, setSettings] = useState<AgentsSettings>(DEFAULT_SETTINGS);
+  const [settings, setSettings] = useState<SettingsView>(mergeWithDefaults({}));
   const [loaded, setLoaded] = useState(() => !hasAgentsAPI());
 
   const fetchSettings = useCallback(async () => {
     if (!hasAgentsAPI()) return;
     try {
       const raw = await window.agentsAPI.settings.get();
-      devLog("[settings] refreshed from main", {
-        ...raw,
-        chatApiKey: raw.chatApiKey ? "(set)" : "",
-        voiceApiKey: raw.voiceApiKey ? "(set)" : "",
-      });
+      // No redaction needed any more — settings:get returns chatApiKeySet/voiceApiKeySet
+      // booleans rather than the keys themselves.
+      devLog("[settings] refreshed from main", raw);
       setSettings(mergeWithDefaults(raw));
     } catch (e) {
       // settings:get can reject (e.g. OS-backed secret decryption failing) — the whole
       // app renders nothing until loaded=true, so we must still flip that even on
       // failure rather than leaving the app blank forever. Fall back to defaults.
       devLog("[settings] failed to load, falling back to defaults", e instanceof Error ? e.message : String(e));
-      setSettings(DEFAULT_SETTINGS);
+      setSettings(mergeWithDefaults({}));
     } finally {
       setLoaded(true);
     }
@@ -59,7 +57,7 @@ export function useSettings() {
       setSettings((prev) => ({ ...prev, ...patch }));
       return;
     }
-    let previous: AgentsSettings | undefined;
+    let previous: SettingsView | undefined;
     setSettings((prev) => {
       previous = prev;
       return { ...prev, ...patch };
@@ -85,7 +83,7 @@ export function useSettings() {
 
   const resetSettings = useCallback(async () => {
     if (hasAgentsAPI()) await window.agentsAPI.settings.reset();
-    setSettings(DEFAULT_SETTINGS);
+    setSettings(mergeWithDefaults({}));
   }, []);
 
   return { settings, updateSettings, resetSettings, loaded };

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -2,8 +2,31 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_SETTINGS, mergeWithDefaults } from "./settings";
 
 describe("mergeWithDefaults", () => {
-  it("returns the defaults untouched when given an empty object", () => {
-    expect(mergeWithDefaults({})).toEqual(DEFAULT_SETTINGS);
+  it("returns the defaults plus the key flags when given an empty object", () => {
+    // The two *Set booleans are not settings — they stand in for the API keys, which
+    // settings:get no longer returns. They are deliberately absent from DEFAULT_SETTINGS so it
+    // keeps mirroring the persisted shape exactly (settingsDefaults.test.ts depends on that).
+    expect(mergeWithDefaults({})).toEqual({
+      ...DEFAULT_SETTINGS,
+      chatApiKeySet: false,
+      voiceApiKeySet: false,
+    });
+  });
+
+  it("assumes no key is set until main says otherwise", () => {
+    // Getting this backwards would show "a key is saved" on a fresh install.
+    expect(mergeWithDefaults({}).chatApiKeySet).toBe(false);
+    expect(mergeWithDefaults({}).voiceApiKeySet).toBe(false);
+  });
+
+  it("takes the key flags from the blob when present", () => {
+    const merged = mergeWithDefaults({ chatApiKeySet: true, voiceApiKeySet: false });
+    expect(merged.chatApiKeySet).toBe(true);
+    expect(merged.voiceApiKeySet).toBe(false);
+  });
+
+  it("leaves the key values empty, since main never sends them", () => {
+    expect(mergeWithDefaults({ chatApiKeySet: true }).chatApiKey).toBe("");
   });
 
   it("overrides only the provided keys, keeping the rest at their defaults", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -120,7 +120,25 @@ export const DEFAULT_SETTINGS: AgentsSettings = {
   soundVariantAgentDeleted: 1,
 };
 
+/**
+ * What the renderer actually holds: every setting, plus the two booleans that stand in for the
+ * API keys.
+ *
+ * `settings:get` does not return the keys — see getVisibleSettings in electron/main/ipc/settings.ts
+ * — so `chatApiKey`/`voiceApiKey` are always "" here. They stay on the type because a *patch*
+ * still carries them: writes go renderer → main normally, it is only the return trip that stops.
+ */
+export type SettingsView = AgentsSettings & {
+  chatApiKeySet: boolean;
+  voiceApiKeySet: boolean;
+};
+
+/** Kept out of DEFAULT_SETTINGS on purpose: that object mirrors the persisted settings exactly,
+ * and `settingsDefaults.test.ts` asserts it matches main's SETTING_DEFAULTS key for key. These
+ * two are derived signals, not settings. */
+const DEFAULT_KEY_FLAGS = { chatApiKeySet: false, voiceApiKeySet: false };
+
 /** Merges a raw settings blob (from `agentsAPI.settings.get()`, shape not guaranteed) onto defaults. */
-export function mergeWithDefaults(raw: Record<string, unknown>): AgentsSettings {
-  return { ...DEFAULT_SETTINGS, ...(raw as Partial<AgentsSettings>) };
+export function mergeWithDefaults(raw: Record<string, unknown>): SettingsView {
+  return { ...DEFAULT_SETTINGS, ...DEFAULT_KEY_FLAGS, ...(raw as Partial<SettingsView>) };
 }


### PR DESCRIPTION
Closes **S9** from the settings review worklist.

## Root cause

`settings:get` decrypted both API keys and handed them to the renderer on every call (`ipc/settings.ts`), and `useSettings` held them in React state for the lifetime of the app. Anything with renderer script access could read both in the clear.

`cb-debug` found that **nothing in the renderer ever needed the value**. Across the whole codebase they were read in exactly two places:

```
SettingsPanel.tsx:370   value={settings.chatApiKey}
SettingsPanel.tsx:434   value={settings.voiceApiKey}
```

Both on `type="password"` inputs, which render dots either way. Every other reference — onboarding, the Settings fields — is a *write*.

## What changed

The IPC returns `chatApiKeySet` / `voiceApiKeySet` booleans instead: the only information that field actually conveyed, and the same shape ConfigAgent's `get_settings` has always used for these two. **Writes are untouched** — a key still travels renderer → main on save; it's only the return trip that stops.

### The bit that wasn't optional

`cb-debug` also turned up a dependency the finding didn't record. Every other field writes on each keystroke and rebinds to the authoritative response. With a masked key that response carries no value — so a per-keystroke field would **clear itself after the first character and a key could never be typed at all**.

So `ApiKeyField` keeps the draft in local state and commits on blur or Enter. That also means one encrypted write per key instead of one per character — pasting a 164-character key used to be 164 OS-keychain round trips. (The per-keystroke write is X5, still open; this is a slice of it forced by the masking.)

**An empty draft on blur means "unchanged", not "remove it."** The renderer is never given the stored value to compare against, so tabbing through Settings must not wipe a configured key. There's a test for exactly that.

### Typing

The `*Set` booleans are deliberately **not** in `AgentsSettings` or `DEFAULT_SETTINGS` — those mirror the persisted shape, and `settingsDefaults.test.ts` asserts `DEFAULT_SETTINGS` matches main's `SETTING_DEFAULTS` key for key. They live on a `SettingsView` type instead, so both invariants survive.

## The CSS change is not incidental

Validating in the app showed the label rendering as:

> **API KeyA key is saved — type a new one to replace it**

`.row-label` had a `small` rule; `.row-field` didn't. **Every DOM assertion passed** — the text was present, the placeholder was right, the value was empty. Only the screenshot caught it. Added the matching rule.

## Validated in the running app

Ten checks against a sandboxed profile, all passing: fresh install reports no key · the key field is absent from the payload · a write is acknowledged as set · neither the write response nor a later get contains the key anywhere · **main can still use it** · stored encrypted at rest · never written to `debug.log`.

The strongest signal is that `testChat` returned `401 Incorrect API key provided` — the throwaway key genuinely reached OpenAI, proving the whole path still works rather than merely not crashing.

Then drove the real UI: opened Settings → AI Models → Chat and confirmed the field renders `placeholder: "••••••••"`, `value: ""`, with the hint below the label. Screenshot checked before and after the CSS fix.

## Tests

+16. `ApiKeyField.test.tsx` (10) covers blur/Enter commit, trimming, the untouched-blur and whitespace-only cases that would otherwise wipe a key, the box clearing after save, the hint appearing without waiting for a refetch, and that the input stays `type="password"`. `ipc/settings.test.ts` gains the masking contract; `settings.test.ts` updates the two assertions that encoded the old behaviour.

One incidental fix: `ApiKeyField.test.tsx` needs an explicit `afterEach(cleanup)` because vitest runs with `globals: false`, so RTL can't register its own — the repo's existing component tests do the same.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **916 passed / 98 files** (900 / 97 before — +16) |
| E2E | – not configured |

## Note

This is defence in depth, not a patched exploit — `contextIsolation` and `sandbox` are on, and the markdown pipeline has no `rehype-raw`, so there's no known path to renderer script execution today. It removes the reward if one ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
