### PR TITLE
S16: recover the Danger Zone button when a reset fails

### DIFF
--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import SettingsPanel from "./SettingsPanel";
+import { mergeWithDefaults } from "@/lib/settings";
+
+// vitest runs with globals: false, so RTL cannot register its own cleanup.
+afterEach(cleanup);
+
+// jsdom has no layout, and Combobox scrolls its active row into view on mount.
+Element.prototype.scrollIntoView = vi.fn();
+
+// The four data hooks this panel uses all guard on hasAgentsAPI(), which is false under jsdom,
+// so they no-op and need no mocking — only the props below.
+function renderDangerZone(onReset: () => Promise<void>) {
+  render(
+    <SettingsPanel
+      open
+      initialSection="danger"
+      onClose={vi.fn()}
+      settings={mergeWithDefaults({})}
+      sessionElapsedMs={0}
+      onUpdate={vi.fn()}
+      onReset={onReset}
+      agents={[]}
+      onUpdateAgent={vi.fn()}
+      onCreateAgent={vi.fn()}
+      onDeleteAgent={vi.fn()}
+      onExportAgent={vi.fn()}
+      onExportAllAgents={vi.fn()}
+      onImportAgents={vi.fn()}
+    />
+  );
+  // Mounting already-open leaves activeSection at its default: sectionOnTransition only fires
+  // on the closed→open edge, which in the real app is how the panel always arrives. Navigate
+  // the way a user does instead.
+  // The sidebar items are role="tab", not buttons.
+  fireEvent.click(screen.getByRole("tab", { name: /Danger Zone/i }));
+  const input = screen.getByPlaceholderText("RESET") as HTMLInputElement;
+  const button = screen.getByRole("button", { name: /Reset to Default/i });
+  return { input, button };
+}
+
+describe("Danger Zone reset", () => {
+  it("stays disabled until the confirmation word is typed exactly", () => {
+    const { input, button } = renderDangerZone(vi.fn());
+    expect(button).toBeDisabled();
+    fireEvent.change(input, { target: { value: "reset" } });
+    expect(button).toBeDisabled();
+    fireEvent.change(input, { target: { value: "RESET" } });
+    expect(button).toBeEnabled();
+  });
+
+  it("calls onReset once when confirmed", async () => {
+    const onReset = vi.fn().mockResolvedValue(undefined);
+    const { input, button } = renderDangerZone(onReset);
+    fireEvent.change(input, { target: { value: "RESET" } });
+    fireEvent.click(button);
+    await waitFor(() => expect(onReset).toHaveBeenCalledExactlyOnceWith());
+  });
+
+  describe("when the reset fails", () => {
+    // settings:reset drops every app table inside a transaction and re-runs migrations. It can
+    // genuinely fail — most plausibly SQLITE_BUSY, since the userData database is shared across
+    // worktrees and a second running instance holds a write lock.
+    const failing = () => vi.fn().mockRejectedValue(new Error("database is locked"));
+
+    it("re-enables the button instead of leaving it on Resetting… forever", async () => {
+      const { input, button } = renderDangerZone(failing());
+      fireEvent.change(input, { target: { value: "RESET" } });
+      fireEvent.click(button);
+      await waitFor(() => expect(button).toBeEnabled());
+      expect(button).toHaveTextContent(/Reset to Default/i);
+    });
+
+    it("tells the user what went wrong", async () => {
+      // It used to say nothing at all — the rejection was unhandled and invisible.
+      const { input, button } = renderDangerZone(failing());
+      fireEvent.change(input, { target: { value: "RESET" } });
+      fireEvent.click(button);
+      await waitFor(() => expect(screen.getByText(/database is locked/i)).toBeInTheDocument());
+    });
+
+    it("lets the user try again", async () => {
+      const onReset = failing();
+      const { input, button } = renderDangerZone(onReset);
+      fireEvent.change(input, { target: { value: "RESET" } });
+      fireEvent.click(button);
+      await waitFor(() => expect(button).toBeEnabled());
+
+      fireEvent.click(button);
+      await waitFor(() => expect(onReset).toHaveBeenCalledTimes(2));
+    });
+
+    it("clears the previous error when retried", async () => {
+      const onReset = vi.fn().mockRejectedValueOnce(new Error("database is locked")).mockResolvedValue(undefined);
+      const { input, button } = renderDangerZone(onReset);
+      fireEvent.change(input, { target: { value: "RESET" } });
+      fireEvent.click(button);
+      await waitFor(() => expect(screen.getByText(/database is locked/i)).toBeInTheDocument());
+
+      fireEvent.click(button);
+      await waitFor(() => expect(screen.queryByText(/database is locked/i)).not.toBeInTheDocument());
+    });
+
+    it("does not report failure when the reset succeeds", async () => {
+      const { input, button } = renderDangerZone(vi.fn().mockResolvedValue(undefined));
+      fireEvent.change(input, { target: { value: "RESET" } });
+      fireEvent.click(button);
+      // Stays disabled on success — onReset reloads the window, and re-enabling would invite a
+      // second click against a database mid-rebuild.
+      await waitFor(() => expect(button).toBeDisabled());
+      expect(screen.queryByText(/settings-error/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -231,6 +231,7 @@ export default function SettingsPanel({
   const [voiceTestResult, setVoiceTestResult] = useState<{ ok: boolean; detail: string } | null>(null);
   const [resetConfirmText, setResetConfirmText] = useState("");
   const [resetting, setResetting] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
   const [orchestratorPrompt, setOrchestratorPrompt] = useState("");
   const [orchestratorPromptLoading, setOrchestratorPromptLoading] = useState(true);
   const [addingAgent, setAddingAgent] = useState(false);
@@ -301,7 +302,21 @@ export default function SettingsPanel({
   const handleReset = async () => {
     if (resetConfirmText !== RESET_CONFIRM_WORD || resetting) return;
     setResetting(true);
-    await onReset();
+    setResetError(null);
+    try {
+      await onReset();
+      // No reset of `resetting` on success: onReset reloads the window, so the button staying
+      // disabled for those last moments is correct — re-enabling it would invite a second click
+      // against a database mid-rebuild.
+    } catch (err) {
+      // settings:reset drops every app table inside a transaction and re-runs migrations. That
+      // can genuinely fail — most plausibly SQLITE_BUSY, since the userData database is shared
+      // across worktrees and a second running instance holds a write lock. Without this the
+      // rejection was unhandled, the button sat on "Resetting…" disabled forever, and the user
+      // was told nothing. Every other async action in this file already catches this way.
+      setResetError(formatHumanizedError(humanizeError(err)));
+      setResetting(false);
+    }
   };
 
   const meta = SECTION_META[activeSection];
@@ -839,6 +854,7 @@ export default function SettingsPanel({
                       autoComplete="off"
                       disabled={resetting}
                     />
+                    {resetError && <p className="settings-error">{resetError}</p>}
                     <button
                       className="danger-btn"
                       disabled={resetConfirmText !== RESET_CONFIRM_WORD || resetting}


### PR DESCRIPTION
Closes **S16**.

## Root cause

```ts
const handleReset = async () => {
  if (resetConfirmText !== RESET_CONFIRM_WORD || resetting) return;
  setResetting(true);
  await onReset();        // no catch, no finally
};
```

On the happy path that's fine — `onReset` reloads the window, so the button never needs re-enabling. **On failure the rejection was unhandled**, the button sat on "Resetting…" disabled forever, and the user was told nothing. The only way out was quitting the app.

Not hypothetical: `settings:reset` drops every app table inside a transaction and re-runs migrations. The likeliest failure is `SQLITE_BUSY`, because the userData database is shared across every checkout and worktree — **a second running instance holds a write lock**.

## What changed

Caught, `resetting` cleared, message surfaced through `formatHumanizedError` — the same shape `runTestChat`, `runTestVoice` and `runAgentAction` already use in this file. The confirmation word stays in the box, so retrying is one click.

Success still leaves the button disabled, deliberately: the window is about to reload, and re-enabling would invite a second click against a database mid-rebuild.

## Validated against a real failure, not a mocked one

Held an `EXCLUSIVE` lock on the sandbox database from a second process, then drove the reset through the UI:

```
PASS  button is enabled before the attempt
PASS  the app is still alive
PASS  button recovered from Resetting…
PASS  button is usable again
PASS  an error is shown — "…SqliteError: database is locked Try again…"
```

That's the exact `SQLITE_BUSY` the finding describes, reproduced end to end rather than simulated.

## Tests

**The first tests this component has had** — 7. Rendering it turned out to need no mocking: its four data hooks all guard on `hasAgentsAPI()`, false under jsdom, so they no-op.

Two things worth knowing for whoever writes the next test here, both noted in the file:
- the sidebar items are `role="tab"`, not buttons
- mounting the panel **already open** leaves `activeSection` at its default, because `sectionOnTransition` only fires on the closed→open edge — so navigate via the sidebar, as a user does

Coverage: confirm-word gating, single call on confirm, button recovery, error shown, retry works, error cleared on retry, and no error on success.

## Reproduced after fix

Against pre-fix `SettingsPanel.tsx`: **4 failed / 3 passed** — recovery, the error message, retry, and error-clearing. Restored: **7/7**.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **937 passed / 99 files** (930 before — +7) |
| E2E | – not configured |

## Flagged, not fixed here

The surfaced message leaks Electron's IPC wrapper:

> Something went wrong: **Error invoking remote method 'settings:reset':** SqliteError: database is locked Try again, and let us know if it keeps happening.

`humanizeError` doesn't strip that prefix. It's readable, and the useful part ("database is locked") survives — but it affects **every** IPC error surface in the app, not just this one, so it belongs in its own change rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
