### PR TITLE
Surface real errors on silent TTS playback failures

### DIFF
--- a/electron/main/ai/provider.test.ts
+++ b/electron/main/ai/provider.test.ts
@@ -13,7 +13,7 @@ vi.mock("../security/secretStorage", () => ({
   decryptSecret: vi.fn(() => "test-key"),
 }));
 
-import { transcribeAudio, estimateGenerationCost } from "./provider";
+import { transcribeAudio, synthesizeSpeech, estimateGenerationCost } from "./provider";
 
 describe("transcribeAudio", () => {
   afterEach(() => {
@@ -91,6 +91,51 @@ describe("transcribeAudio", () => {
       })
     );
     await expect(transcribeAudio("base64audio", "webm")).rejects.toThrow(/Transcription failed \(400\)/);
+  });
+});
+
+describe("synthesizeSpeech", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns base64 audio when the provider responds with an audio content-type", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "audio/mpeg" }),
+        arrayBuffer: async () => new TextEncoder().encode("fake-mp3-bytes").buffer,
+      })
+    );
+    const result = await synthesizeSpeech("hello");
+    expect(result.format).toBe("mp3");
+    expect(Buffer.from(result.audio, "base64").toString()).toBe("fake-mp3-bytes");
+  });
+
+  it("throws with response detail on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () => "bad voice",
+      })
+    );
+    await expect(synthesizeSpeech("hello")).rejects.toThrow(/Speech synthesis failed \(400\)/);
+  });
+
+  it("throws when a 200 response isn't actually audio", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        text: async () => '{"error":"upstream unavailable"}',
+      })
+    );
+    await expect(synthesizeSpeech("hello")).rejects.toThrow(/non-audio content-type "application\/json"/);
   });
 });
 

--- a/electron/main/ai/provider.ts
+++ b/electron/main/ai/provider.ts
@@ -217,6 +217,16 @@ export async function synthesizeSpeech(text: string): Promise<{ audio: string; f
     throw new Error(`Speech synthesis failed (${response.status}): ${detail || response.statusText}`);
   }
 
+  // A 200 status isn't necessarily audio — some providers/proxies return an error page or
+  // JSON body with a success status. Without this check, that body gets base64-encoded and
+  // handed to the renderer as if it were valid mp3, where it fails silently at playback
+  // (Audio.onerror) with no indication of what actually went wrong.
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("audio/")) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`Speech synthesis returned non-audio content-type "${contentType}": ${detail.slice(0, 200)}`);
+  }
+
   const arrayBuffer = await response.arrayBuffer();
   return { audio: Buffer.from(arrayBuffer).toString("base64"), format };
 }

--- a/src/hooks/useSpeak.ts
+++ b/src/hooks/useSpeak.ts
@@ -76,7 +76,12 @@ export function useSpeak() {
           el.onerror = () => {
             setSpeaking(false);
             audioRef.current = null;
-            devLog("[speak] audio playback failed, falling back to browser TTS");
+            const mediaError = el.error;
+            devLog(
+              "[speak] audio playback failed, falling back to browser TTS",
+              `code=${mediaError?.code ?? "unknown"}`,
+              mediaError?.message || "(no message)"
+            );
             speakWithBrowserTts(text, callbacks);
           };
           void el.play();


### PR DESCRIPTION
## What changed
Adds diagnostics to the TTS synthesis/playback path so a silent TTS failure becomes traceable. `synthesizeSpeech` now validates that a 200 response is actually audio before treating the body as such; the browser-fallback log now includes the real `MediaError` code/message instead of a fixed string.

## Root cause
Not fully confirmed for the specific report that prompted this — but `synthesizeSpeech` accepted any 200-status response as audio bytes with no content-type check, so a non-audio 200 (error page, JSON) would silently reach the renderer and fail at `Audio.onerror` with no diagnostic detail. This closes that blind spot going forward.

## Testing
- Unit/integration: 940 passed (3 new tests added for `synthesizeSpeech`'s content-type guard)
- E2E: not configured
- Manual: verified via unit test that a 200/`application/json` response now throws with the real body instead of silently succeeding

## Notes
This doesn't confirm-and-fix the original silent failure — it makes the next occurrence self-diagnosing (real content-type + MediaError surface in devLog instead of a dead end).