### PR TITLE
X4: validate settings per key when merging onto defaults (closes S6, S19)

### DIFF
--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SETTINGS, mergeWithDefaults } from "./settings";
+import { DEFAULT_SETTINGS, SOUND_FX_VARIANT_COUNT, mergeWithDefaults } from "./settings";
 
 describe("mergeWithDefaults", () => {
   it("returns the defaults plus the key flags when given an empty object", () => {
@@ -94,8 +94,68 @@ describe("mergeWithDefaults", () => {
     expect(DEFAULT_SETTINGS.userName).toBe("");
   });
 
-  it("carries through unknown extra keys from the raw blob", () => {
+  it("drops unknown keys instead of carrying them through", () => {
+    // This asserted the opposite until X4. Unknown keys cannot be written any more, but a
+    // database from before the settings schema can still hold them, and carrying them into app
+    // state only spreads the mess.
     const merged = mergeWithDefaults({ someFutureField: "x" } as Record<string, unknown>);
-    expect((merged as unknown as Record<string, unknown>).someFutureField).toBe("x");
+    expect("someFutureField" in merged).toBe(false);
+  });
+
+  describe("a stored value that doesn't match its default's type", () => {
+    it("falls back rather than letting a stored null win", () => {
+      // The case this exists for. A spread let null through, and `<input value={null}>` flips
+      // React to an uncontrolled input — noisy in the console, and the field stops tracking state.
+      expect(mergeWithDefaults({ chatApiUrl: null }).chatApiUrl).toBe("");
+      expect(mergeWithDefaults({ agentName: null }).agentName).toBe("Orbit");
+      expect(mergeWithDefaults({ voiceInputEnabled: null }).voiceInputEnabled).toBe(true);
+    });
+
+    it("falls back on a wrong primitive type", () => {
+      expect(mergeWithDefaults({ agentName: 42 }).agentName).toBe("Orbit");
+      expect(mergeWithDefaults({ locationEnabled: "true" }).locationEnabled).toBe(false);
+      expect(mergeWithDefaults({ agentRunTimeoutSeconds: "60" }).agentRunTimeoutSeconds).toBe(60);
+    });
+
+    it("falls back when an id list isn't an array of strings", () => {
+      // A null list reached components that iterate it.
+      expect(mergeWithDefaults({ orchestratorMcpServerIds: null }).orchestratorMcpServerIds).toEqual([]);
+      expect(mergeWithDefaults({ orchestratorConnectorIds: "gmail" }).orchestratorConnectorIds).toEqual([]);
+      expect(mergeWithDefaults({ orchestratorMcpServerIds: ["ok", 3] }).orchestratorMcpServerIds).toEqual([]);
+    });
+
+    it("still accepts a well-formed id list", () => {
+      expect(mergeWithDefaults({ orchestratorConnectorIds: ["gmail"] }).orchestratorConnectorIds).toEqual(["gmail"]);
+      expect(mergeWithDefaults({ orchestratorMcpServerIds: [] }).orchestratorMcpServerIds).toEqual([]);
+    });
+
+    it("keeps falsy values, which are not the same as wrong", () => {
+      expect(mergeWithDefaults({ agentName: "" }).agentName).toBe("");
+      expect(mergeWithDefaults({ voiceInputEnabled: false }).voiceInputEnabled).toBe(false);
+      expect(mergeWithDefaults({ bgMusicVolume: 0 }).bgMusicVolume).toBe(0);
+    });
+  });
+
+  describe("sound variants", () => {
+    it("clamps to the range the picker actually offers", () => {
+      // Out of range, sfxPreviewSrc requests a file that isn't there — the preview silently does
+      // nothing — and the Combobox shows a value absent from its own option list.
+      expect(mergeWithDefaults({ soundVariantSend: 99 }).soundVariantSend).toBe(SOUND_FX_VARIANT_COUNT);
+      expect(mergeWithDefaults({ soundVariantReceive: 0 }).soundVariantReceive).toBe(1);
+      expect(mergeWithDefaults({ soundVariantStartup: -3 }).soundVariantStartup).toBe(1);
+    });
+
+    it("rounds a fractional variant to a real file", () => {
+      expect(mergeWithDefaults({ soundVariantHandoff: 2.7 }).soundVariantHandoff).toBe(3);
+    });
+
+    it("leaves an in-range variant alone", () => {
+      expect(mergeWithDefaults({ soundVariantComplete: 4 }).soundVariantComplete).toBe(4);
+    });
+
+    it("falls back to 1 when the stored value isn't a number at all", () => {
+      expect(mergeWithDefaults({ soundVariantSend: "3" }).soundVariantSend).toBe(1);
+      expect(mergeWithDefaults({ soundVariantSend: null }).soundVariantSend).toBe(1);
+    });
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -138,7 +138,60 @@ export type SettingsView = AgentsSettings & {
  * two are derived signals, not settings. */
 const DEFAULT_KEY_FLAGS = { chatApiKeySet: false, voiceApiKeySet: false };
 
-/** Merges a raw settings blob (from `agentsAPI.settings.get()`, shape not guaranteed) onto defaults. */
+/** The sound-effect settings, whose stored value has to sit inside the range the picker offers. */
+const SOUND_VARIANT_KEYS = Object.keys(DEFAULT_SETTINGS).filter((key) =>
+  key.startsWith("soundVariant")
+) as (keyof AgentsSettings)[];
+
+/**
+ * Decides whether a stored value is usable, given the default that describes its shape.
+ *
+ * The default is the type reference — there is no separate schema on this side, and adding one
+ * would be a second copy of what `DEFAULT_SETTINGS` already says.
+ */
+function isUsable(value: unknown, fallback: unknown): boolean {
+  if (Array.isArray(fallback)) {
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+  }
+  // Catches the case this function exists for: `null` is an object, so a stored null fails the
+  // typeof check against every default except an array's, and falls back instead of winning.
+  return value !== null && typeof value === typeof fallback;
+}
+
+/**
+ * Merges a raw settings blob (from `agentsAPI.settings.get()`, shape not guaranteed) onto defaults.
+ *
+ * Per key rather than a spread. A spread lets anything in the blob win, including the things a
+ * default exists to prevent: a stored `null` beat the default outright and reached the UI as
+ * `<input value={null}>`, which flips React to an uncontrolled input; a `null` id list reached
+ * components that iterate it. Writes have been validated since the settings schema landed, but
+ * rows written by earlier builds are still out there, and this is the read side.
+ *
+ * Three rules:
+ *  - a value whose type doesn't match its default is discarded
+ *  - a sound variant outside the range the picker offers is clamped, because an out-of-range one
+ *    makes the preview request a file that doesn't exist and leaves the Combobox showing a value
+ *    absent from its own option list
+ *  - a key nobody has heard of is dropped rather than carried through
+ */
 export function mergeWithDefaults(raw: Record<string, unknown>): SettingsView {
-  return { ...DEFAULT_SETTINGS, ...DEFAULT_KEY_FLAGS, ...(raw as Partial<SettingsView>) };
+  const merged: SettingsView = { ...DEFAULT_SETTINGS, ...DEFAULT_KEY_FLAGS };
+  // One local escape hatch so the loops below can address keys dynamically; `merged` keeps its
+  // real type, so the return value is checked rather than asserted.
+  const writable = merged as unknown as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(raw)) {
+    // Unknown keys are dropped. They cannot be written any more, but a database from before that
+    // can still hold them, and carrying them into app state only spreads the mess further.
+    if (!(key in writable)) continue;
+    if (!isUsable(value, writable[key])) continue;
+    writable[key] = value;
+  }
+
+  for (const key of SOUND_VARIANT_KEYS) {
+    const variant = writable[key] as number;
+    writable[key] = Math.min(SOUND_FX_VARIANT_COUNT, Math.max(1, Math.round(variant)));
+  }
+
+  return merged;
 }


### PR DESCRIPTION
Closes **X4**, and with it **S6** (sound-variant clamping) and **S19** (the test that encoded the old behaviour). All three rewrite the same function.

## Root cause

`mergeWithDefaults` was a spread:

```ts
return { ...DEFAULT_SETTINGS, ...DEFAULT_KEY_FLAGS, ...raw };
```

So anything in the stored blob won — including the things a default exists to prevent. A stored `null` beat its default outright and reached the UI as `<input value={null}>`, which flips React to an uncontrolled input. A `null` id list reached components that iterate it.

Writes have been validated since [#16](https://github.com/maneja81/OpenOrbit/pull/16), but rows written by earlier builds are still out there, and **this is the read side**.

## What changed

Per key, with **the default as the type reference**. There is no second schema on the renderer side, and adding one would duplicate what `DEFAULT_SETTINGS` already says — so `typeof` against the default *is* the check, plus `Array.isArray` for the id lists.

Three rules:

- a value whose type doesn't match its default is discarded
- a sound variant is clamped to `1..SOUND_FX_VARIANT_COUNT` (**S6**) — out of range, `sfxPreviewSrc` requests a file that isn't there so the preview silently does nothing, and the Combobox shows a value absent from its own option list
- an unknown key is dropped rather than carried through (**S19**)

`null` deserves a note: it is `typeof "object"`, so it fails the check against every default except an array's — which is exactly the case this exists for.

The two `*Set` booleans survive, because they belong to `SettingsView` even though they aren't settings. That's why unknown-key dropping is keyed on defaults **plus** flags rather than defaults alone.

## Found by validating in the app

Seeded a database with rows a pre-schema build could have written, then drove the real UI:

| stored | before | after |
|---|---|---|
| `agentName: null` | `value={null}` → uncontrolled input | falls back to `"Orbit"` |
| `orchestratorMcpServerIds: null` | `null` reaches iterating components | `[]` |
| `soundVariantSend: 99` | preview 404s, Combobox shows a phantom option | UI shows **"Variant 5"** |
| `locationEnabled: "true"` | **toggle displays ON** | `aria-checked="false"` |
| `someFutureField: "junk"` | carried into app state | dropped |

**The `locationEnabled` row is the one worth reading twice.** A non-empty string is truthy, so the Location access toggle displayed **ON** — while main, which validates on read since [#17](https://github.com/maneja81/OpenOrbit/pull/17), treated it as off. A privacy control showing the opposite of what the app would actually do. That wasn't in the finding; it turned up because the row was tried in a running app rather than a test.

## Reproduced after fix

New tests against pre-fix `settings.ts`: **7 failed / 17 passed**. Restored: **24/24**.

## Tests

+13 across null-vs-default, wrong primitive types, malformed and well-formed id lists, falsy values surviving (`""`, `false`, `0` are not "wrong"), the four sound-variant cases including fractional rounding, and the inverted unknown-key assertion.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **925 passed / 98 files** (916 before — +9 net) |
| E2E | – not configured |

## Note

Considered importing main's `validateSettingValue` rather than type-checking against defaults — `settingsSchema.ts` is dependency-free and already listed in `tsconfig.web.json`. Rejected: that listing is there for the cross-project defaults *test*, with a comment saying it isn't an invitation for renderer code to import from `electron/`. Doing it properly would mean moving the schema to a shared project — a real refactor, and not what X4 is. The defaults already carry the type information needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
