### PR TITLE
S22: unwrap IPC errors before deciding what to tell the user

### DIFF
--- a/src/lib/humanizeError.test.ts
+++ b/src/lib/humanizeError.test.ts
@@ -67,3 +67,63 @@ describe("formatHumanizedError", () => {
     expect(formatted).toBe("Something went wrong: Unexpected error.");
   });
 });
+
+describe("errors that arrived over IPC", () => {
+  // Electron wraps every rejected ipcRenderer.invoke as
+  // `Error invoking remote method '<channel>': <ErrorName>: <message>`. Nearly every error this
+  // function sees comes that way, so the wrapper decided most categorisations before this.
+  it("categorises a wrapped Access denied, which it previously could not", () => {
+    // The one with real consequences: ipc/filesystem.ts throws this, so it *always* arrives
+    // wrapped, and the startsWith check never matched. Users got "Something went wrong" instead
+    // of the only message that tells them what to do.
+    const h = humanizeError(
+      new Error(`Error invoking remote method 'fs:readFile': Error: Access denied: "/etc" is outside all allowed folders`)
+    );
+    expect(h.title).toBe("Access denied");
+    expect(h.nextSteps[0]).toMatch(/Settings > Folders/);
+  });
+
+  it("keeps a named error class, which is worth showing", () => {
+    const h = humanizeError(new Error("Error invoking remote method 'settings:reset': SqliteError: database is locked"));
+    expect(h.message).toBe("SqliteError: database is locked");
+    expect(h.message).not.toMatch(/invoking remote method/);
+  });
+
+  it("drops the bare Error: prefix, which says nothing", () => {
+    expect(humanizeError(new Error("Error invoking remote method 'x:y': Error: boom")).message).toBe("boom");
+  });
+
+  it("still categorises a wrapped validation failure", () => {
+    const h = humanizeError(new Error("Error invoking remote method 'mcp:update': Error: mcp:update requires a non-empty server id"));
+    expect(h.title).toBe("Something's missing");
+    expect(h.message).toBe("mcp:update requires a non-empty server id");
+  });
+
+  it("leaves an unwrapped message alone", () => {
+    expect(humanizeError(new Error("plain failure")).message).toBe("plain failure");
+  });
+
+  it("handles a channel name containing a colon", () => {
+    // Every channel in this app is namespaced with one, so a lazy regex would under-match.
+    expect(humanizeError(new Error("Error invoking remote method 'agent:runStream': Error: nope")).message).toBe("nope");
+  });
+});
+
+describe("formatHumanizedError punctuation", () => {
+  it("does not run the message into the next step", () => {
+    // "database is locked Try again, and let us know…" — thrown messages rarely end in a period.
+    const formatted = formatHumanizedError(
+      humanizeError(new Error("Error invoking remote method 'settings:reset': SqliteError: database is locked"))
+    );
+    expect(formatted).toBe("Something went wrong: SqliteError: database is locked. Try again, and let us know if it keeps happening.");
+  });
+
+  it("does not double up punctuation the message already has", () => {
+    const formatted = formatHumanizedError({ title: "T", message: "Already ends properly.", nextSteps: ["Next."] });
+    expect(formatted).toBe("T: Already ends properly. Next.");
+  });
+
+  it("omits the separator when there are no next steps", () => {
+    expect(formatHumanizedError({ title: "T", message: "m", nextSteps: [] })).toBe("T: m");
+  });
+});

--- a/src/lib/humanizeError.ts
+++ b/src/lib/humanizeError.ts
@@ -8,11 +8,30 @@ const VALIDATION_PATTERNS = [/requires/i, /must be/i, /is required/i];
 
 const BRIDGE_UNAVAILABLE_PATTERNS = [/bridge unavailable/i, /window\.agentsAPI/i];
 
+/**
+ * Electron wraps every rejected `ipcRenderer.invoke` as
+ * `Error invoking remote method '<channel>': <ErrorName>: <message>`.
+ *
+ * That wrapper defeated the categories below, which is worse than it looks. `Access denied:` is
+ * thrown by ipc/filesystem.ts and so always arrives wrapped — the startsWith check never matched,
+ * and the user got the generic "Something went wrong" instead of the one message that tells them
+ * what to actually do about it. Nearly every error this function sees comes over IPC.
+ *
+ * The plain `Error:` left behind is dropped too, since it says nothing. A named class
+ * (`SqliteError:`) is kept — that one is worth showing.
+ */
+const IPC_WRAPPER = /^Error invoking remote method '[^']*':\s*/;
+const PLAIN_ERROR_PREFIX = /^Error:\s*/;
+
+function unwrap(message: string): string {
+  return message.replace(IPC_WRAPPER, "").replace(PLAIN_ERROR_PREFIX, "").trim();
+}
+
 function rawMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
+  if (error instanceof Error) return unwrap(error.message);
+  if (typeof error === "string") return unwrap(error);
   try {
-    return String(error);
+    return unwrap(String(error));
   } catch {
     return "Unknown error";
   }
@@ -62,8 +81,12 @@ export function humanizeError(error: unknown): HumanizedError {
   };
 }
 
-/** Joins a HumanizedError into one string for surfaces that only render plain text. */
+/** Joins a HumanizedError into one string for surfaces that only render plain text.
+ *
+ * The message is punctuated before the next steps are appended — most come from a thrown Error
+ * and end without any, which ran the two together: "database is locked Try again". */
 export function formatHumanizedError(h: HumanizedError): string {
-  const steps = h.nextSteps.length > 0 ? ` ${h.nextSteps.join(" ")}` : "";
-  return `${h.title}: ${h.message}${steps}`;
+  if (h.nextSteps.length === 0) return `${h.title}: ${h.message}`;
+  const message = /[.!?]$/.test(h.message.trim()) ? h.message.trim() : `${h.message.trim()}.`;
+  return `${h.title}: ${message} ${h.nextSteps.join(" ")}`;
 }


### PR DESCRIPTION
Closes **S22**, which I logged as cosmetic yesterday and `cb-debug` showed is not.

## Root cause

Electron wraps every rejected `ipcRenderer.invoke`:

```
Error invoking remote method '<channel>': <ErrorName>: <message>
```

`humanizeError` never stripped it. That reads as clutter — but **the real cost is that the wrapper decided the categorisation**.

`Access denied:` is thrown by `ipc/filesystem.ts:60`, so it *always* arrives wrapped, so `msg.startsWith("Access denied:")` was never true. The user got the generic *"Something went wrong"* instead of the one message that tells them what to do about it:

> Add the folder under Settings > Folders, then try again.

Nearly every error this function sees comes over IPC, so the categories were being decided by a prefix rather than by the error. That's the opposite of what the module is for.

## What changed

The wrapper is stripped, along with the bare `Error:` it leaves behind, which says nothing. A named class like `SqliteError:` is **kept** — that one is worth showing.

`formatHumanizedError` also punctuates the message before appending next steps. Thrown messages rarely end in a period, so the two ran together.

## Before and after, in the app

Same scenario as [#27](https://github.com/maneja81/OpenOrbit/pull/27) — an `EXCLUSIVE` lock held on the sandbox database from a second process, reset driven through the UI:

```
before  Something went wrong: Error invoking remote method 'settings:reset': SqliteError: database is locked Try again, and let us know if it keeps happening.
after   Something went wrong: SqliteError: database is locked. Try again, and let us know if it keeps happening.
```

## Reproduced after fix

New tests against pre-fix `humanizeError.ts`: **6 failed / 11 passed**. Restored: **17/17**.

## Tests

+9. The `Access denied` categorisation that previously couldn't work, keeping a named error class, dropping the bare `Error:`, a wrapped validation failure still categorising, an unwrapped message left alone, and a channel name containing a colon (every channel in this app is namespaced, so a lazy regex would under-match). Plus three on punctuation, including not doubling up when the message already ends properly.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **946 passed / 99 files** (937 before — +9) |
| E2E | – not configured |

## Note

The `Access denied` path is covered by unit test rather than driven in the app — triggering it needs a filesystem access outside the allowed roots through the UI. It's the same code path as the `SqliteError` case that *was* driven, and the assertion is direct.

Worth recording how this was found: not by reading the code, but by **looking at the error the Danger Zone actually put on screen** while validating S16. I'd logged it as a cosmetic P3 on that basis; only investigating it properly showed the categorisation failure underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
