### PR TITLE
S10: gather the safety controls into their own Settings section

### DIFF
--- a/src/components/organisms/HttpToolsTab.test.tsx
+++ b/src/components/organisms/HttpToolsTab.test.tsx
@@ -26,7 +26,6 @@ function collection(id: string, name: string, overrides: Partial<HttpToolCollect
 }
 
 function renderTab(collections: HttpToolCollectionRow[], overrides: Partial<HttpTools> = {}, settingsPatch = {}) {
-  const onUpdate = vi.fn();
   const httpTools: HttpTools = {
     collections,
     tools: [],
@@ -44,10 +43,13 @@ function renderTab(collections: HttpToolCollectionRow[], overrides: Partial<Http
     ...overrides,
   } as unknown as HttpTools;
   const settings = { ...DEFAULT_SETTINGS, ...settingsPatch };
-  const view = render(<HttpToolsTab httpTools={httpTools} settings={settings} onUpdate={onUpdate} />);
-  return { ...view, httpTools, onUpdate };
+  const view = render(<HttpToolsTab httpTools={httpTools} settings={settings} />);
+  return { ...view, httpTools };
 }
 
+// The approval controls moved to Settings → Privacy & Safety (finding S10); their tests
+// moved with them, to SettingsPanel.test.tsx. What stays here is the per-endpoint "Asks first"
+// badge, which is context for the tools rather than a control.
 describe("HttpToolsTab", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(cleanup);
@@ -66,40 +68,6 @@ describe("HttpToolsTab", () => {
 
   /** The write methods each get their own toggle, and reads are never gated — the hint says
    * so, and there is deliberately no GET/HEAD row to turn on. */
-  it("offers a toggle for each write method and none for reads", () => {
-    renderTab([]);
-
-    expect(screen.getByLabelText("Ask before POST requests")).toBeTruthy();
-    expect(screen.getByLabelText("Ask before PUT / PATCH requests")).toBeTruthy();
-    expect(screen.getByLabelText("Ask before DELETE requests")).toBeTruthy();
-    expect(screen.queryByLabelText(/Ask before GET/)).toBeNull();
-    expect(screen.getByText(/Reads \(GET, HEAD\) never ask/)).toBeTruthy();
-  });
-
-  it("ships with every write method gated by default", () => {
-    renderTab([]);
-    for (const label of ["Ask before POST requests", "Ask before PUT / PATCH requests", "Ask before DELETE requests"]) {
-      expect(screen.getByLabelText(label).getAttribute("aria-checked"), label).toBe("true");
-    }
-  });
-
-  it("writes each method's policy back under its own key", () => {
-    const { onUpdate } = renderTab([]);
-
-    fireEvent.click(screen.getByLabelText("Ask before DELETE requests"));
-
-    expect(onUpdate).toHaveBeenCalledWith({ httpToolApprovalDelete: false });
-  });
-
-  it("turns a policy back on independently of the others", () => {
-    const { onUpdate } = renderTab([], {}, { httpToolApprovalPost: false });
-
-    expect(screen.getByLabelText("Ask before POST requests").getAttribute("aria-checked")).toBe("false");
-    fireEvent.click(screen.getByLabelText("Ask before POST requests"));
-
-    expect(onUpdate).toHaveBeenCalledWith({ httpToolApprovalPost: true });
-  });
-
   // --- Encrypted header storage ---------------------------------------------------------
 
   /** Header values are stored encrypted on the row, so the form must fetch the decrypted set

--- a/src/components/organisms/HttpToolsTab.tsx
+++ b/src/components/organisms/HttpToolsTab.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import TablerIcon from "@/components/atoms/TablerIcon";
 import Toggle from "@/components/atoms/Toggle";
-import Combobox from "@/components/atoms/Combobox";
-import { AgentsSettings, type ToolApprovalDisplay } from "@/lib/settings";
+import { AgentsSettings } from "@/lib/settings";
 import SettingsAccordion from "@/components/molecules/SettingsAccordion";
 import DeleteConfirmModal from "@/components/molecules/DeleteConfirmModal";
 import HttpToolForm from "@/components/molecules/HttpToolForm";
@@ -20,24 +19,10 @@ import { useHttpTools } from "@/hooks/useHttpTools";
 
 interface HttpToolsTabProps {
   httpTools: ReturnType<typeof useHttpTools>;
+  /** Only read, never written: the approval controls moved to Privacy & Safety, but the
+   * per-endpoint "Asks first" badges below are genuinely context for the tools themselves. */
   settings: AgentsSettings;
-  onUpdate: (patch: Partial<AgentsSettings>) => void;
 }
-
-const APPROVAL_METHODS: {
-  key: "httpToolApprovalPost" | "httpToolApprovalPutPatch" | "httpToolApprovalDelete";
-  label: string;
-  hint: string;
-}[] = [
-  { key: "httpToolApprovalPost", label: "POST", hint: "Creating something" },
-  { key: "httpToolApprovalPutPatch", label: "PUT / PATCH", hint: "Updating something" },
-  { key: "httpToolApprovalDelete", label: "DELETE", hint: "Removing something" },
-];
-
-const DISPLAY_OPTIONS = [
-  { value: "modal", label: "Pop-up dialog" },
-  { value: "inline", label: "Card in the chat" },
-];
 
 interface CollectionDraft {
   name: string;
@@ -55,7 +40,7 @@ const EMPTY_COLLECTION_DRAFT: CollectionDraft = {
   allowPrivateHosts: false,
 };
 
-export default function HttpToolsTab({ httpTools, settings, onUpdate }: HttpToolsTabProps) {
+export default function HttpToolsTab({ httpTools, settings }: HttpToolsTabProps) {
   const approvalPolicy = {
     post: settings.httpToolApprovalPost,
     putPatch: settings.httpToolApprovalPutPatch,
@@ -292,44 +277,15 @@ export default function HttpToolsTab({ httpTools, settings, onUpdate }: HttpTool
         they aren't available to every agent by default.
       </p>
 
-      {/* One global posture rather than a switch on every endpoint: "ask before anything is
-          deleted" is a decision about how you want to work, not a property of one URL. */}
-      <div className="group">
-        <div className="group-label">
-          <span>Approval</span>
-        </div>
-        <p className="group-hint">
-          Pause and ask before a request runs. Applies to every API below. Reads (GET, HEAD) never ask.
-        </p>
-        <div className="card">
-          {APPROVAL_METHODS.map(({ key, label, hint }) => (
-            <div className="row" key={key}>
-              <span className="row-label">
-                {label}
-                <small>{hint}</small>
-              </span>
-              <Toggle
-                checked={settings[key]}
-                onChange={(checked) => onUpdate({ [key]: checked })}
-                label={`Ask before ${label} requests`}
-              />
-            </div>
-          ))}
-          <div className="row">
-            <span className="row-label">
-              Ask me with
-              <small>A pop-up is harder to miss; a card keeps the orbit view clear</small>
-            </span>
-            <Combobox
-              value={settings.toolApprovalDisplay}
-              options={DISPLAY_OPTIONS}
-              onChange={(value) => onUpdate({ toolApprovalDisplay: value as ToolApprovalDisplay })}
-              ariaLabel="How to ask for approval"
-              size="sm"
-            />
-          </div>
-        </div>
-      </div>
+      {/* The approval controls themselves live in Settings → Privacy & Safety, with the other
+          decisions about what this app does without asking. They used to sit here, which meant
+          the app's whole "ask before writing" posture was only findable by opening a tab that
+          reads as "configure my own API endpoints" (finding S10). The badges below still show
+          which endpoints will pause, because that is genuinely context for the tools. */}
+      <p className="group-hint">
+        Requests marked <strong>Asks first</strong> pause for your approval. Change what pauses in
+        Settings → Privacy &amp; Safety. Reads (GET, HEAD) never ask.
+      </p>
 
       {addingCollection && <div className="agent-accordion-body http-collection-form">{collectionForm(null)}</div>}
 

--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -174,3 +174,92 @@ describe("orchestrator prompt override", () => {
     expect(resetButton()).toBeUndefined();
   });
 });
+
+describe("Privacy & Safety", () => {
+  // These six decide what the app does without asking, and what it can see. They used to be
+  // split between the HTTP Tools tab and General, so nobody auditing that had one place to look
+  // (finding S10). The approval tests below moved here from HttpToolsTab.test.tsx with the
+  // controls themselves.
+  function renderSafety(settingsPatch: Record<string, unknown> = {}) {
+    const onUpdate = vi.fn();
+    render(
+      <SettingsPanel
+        open
+        onClose={vi.fn()}
+        settings={mergeWithDefaults(settingsPatch)}
+        sessionElapsedMs={0}
+        onUpdate={onUpdate}
+        onReset={vi.fn()}
+        agents={[]}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /Privacy & Safety/i }));
+    return { onUpdate };
+  }
+
+  it("is reachable from the sidebar under its own name", () => {
+    renderSafety();
+    expect(screen.getByRole("tab", { name: /Privacy & Safety/i })).toBeInTheDocument();
+  });
+
+  it("gathers all six controls in one place", () => {
+    renderSafety();
+    for (const label of [
+      "Ask before POST requests",
+      "Ask before PUT / PATCH requests",
+      "Ask before DELETE requests",
+      "How to ask for approval",
+      "Toggle location access",
+      "Toggle automatic remote image loading",
+    ]) {
+      expect(screen.getByLabelText(label), label).toBeTruthy();
+    }
+  });
+
+  it("offers a toggle for each write method and none for reads", () => {
+    renderSafety();
+    expect(screen.queryByLabelText(/Ask before GET/)).toBeNull();
+    expect(screen.getByText(/Reads \(GET, HEAD\) never ask/)).toBeTruthy();
+  });
+
+  it("ships with every write method gated by default", () => {
+    renderSafety();
+    for (const label of ["Ask before POST requests", "Ask before PUT / PATCH requests", "Ask before DELETE requests"]) {
+      expect(screen.getByLabelText(label).getAttribute("aria-checked"), label).toBe("true");
+    }
+  });
+
+  it("writes each method's policy back under its own key", () => {
+    const { onUpdate } = renderSafety();
+    fireEvent.click(screen.getByLabelText("Ask before DELETE requests"));
+    expect(onUpdate).toHaveBeenCalledWith({ httpToolApprovalDelete: false });
+  });
+
+  it("turns a policy back on independently of the others", () => {
+    const { onUpdate } = renderSafety({ httpToolApprovalPost: false });
+    expect(screen.getByLabelText("Ask before POST requests").getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(screen.getByLabelText("Ask before POST requests"));
+    expect(onUpdate).toHaveBeenCalledWith({ httpToolApprovalPost: true });
+  });
+
+  it("keeps the two privacy defaults off", () => {
+    // The default is the security control for both — an install that has never heard of them
+    // must not be read as consent.
+    renderSafety();
+    expect(screen.getByLabelText("Toggle location access").getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByLabelText("Toggle automatic remote image loading").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("no longer leaves them in General", () => {
+    renderSafety();
+    fireEvent.click(screen.getByRole("tab", { name: /^General$/i }));
+    expect(screen.queryByLabelText("Toggle location access")).toBeNull();
+    expect(screen.queryByLabelText("Ask before DELETE requests")).toBeNull();
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -14,7 +14,7 @@ import ConnectorsTab from "@/components/organisms/ConnectorsTab";
 import HttpToolsTab from "@/components/organisms/HttpToolsTab";
 import AboutTab from "@/components/organisms/AboutTab";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
-import { DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
+import { ToolApprovalDisplay, DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { hasAgentsAPI } from "@/lib/agentsApi";
 import { useMcpServers } from "@/hooks/useMcpServers";
@@ -72,6 +72,7 @@ export type SettingsSection =
   | "http"
   | "files"
   | "general"
+  | "safety"
   | "sounds"
   | "danger"
   | "about";
@@ -91,6 +92,7 @@ const NAV_GROUPS: SettingsNavGroup[] = [
     label: "App",
     items: [
       { id: "general", label: "General", icon: "ti-adjustments" },
+      { id: "safety", label: "Privacy & Safety", icon: "ti-shield-lock" },
       { id: "sounds", label: "App Sounds", icon: "ti-volume" },
       { id: "files", label: "Knowledge", icon: "ti-books" },
       { id: "about", label: "About", icon: "ti-info-circle" },
@@ -112,6 +114,13 @@ const SECTION_META: Record<SettingsSection, { icon: string; title: string; subti
   // list in tourSteps.test.ts and by any tour step's settingsSection, so only the label changes.
   files: { icon: "ti-books", title: "Knowledge", subtitle: "Folders and documents agents can read" },
   general: { icon: "ti-adjustments", title: "General", subtitle: "Voice, sound, and input preferences" },
+  // Gathered from three different screens. What this app will do without asking was previously
+  // split between the HTTP Tools tab and General, so nobody auditing it had one place to look.
+  safety: {
+    icon: "ti-shield-lock",
+    title: "Privacy & Safety",
+    subtitle: "What Orbit does without asking, and what it can see",
+  },
   sounds: { icon: "ti-volume", title: "App Sounds", subtitle: "Pick a variation for each sound effect" },
   danger: { icon: "ti-alert-triangle", title: "Danger Zone", subtitle: "Irreversible actions" },
   about: { icon: "ti-info-circle", title: "About", subtitle: "Version, storage, and licenses" },
@@ -171,6 +180,21 @@ const SOUND_VARIANT_OPTIONS = Array.from({ length: SOUND_FX_VARIANT_COUNT }, (_,
   value: String(i + 1),
   label: `Variant ${i + 1}`,
 }));
+
+const APPROVAL_METHODS: {
+  key: "httpToolApprovalPost" | "httpToolApprovalPutPatch" | "httpToolApprovalDelete";
+  label: string;
+  hint: string;
+}[] = [
+  { key: "httpToolApprovalPost", label: "POST", hint: "Creating something" },
+  { key: "httpToolApprovalPutPatch", label: "PUT / PATCH", hint: "Updating something" },
+  { key: "httpToolApprovalDelete", label: "DELETE", hint: "Removing something" },
+];
+
+const APPROVAL_DISPLAY_OPTIONS = [
+  { value: "modal", label: "Pop-up dialog" },
+  { value: "inline", label: "Card in the chat" },
+];
 
 const RESET_CONFIRM_WORD = "RESET";
 
@@ -626,7 +650,7 @@ export default function SettingsPanel({
 
             {activeSection === "http" && (
               <ErrorBoundary fallbackTitle="HTTP tools failed to load">
-                <HttpToolsTab httpTools={httpTools} settings={settings} onUpdate={onUpdate} />
+                <HttpToolsTab httpTools={httpTools} settings={settings} />
               </ErrorBoundary>
             )}
 
@@ -744,30 +768,6 @@ export default function SettingsPanel({
                       label="Toggle type-anywhere focus"
                     />
                   </div>
-                  <div className="row">
-                    <span className="row-label">
-                      Location access<small>Let agents look up where you are</small>
-                    </span>
-                    <Toggle
-                      checked={settings.locationEnabled}
-                      onChange={(checked) => onUpdate({ locationEnabled: checked })}
-                      label="Toggle location access"
-                    />
-                  </div>
-                  <div className="row">
-                    <span className="row-label">
-                      Load remote images automatically
-                      <small>
-                        Off is safer: a reply can be steered by a web page or email it read, and an
-                        image that loads on sight sends a request before you have read it
-                      </small>
-                    </span>
-                    <Toggle
-                      checked={settings.remoteImagesAutoLoad}
-                      onChange={(checked) => onUpdate({ remoteImagesAutoLoad: checked })}
-                      label="Toggle automatic remote image loading"
-                    />
-                  </div>
                 </div>
 
                 <div className="card">
@@ -810,6 +810,83 @@ export default function SettingsPanel({
                       }}
                     />
                   </label>
+                </div>
+              </div>
+            )}
+
+
+            {activeSection === "safety" && (
+              <div className="group">
+                <div className="group-label">
+                  <span>Approval</span>
+                </div>
+                {/* One global posture rather than a switch on every endpoint: "ask before
+                    anything is deleted" is a decision about how you want to work, not a property
+                    of one URL. */}
+                <p className="group-hint">
+                  Pause and ask before an HTTP tool sends a request. Reads (GET, HEAD) never ask.
+                </p>
+                <div className="card">
+                  {APPROVAL_METHODS.map(({ key, label, hint }) => (
+                    <div className="row" key={key}>
+                      <span className="row-label">
+                        {label}
+                        <small>{hint}</small>
+                      </span>
+                      <Toggle
+                        checked={settings[key]}
+                        onChange={(checked) => onUpdate({ [key]: checked })}
+                        label={`Ask before ${label} requests`}
+                      />
+                    </div>
+                  ))}
+                  <div className="row">
+                    <span className="row-label">
+                      Ask me with
+                      <small>A pop-up is harder to miss; a card keeps the orbit view clear</small>
+                    </span>
+                    <Combobox
+                      value={settings.toolApprovalDisplay}
+                      options={APPROVAL_DISPLAY_OPTIONS}
+                      onChange={(value) => onUpdate({ toolApprovalDisplay: value as ToolApprovalDisplay })}
+                      ariaLabel="How to ask for approval"
+                      size="sm"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeSection === "safety" && (
+              <div className="group">
+                <div className="group-label">
+                  <span>What Orbit can see</span>
+                </div>
+                <div className="card">
+                  <div className="row">
+                    <span className="row-label">
+                      Location access<small>Let agents look up where you are</small>
+                    </span>
+                    <Toggle
+                      checked={settings.locationEnabled}
+                      onChange={(checked) => onUpdate({ locationEnabled: checked })}
+                      label="Toggle location access"
+                    />
+                  </div>
+                  <div className="row">
+                    <span className="row-label">
+                      Load remote images automatically
+                      <small>
+                        Off is safer: a reply can be steered by a web page or email it read, and an
+                        image that loads on sight sends a request before you have read it
+                      </small>
+                    </span>
+                    <Toggle
+                      checked={settings.remoteImagesAutoLoad}
+                      onChange={(checked) => onUpdate({ remoteImagesAutoLoad: checked })}
+                      label="Toggle automatic remote image loading"
+                    />
+                  </div>
                 </div>
               </div>
             )}

--- a/src/lib/tourSteps.test.ts
+++ b/src/lib/tourSteps.test.ts
@@ -10,6 +10,7 @@ const SETTINGS_SECTIONS = [
   "http",
   "files",
   "general",
+  "safety",
   "sounds",
   "danger",
   "about",


### PR DESCRIPTION
Closes **S10**, and makes HTTP Tools consistently accordion-based as requested.

## The problem

What this app will do **without asking** was split across two screens:

| control | lived in |
|---|---|
| `httpToolApprovalPost` / `PutPatch` / `Delete` | HTTP Tools tab |
| `toolApprovalDisplay` | HTTP Tools tab |
| `locationEnabled` | General |
| `remoteImagesAutoLoad` | General |

Someone auditing what the app does to their data had no single place to look — and no reason to open a tab that reads as *"configure my own API endpoints"*.

## What changed

All six now sit under **Settings → Privacy & Safety**, in two groups: *Approval*, and *What Orbit can see*. Named for what it is, so it can be found by looking rather than by already knowing.

**HTTP Tools keeps the per-endpoint "Asks first" badges** — those are context for the tools, not a control — and gains a line saying where the policy lives. With the approval block gone it's now **entirely collection accordions**, consistent with the MCP Servers and Connectors tabs.

`HttpToolsTab` no longer takes `onUpdate` at all; it only reads `settings` now.

## The two requests resolved together

They initially pulled against each other — S10 wants these controls *more* visible, and an accordion would have collapsed them. Moving them out settles both: HTTP Tools becomes purely accordions, and the controls land somewhere named for their purpose rather than being hidden behind a chevron.

## Tests moved, not deleted

The four approval tests went to `SettingsPanel.test.tsx` **with the controls**, so coverage follows behaviour rather than disappearing with the markup. `HttpToolsTab.test.tsx` carries a note saying where they went.

+8 net: the four relocated, plus the section being reachable by name, all six controls present in one place, both privacy defaults still off, and General no longer offering either.

`tourSteps.test.ts`'s hardcoded section list gains `"safety"` — it asserts every step's `settingsSection` is real, so a new section has to be declared there too.

## Validated in the app

Sidebar reads:

```
Models · Agents · MCP Servers · Connectors · HTTP Tools
General · Privacy & Safety · App Sounds · Knowledge · About
Danger Zone
```

Opening it shows all five toggles plus the display combobox in one place; HTTP Tools reports **zero** switches remaining and renders the pointer line. Screenshots checked for both.

One iteration came from looking: the two sub-groups were initially inside a single `.group`, which made them read as one merged card. Split into two, matching the rhythm used elsewhere.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **964 passed / 99 files** (960 before) |
| E2E | – not configured |

## Note

Nothing about the *policy* changed — same defaults, same keys, same enforcement. This is purely where the controls live. The agent still can't write any of them (S11, S20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
