### PR TITLE
Fix CSP blocking TTS audio playback

### DIFF
--- a/electron/main/csp.test.ts
+++ b/electron/main/csp.test.ts
@@ -43,9 +43,11 @@ describe("contentSecurityPolicy", () => {
     expect(prod["img-src"]).toBe("'self' data: https:");
   });
 
-  it("keeps local fonts and the background video loadable", () => {
+  it("keeps local fonts, the background video, and synthesized TTS audio loadable", () => {
+    // TTS audio is played as `new Audio('data:audio/mp3;base64,...')` — the bytes come from
+    // the Voice API over IPC, so media-src needs data: alongside the bundled video's 'self'.
     expect(prod["font-src"]).toBe("'self'");
-    expect(prod["media-src"]).toBe("'self'");
+    expect(prod["media-src"]).toBe("'self' data:");
   });
 
   it("allows the inline styles React writes for computed values", () => {

--- a/electron/main/csp.ts
+++ b/electron/main/csp.ts
@@ -14,6 +14,10 @@
  *
  * `style-src` needs 'unsafe-inline': ten components set style={{…}} for computed values
  * (orb geometry, meter widths), and React writes those as inline style attributes.
+ *
+ * `media-src` admits data: because useSpeak plays synthesized TTS audio via
+ * `new Audio('data:audio/mp3;base64,...')` — the bytes come from the Voice API over IPC,
+ * not a network fetch, so there's no bundled asset to point a `self` src at instead.
  */
 const DIRECTIVES = [
   "default-src 'none'",
@@ -21,7 +25,7 @@ const DIRECTIVES = [
   "style-src 'self' 'unsafe-inline'",
   "font-src 'self'",
   "img-src 'self' data: https:",
-  "media-src 'self'",
+  "media-src 'self' data:",
   "connect-src 'none'",
   "base-uri 'none'",
   "form-action 'none'",


### PR DESCRIPTION
## What changed
Allows `data:` URIs in the renderer's `media-src` CSP directive so synthesized TTS audio (`new Audio('data:audio/mp3;base64,...')` in `useSpeak.ts`) can actually play, instead of being silently blocked and falling back to browser TTS on every use.

## Root cause
`media-src` was `'self'` only. TTS audio bytes come from the Voice API over IPC, not a bundled asset, so they're played via a `data:` URI — which CSP was rejecting. This surfaced as `MediaError` code 4, "Media load rejected by URL safety check" (visible thanks to the diagnostics added in #30).

## Testing
- Unit/integration: 949 passed (updated the existing `media-src` assertion in `csp.test.ts`)
- E2E: not configured
- Manual: verified via the `run-openorbit` sandbox driver (securitypolicyviolation event fires pre-fix, none post-fix) and confirmed end-to-end by the user running `npm run dev` on this branch — TTS now plays with no playback errors.

## Notes
Closes out the original silent-TTS-fallback report (#30 only added diagnostics).