### PR TITLE
Fix tool_output log truncation

### DIFF
--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -43,11 +43,11 @@ function describeRunItem(item: unknown): string {
       output?: unknown;
       agent?: { name?: string };
     };
-    if (anyItem.rawItem?.name) {
-      return `tool="${anyItem.rawItem.name}" args=${anyItem.rawItem.arguments ?? "{}"}`;
-    }
     if (anyItem.output !== undefined) {
       return `output=${typeof anyItem.output === "string" ? anyItem.output : JSON.stringify(anyItem.output)}`;
+    }
+    if (anyItem.rawItem?.name) {
+      return `tool="${anyItem.rawItem.name}" args=${anyItem.rawItem.arguments ?? "{}"}`;
     }
     return JSON.stringify(item).slice(0, 300);
   } catch {


### PR DESCRIPTION
## What changed
Fixes the dev diagnostic log so `tool_output` entries show the tool's actual return value instead of silently re-printing the preceding `tool_called` line. Affects debugging only — no runtime/agent behavior changes.

## Root cause
`describeRunItem` checked `rawItem?.name` before `output`. Both call items and result items (`function_call_result`) carry `rawItem.name`, so result items always took the call-args branch and printed a stale `args={}`, masking the real output.

## Testing
- Unit/integration: 930 passed / not previously covering this function
- E2E: not configured
- Manual: reproduced the exact bug with a simulated `function_call_result` item (`name` + `output`, no `arguments`) — old code printed `tool="get_current_location" args={}`, new code prints the real `output=...`. Confirmed `tool_called` items are unaffected.

## Notes
No existing test covered `describeRunItem`; worth adding one as follow-up.