### PR TITLE
S13: show the orchestrator prompt template, not a rendered snapshot of it

### DIFF
--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -593,15 +593,28 @@ const getCurrentLocationTool = tool({
 });
 
 /** Returns the user's saved override if set (via Settings → Agents), else the built-in orchestrator.md template. */
-function getOrchestratorPromptTemplate(): string {
+export function getOrchestratorPromptTemplate(): string {
   const override = readAppSetting("orchestratorPromptOverride");
   return override.trim().length > 0 ? override : orchestratorPrompt;
 }
 
-export function getOrchestratorPrompt(): string {
-  const agentName = readAppSetting("agentName");
-  const userName = readAppSetting("userName");
-  return renderPrompt(getOrchestratorPromptTemplate(), { agentName, userName, currentDateTime: getCurrentDateTime() });
+/**
+ * The orchestrator prompt as the Settings panel should show it: the *template*, placeholders
+ * intact.
+ *
+ * This used to return the rendered prompt, which quietly made editing it destructive. The panel
+ * saves whatever the textarea holds as orchestratorPromptOverride, so a rendered prompt saved
+ * back froze the substitutions permanently: {{agentName}} stopped following a rename, and
+ * {{currentDateTime}} pinned the model to the date and time of the edit — reintroducing exactly
+ * the stale-date bug getCurrentDateTime exists to prevent, for good, from one edit.
+ *
+ * Every sub-agent's prompt in the same list is its raw column, placeholders and all, so showing
+ * the template here is also what makes the orchestrator consistent with them.
+ *
+ * Nothing else calls this: the agent build renders the template separately at build time.
+ */
+export function getOrchestratorPromptForEditing(): string {
+  return getOrchestratorPromptTemplate();
 }
 
 export function listAgents(): AgentRow[] {

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -19,7 +19,7 @@ import {
   exportAgent,
   exportAllAgents,
   importAgent,
-  getOrchestratorPrompt,
+  getOrchestratorPromptForEditing,
   AgentUpdatePatch,
   AgentCreateInput,
   AgentExport,
@@ -597,7 +597,7 @@ export function registerAgentHandlers() {
     return createAgent(input);
   });
 
-  ipcMain.handle("agent:orchestratorPrompt", (): string => getOrchestratorPrompt());
+  ipcMain.handle("agent:orchestratorPrompt", (): string => getOrchestratorPromptForEditing());
 
   ipcMain.handle("agent:delete", (_event, id: string) => {
     if (typeof id !== "string" || id.length === 0) {

--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -23,6 +23,9 @@ interface AgentAccordionProps {
   onChangeDescription?: (description: string) => void;
   onChangeModel?: (model: string) => void;
   onChangePrompt?: (prompt: string) => void;
+  /** Shown as a "Reset to default" control beside the prompt label. Only passed when the
+   * prompt is actually customised, so its presence is what says so. */
+  onResetPrompt?: () => void;
   onChangeEnabled: (enabled: boolean) => void;
   defaultOpen?: boolean;
   availableMcpServers?: McpServerRow[];
@@ -56,6 +59,7 @@ export default function AgentAccordion({
   onChangeDescription,
   onChangeModel,
   onChangePrompt,
+  onResetPrompt,
   onChangeEnabled,
   defaultOpen = false,
   availableMcpServers,
@@ -228,7 +232,21 @@ export default function AgentAccordion({
             </label>
           )}
           <label className="settings-field">
-            <span>Prompt (Markdown){promptDisabled ? " — locked" : ""}</span>
+            <span className="agent-accordion-prompt-label">
+              <span>Prompt (Markdown){promptDisabled ? " — locked" : ""}</span>
+              {onResetPrompt && (
+                <button
+                  type="button"
+                  className="settings-action-btn-sm settings-action-btn-ghost"
+                  // Nothing else told the user their prompt was frozen at a copy of the built-in,
+                  // so improvements to it silently stopped reaching them. This is both the signal
+                  // and the way back.
+                  onClick={onResetPrompt}
+                >
+                  Customised — reset to default
+                </button>
+              )}
+            </span>
             <textarea
               className="agent-accordion-prompt"
               value={promptLoading ? "Loading…" : promptDraft}

--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -114,3 +114,63 @@ describe("Danger Zone reset", () => {
     });
   });
 });
+
+describe("orchestrator prompt override", () => {
+  function renderAgents(overrideValue: string) {
+    const onUpdate = vi.fn();
+    render(
+      <SettingsPanel
+        open
+        onClose={vi.fn()}
+        settings={mergeWithDefaults({ orchestratorPromptOverride: overrideValue })}
+        sessionElapsedMs={0}
+        onUpdate={onUpdate}
+        onReset={vi.fn()}
+        agents={[]}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^Agents$/i }));
+    // The orchestrator's accordion is collapsed by default, so its prompt section isn't rendered
+    // until the header toggle is clicked.
+    const toggle = document.querySelector(".agent-accordion-header-toggle");
+    if (!toggle) throw new Error("no accordion header");
+    fireEvent.click(toggle);
+    // Queried directly rather than through screen: the panel renders into a portal with
+    // aria-modal, and once the accordion is expanded getByRole stops resolving inside it.
+    const resetButton = () =>
+      [...document.querySelectorAll("button")].find((b) => /reset to default/i.test(b.textContent ?? ""));
+    return { onUpdate, resetButton };
+  }
+
+  it("says nothing when the prompt is the built-in one", () => {
+    const { resetButton } = renderAgents("");
+    expect(resetButton()).toBeUndefined();
+  });
+
+  it("says the prompt is customised, and offers a way back", () => {
+    // Nothing told the user an override was active, so improvements to orchestrator.md silently
+    // stopped reaching them and there was no way to undo it short of clearing the box by hand.
+    const { resetButton } = renderAgents("You are a custom orchestrator.");
+    expect(resetButton()).toBeDefined();
+    expect(resetButton()?.textContent).toMatch(/customised/i);
+  });
+
+  it("clears the override when reset is pressed", () => {
+    const { onUpdate, resetButton } = renderAgents("You are a custom orchestrator.");
+    fireEvent.click(resetButton()!);
+    expect(onUpdate).toHaveBeenCalledWith({ orchestratorPromptOverride: "" });
+  });
+
+  it("treats a whitespace-only override as no override", () => {
+    // getOrchestratorPromptTemplate trims before deciding, so the renderer must agree —
+    // otherwise the button appears for a prompt main is already ignoring.
+    const { resetButton } = renderAgents("   \n  ");
+    expect(resetButton()).toBeUndefined();
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -295,6 +295,20 @@ export default function SettingsPanel({
     };
   }, [open]);
 
+  /** Clears the override and pulls the built-in template back into the textarea. The refetch
+   * matters: the panel loads the prompt once on open, so without it the box would keep showing
+   * the customised text the user just discarded. */
+  const resetOrchestratorPrompt = async () => {
+    onUpdate({ orchestratorPromptOverride: "" });
+    if (!hasAgentsAPI()) return;
+    setOrchestratorPromptLoading(true);
+    try {
+      setOrchestratorPrompt(await window.agentsAPI.agent.orchestratorPrompt());
+    } finally {
+      setOrchestratorPromptLoading(false);
+    }
+  };
+
   const previewSound = (event: SoundFxEvent, variant: number) => {
     new Audio(sfxPreviewSrc(event, variant)).play().catch(() => {});
   };
@@ -538,6 +552,11 @@ export default function SettingsPanel({
                       setOrchestratorPrompt(prompt);
                       onUpdate({ orchestratorPromptOverride: prompt });
                     }}
+                    onResetPrompt={
+                      settings.orchestratorPromptOverride.trim().length > 0
+                        ? () => void resetOrchestratorPrompt()
+                        : undefined
+                    }
                     onChangeEnabled={(enabled) => onUpdate({ orchestratorEnabled: enabled })}
                     availableMcpServers={mcpServers}
                     mcpServerIds={settings.orchestratorMcpServerIds}

--- a/src/globals.css
+++ b/src/globals.css
@@ -2193,6 +2193,16 @@ svg#oc {
   color: rgba(200, 230, 255, 0.65);
 }
 
+/* The prompt label carries a "reset to default" control on its right when the prompt has been
+   customised. Without this the button stacks under the label text, since .settings-field is a
+   column and its spans are plain inline text everywhere else. */
+.agent-accordion-prompt-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .settings-field input {
   background: rgba(255, 255, 255, 0.04);
   border: 0.5px solid rgba(60, 140, 255, 0.22);


### PR DESCRIPTION
Closes **S13**, and the root cause turned out to be worse than the finding recorded.

## The part the finding had

Nothing said an override was active. Improvements to `orchestrator.md` silently stopped reaching anyone who had touched the box, and the only way back was clearing it by hand.

## The part it didn't

`getOrchestratorPrompt()` returned the **rendered** prompt — `renderPrompt` had already substituted `{{agentName}}`, `{{userName}}` and `{{currentDateTime}}`. The panel saves whatever the textarea holds as `orchestratorPromptOverride`.

**So editing the prompt froze those substitutions permanently.** The agent name stopped following a rename, and the date and time of the edit were baked in for good — which reintroduces the exact problem `getCurrentDateTime`'s own comment says it exists to prevent:

> *"this is what actually fixes the model reporting a stale training-cutoff date instead of today's real date"*

One deliberate edit, no warning, no way back, and the model is pinned to that moment forever.

## What changed

**The IPC returns the template**, placeholders intact. Nothing else called that function — the agent build renders the template separately at build time — so its only job was feeding this textarea, and it was doing it wrong. It also makes the orchestrator consistent with every sub-agent in the same list, whose prompts are their raw column, placeholders and all.

**The prompt label carries a "Customised — reset to default" control** whenever the override is non-empty. Its presence *is* the signal; pressing it clears the override and pulls the built-in template back into the box. The refetch matters — the panel loads the prompt once on open, so without it the box would keep showing text the user just discarded.

## Correction to the finding

It claimed this field writes on every keystroke. It doesn't — `AgentAccordion` commits on blur and only when the text actually changed. It takes a real edit, not a stray keypress. The trap is narrower than recorded, but the consequence is worse.

## Validated in the app

With `agentName` set to `Cassini` and no override:

```
hasAgentNamePlaceholder: true
hasDatePlaceholder:      true
leakedName:              false     ← "Cassini" would have been baked in before
```

Then with an override stored, opened Settings → Agents → expanded the orchestrator: the control renders as `Customised — reset to default`, right-aligned on the prompt label's row. Screenshot checked.

## Tests

+4 in `SettingsPanel.test.tsx`: no control when the prompt is the built-in one, the control present and labelled when customised, reset calling `onUpdate({ orchestratorPromptOverride: "" })`, and a whitespace-only override treated as no override — which matters because `getOrchestratorPromptTemplate` trims before deciding, so the renderer has to agree or the button appears for a prompt main is already ignoring.

A CSS rule is included: `.settings-field` is a column and its spans are plain inline text everywhere else, so without it the button stacked under the label.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **950 passed / 99 files** (946 before — +4) |
| E2E | – not configured |

## Note for the next test in this file

Once the agent accordion is expanded, `getByRole` stops resolving inside the panel — it renders into a portal with `aria-modal`, and the accessibility tree collapses to just the dialog. Query the DOM directly. Noted in the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
