### PR TITLE
S7: leave one declaration of the orchestrator model default per project

### DIFF
--- a/electron/main/ai/httpTools.test.ts
+++ b/electron/main/ai/httpTools.test.ts
@@ -16,7 +16,12 @@ vi.mock("../db/index", () => ({ getDb: () => db }));
 
 import { createHttpTool, createHttpToolCollection, updateHttpTool, updateHttpToolCollection } from "../db/httpToolsStore";
 import { setSetting } from "../db/settingsStore";
-import { buildHttpToolsForCollectionIds, buildHttpToolsPromptBlock, formatHttpToolsForPrompt } from "./httpTools";
+import {
+  buildHttpToolsForCollectionIds,
+  buildHttpToolsPromptBlock,
+  formatHttpToolsForPrompt,
+  readApprovalPolicy,
+} from "./httpTools";
 
 /** Calls a built tool the way the SDK does — through invoke() with a JSON argument string,
  * so zod parsing runs too. */
@@ -280,5 +285,41 @@ describe("http tool building and execution", () => {
     // With the gate off, claiming the app will ask would be a lie the agent acts on.
     setSetting("appSettings.httpToolApprovalDelete", false);
     expect(buildHttpToolsPromptBlock([collection.id])).not.toContain("call it directly, don't ask first");
+  });
+});
+
+describe("readApprovalPolicy", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    runMigrations(db);
+  });
+
+  it("asks before every write when nothing has been stored", () => {
+    // A fresh install must ask. The defaults come from settingsSchema now rather than three
+    // inline `true`s here.
+    expect(readApprovalPolicy()).toEqual({ post: true, putPatch: true, delete: true });
+  });
+
+  it("honours a real stored choice", () => {
+    setSetting("appSettings.httpToolApprovalDelete", false);
+    expect(readApprovalPolicy().delete).toBe(false);
+    expect(readApprovalPolicy().post).toBe(true);
+  });
+
+  it("falls back to asking when a stored value isn't a boolean", () => {
+    // This is the one that matters. The policy feeds needsApproval directly, and a null row —
+    // writable by any build from before the settings schema — is falsy, so the gate would have
+    // stopped asking silently, in the unsafe direction.
+    for (const bad of [null, "false", "true", 0, 1]) {
+      setSetting("appSettings.httpToolApprovalDelete", bad);
+      expect(readApprovalPolicy().delete).toBe(true);
+    }
+  });
+
+  it("does not let one unusable value change the others", () => {
+    setSetting("appSettings.httpToolApprovalPost", false);
+    setSetting("appSettings.httpToolApprovalDelete", null);
+    expect(readApprovalPolicy()).toEqual({ post: false, putPatch: true, delete: true });
   });
 });

--- a/electron/main/ai/httpTools.ts
+++ b/electron/main/ai/httpTools.ts
@@ -13,7 +13,7 @@ import {
 import { assertPublicHttpUrl } from "../net/urlSafety";
 import { buildHttpRequest, toolParamsSchema, type HttpToolArgValue } from "./httpToolRequest";
 import { requiresApproval, type ApprovalPolicy } from "./approvalPolicy";
-import { getSetting } from "../db/settingsStore";
+import { readAppSetting } from "../appSettings";
 import { devLog } from "../devLog";
 
 /** Per-request ceiling. A slow or hanging endpoint must never hold an agent run open until
@@ -118,14 +118,21 @@ function describeTool(collection: HttpToolCollectionRow, row: HttpToolRow): stri
   return parts.join(" ");
 }
 
-/** Reads the user's global approval posture. Defaults match DEFAULT_SETTINGS in
- * src/lib/settings.ts — all writes ask, so a database that has never stored these keys
- * still behaves safely. */
+/**
+ * Reads the user's global approval posture, defaults resolved from settingsSchema so a database
+ * that has never stored these keys still asks before every write.
+ *
+ * Through readAppSetting rather than getSetting, which matters more here than elsewhere: this
+ * feeds `needsApproval` directly, and `getSetting<boolean>` is an assertion, not a check. A row
+ * holding null — writable by any build from before the settings schema — is falsy, so the gate
+ * would simply stop asking, silently and in the unsafe direction. Now a value that isn't a real
+ * boolean falls back to "ask".
+ */
 export function readApprovalPolicy(): ApprovalPolicy {
   return {
-    post: getSetting<boolean>("appSettings.httpToolApprovalPost", true),
-    putPatch: getSetting<boolean>("appSettings.httpToolApprovalPutPatch", true),
-    delete: getSetting<boolean>("appSettings.httpToolApprovalDelete", true),
+    post: readAppSetting("httpToolApprovalPost"),
+    putPatch: readAppSetting("httpToolApprovalPutPatch"),
+    delete: readAppSetting("httpToolApprovalDelete"),
   };
 }
 

--- a/electron/main/ai/skillDistill.ts
+++ b/electron/main/ai/skillDistill.ts
@@ -8,7 +8,8 @@
 
 import OpenAI from "openai";
 import { getConfiguredChatUrl, getDecryptedChatApiKey } from "./provider";
-import { getSetting } from "../db/settingsStore";
+import { readAppSetting } from "../appSettings";
+import { SETTING_DEFAULTS } from "../settingsSchema";
 
 // Reads the same setting agents.ts's buildOrchestrator() uses for the orchestrator's
 // own model, via settingsStore directly rather than importing agents.ts (which would be
@@ -16,10 +17,12 @@ import { getSetting } from "../db/settingsStore";
 // distillation on whatever model the user actually has configured instead of a separately
 // hardcoded literal that can silently drift out of sync — which is exactly what happened
 // when DEFAULT_MODEL switched formats and this file's old hardcoded copy didn't.
-const FALLBACK_MODEL = "gpt-4.1-mini";
-
 function getOrchestratorModel(): string {
-  return getSetting<string>("appSettings.orchestratorModel", FALLBACK_MODEL) || FALLBACK_MODEL;
+  // The local FALLBACK_MODEL this used to declare was the fourth hardcoded copy of the same
+  // string — and the comment above it already described that exact failure happening once
+  // before. readAppSetting resolves the default from settingsSchema, so there is nothing left
+  // here to drift. The `||` still stands because "" is a legal stored value meaning "unset".
+  return readAppSetting("orchestratorModel") || SETTING_DEFAULTS.orchestratorModel;
 }
 
 export interface SkillDistillSource {

--- a/src/components/molecules/AddAgentForm.tsx
+++ b/src/components/molecules/AddAgentForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
+import { DEFAULT_ORCHESTRATOR_MODEL } from "@/lib/settings";
 
 interface AddAgentFormProps {
   defaultModel: string;
@@ -83,7 +84,7 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder="gpt-4.1-mini"
+            placeholder={DEFAULT_ORCHESTRATOR_MODEL}
             autoComplete="off"
           />
         </label>

--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -3,6 +3,7 @@ import TablerIcon from "@/components/atoms/TablerIcon";
 import Toggle from "@/components/atoms/Toggle";
 import TagMultiSelect from "@/components/atoms/TagMultiSelect";
 import DeleteConfirmModal from "@/components/molecules/DeleteConfirmModal";
+import { DEFAULT_ORCHESTRATOR_MODEL } from "@/lib/settings";
 
 interface AgentAccordionProps {
   icon: string;
@@ -221,7 +222,7 @@ export default function AgentAccordion({
                   if (modelDraft !== (model ?? "")) onChangeModel(modelDraft);
                 }}
                 onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-                placeholder="gpt-4.1-mini"
+                placeholder={DEFAULT_ORCHESTRATOR_MODEL}
                 autoComplete="off"
               />
             </label>

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -14,7 +14,7 @@ import ConnectorsTab from "@/components/organisms/ConnectorsTab";
 import HttpToolsTab from "@/components/organisms/HttpToolsTab";
 import AboutTab from "@/components/organisms/AboutTab";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
-import { AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
+import { DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { hasAgentsAPI } from "@/lib/agentsApi";
 import { useMcpServers } from "@/hooks/useMcpServers";
@@ -385,7 +385,7 @@ export default function SettingsPanel({
                           type="text"
                           value={settings.orchestratorModel}
                           onChange={(e) => onUpdate({ orchestratorModel: e.target.value })}
-                          placeholder="gpt-4.1-mini"
+                          placeholder={DEFAULT_ORCHESTRATOR_MODEL}
                           autoComplete="off"
                         />
                       </label>

--- a/src/lib/settingsDefaults.test.ts
+++ b/src/lib/settingsDefaults.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SETTINGS } from "./settings";
+import { DEFAULT_ORCHESTRATOR_MODEL, DEFAULT_SETTINGS } from "./settings";
 import { SETTING_DEFAULTS } from "../../electron/main/settingsSchema";
 
 /**
@@ -43,5 +43,16 @@ describe("settings defaults, renderer vs main", () => {
     expect(SETTING_DEFAULTS.httpToolApprovalPost).toBe(true);
     expect(SETTING_DEFAULTS.httpToolApprovalPutPatch).toBe(true);
     expect(SETTING_DEFAULTS.httpToolApprovalDelete).toBe(true);
+  });
+});
+
+describe("the orchestrator model default", () => {
+  it("is declared once per side and nowhere else", () => {
+    // Finding S7 was three hardcoded copies of this string drifting apart, and the comment on
+    // skillDistill.ts's copy described that having already happened once. Both sides now derive
+    // from a single constant; this asserts the two constants still agree, which is the only
+    // remaining way they could diverge.
+    expect(SETTING_DEFAULTS.orchestratorModel).toBe(DEFAULT_ORCHESTRATOR_MODEL);
+    expect(DEFAULT_SETTINGS.orchestratorModel).toBe(DEFAULT_ORCHESTRATOR_MODEL);
   });
 });


### PR DESCRIPTION
Closes **S7**, and fixes a gap `cb-debug` found next to it.

## S7 was already half-closed

Making `orchestratorModel` a `model` kind in the schema ([#16](https://github.com/maneja81/OpenOrbit/pull/16)) put both write paths on the same `MODEL_ID_PATTERN`. The "two validation standards" half of the finding is gone.

What remained was the triplicated default. `skillDistill.ts` held the last hardcoded copy — under a comment that reads, in hindsight, like a warning to itself:

> *"…instead of a separately hardcoded literal that can silently drift out of sync — which is exactly what happened when `DEFAULT_MODEL` switched formats and this file's old hardcoded copy didn't."*

Immediately followed by `const FALLBACK_MODEL = "gpt-4.1-mini"`. The abstraction was built to solve the problem it still had.

## What changed

`skillDistill` now reads through `readAppSetting`, which resolves the default from the schema. Three renderer placeholders derive from `DEFAULT_ORCHESTRATOR_MODEL` rather than repeating it, so a model bump can't leave a stale hint on screen.

**Two declarations remain, one per TypeScript project** — main can't import the renderer's. `settingsDefaults.test.ts` already asserted they agree key for key; it now names this one specifically, since it's the one with a history.

`provider.ts` keeps its literal deliberately: that's a key in the pricing table, not a default.

## The part that isn't S7

`httpTools.ts:126-128` read the three **approval** settings with raw `getSetting` and its own inline defaults — the one file S1 and X3 missed.

That read feeds `needsApproval` directly, and `getSetting<boolean>` is an assertion, not a check. A row holding `null` — writable by any build from before the settings schema — is **falsy**. So the approval gate would simply stop asking. Silently, and in the unsafe direction.

Folded in rather than filed: three lines, the same one-line pattern, and shipping a "single source of truth" PR while leaving a known unvalidated read of the approval policy would be incoherent.

## Reproduced after fix

New `readApprovalPolicy` tests against pre-fix `httpTools.ts`: **2 failed / 16 passed** — the null case and the "one bad value doesn't affect the others" case. Restored: **18/18**.

## Validated in the app

Planted `httpToolApprovalDelete: null` and opened Settings → HTTP Tools: the DELETE toggle reads `aria-checked="true"`, still asking.

**Honest limit:** that's the renderer path (X4's merge). Reaching main's `needsApproval` in the app needs an HTTP tool collection plus a live agent turn that calls a DELETE endpoint. The main-side read is covered by the unit tests above and by the fact that the `readApprovalPolicy` → `needsApproval` wiring is untouched.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **930 passed / 98 files** (925 before — +5) |
| E2E | – not configured |

Remaining hardcoded occurrences of the string, for the record:

```
electron/main/settingsSchema.ts   orchestratorModel: "gpt-4.1-mini"   ← main's declaration
src/lib/settings.ts               DEFAULT_ORCHESTRATOR_MODEL          ← renderer's declaration
electron/main/ai/provider.ts      pricing table key                   ← not a default
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
