### PR TITLE
X10: validate the tasks IPC input

### DIFF
--- a/electron/main/ipc/tasks.test.ts
+++ b/electron/main/ipc/tasks.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrations";
+
+let db: Database.Database;
+
+vi.mock("electron", () => ({ ipcMain: { handle: vi.fn() } }));
+vi.mock("../db", () => ({ getDb: () => db }));
+vi.mock("../db/index", () => ({ getDb: () => db }));
+
+import { ipcMain } from "electron";
+import { registerTaskHandlers } from "./tasks";
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+function handlerFor(channel: string): Handler {
+  registerTaskHandlers();
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((c) => c[0] === channel);
+  if (!call) throw new Error(`${channel} was never registered`);
+  return call[1] as Handler;
+}
+
+const create = (input: unknown) => handlerFor("tasks:create")(null, input);
+const update = (id: unknown, patch: unknown) => handlerFor("tasks:update")(null, id, patch);
+
+describe("tasks IPC input validation", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    runMigrations(db);
+    // tasks.prompt_target_agent_id is a real foreign key, and migrations don't seed agents.
+    db.prepare(
+      "INSERT INTO agents (id, name, prompt, model) VALUES ('explorerAgent', 'Explorer', 'p', 'gpt-4.1-mini')"
+    ).run();
+    vi.mocked(ipcMain.handle).mockClear();
+  });
+
+  describe("tasks:create", () => {
+    it("creates a task from a valid input", () => {
+      const row = create({ title: "Water the plants" }) as { title: string };
+      expect(row.title).toBe("Water the plants");
+    });
+
+    it("accepts every optional field", () => {
+      expect(() =>
+        create({
+          title: "Weekly digest",
+          notes: "n",
+          dueAt: "2026-08-03T09:00:00Z",
+          prompt: "Summarise the week",
+          promptTargetAgentId: "explorerAgent",
+          recurrenceIntervalMs: 604800000,
+          recurrenceParams: { tone: "brief" },
+        })
+      ).not.toThrow();
+    });
+
+    it("refuses input that isn't a plain object", () => {
+      for (const bad of [null, "task", 42, ["title"]]) {
+        expect(() => create(bad), String(bad)).toThrow("plain object");
+      }
+    });
+
+    it("refuses a missing or blank title", () => {
+      expect(() => create({})).toThrow("non-empty title");
+      expect(() => create({ title: "   " })).toThrow("non-empty title");
+      expect(() => create({ title: 42 })).toThrow("non-empty title");
+    });
+
+    it("refuses a non-string where a string belongs", () => {
+      expect(() => create({ title: "t", notes: 42 })).toThrow("notes must be a string");
+      expect(() => create({ title: "t", prompt: {} })).toThrow("prompt must be a string");
+    });
+
+    it("refuses a recurrence interval that could never work", () => {
+      // It becomes a scheduler delay: zero or negative either never fires or fires continuously.
+      for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, "3600000"]) {
+        expect(() => create({ title: "t", recurrenceIntervalMs: bad }), String(bad)).toThrow(
+          "recurrenceIntervalMs must be a positive number"
+        );
+      }
+    });
+
+    it("refuses recurrence params that aren't a flat string map", () => {
+      // They are rendered into the task's prompt, so a nested value would reach the model as
+      // "[object Object]".
+      expect(() => create({ title: "t", recurrenceParams: "tone=brief" })).toThrow("plain object");
+      expect(() => create({ title: "t", recurrenceParams: { tone: { a: 1 } } })).toThrow("values must be strings");
+    });
+  });
+
+  describe("tasks:update", () => {
+    function existingId(): string {
+      return (create({ title: "Original" }) as { id: string }).id;
+    }
+
+    it("applies a valid patch", () => {
+      const id = existingId();
+      expect((update(id, { title: "Renamed" }) as { title: string }).title).toBe("Renamed");
+    });
+
+    it("refuses a missing or blank id", () => {
+      for (const bad of [undefined, "", "  ", 42, null]) {
+        expect(() => update(bad, { title: "x" }), String(bad)).toThrow("non-empty task id");
+      }
+    });
+
+    it("refuses a patch that isn't a plain object", () => {
+      expect(() => update(existingId(), null)).toThrow("plain object patch");
+      expect(() => update(existingId(), ["title"])).toThrow("plain object patch");
+    });
+
+    it("refuses an explicitly blank title", () => {
+      // Absent means "unchanged"; blank would leave the task unnamed in every list showing it.
+      expect(() => update(existingId(), { title: "" })).toThrow("title cannot be empty");
+    });
+
+    it("refuses a status outside the three the store knows", () => {
+      expect(() => update(existingId(), { status: "finished" })).toThrow("status must be one of");
+      expect(() => update(existingId(), { status: 1 })).toThrow("status must be one of");
+    });
+
+    it("accepts each real status", () => {
+      for (const status of ["pending", "done", "cancelled"]) {
+        expect(() => update(existingId(), { status }), status).not.toThrow();
+      }
+    });
+  });
+
+  describe("tasks:complete and tasks:delete", () => {
+    it("refuse a missing or blank id", () => {
+      for (const channel of ["tasks:complete", "tasks:delete"]) {
+        for (const bad of [undefined, "", 42]) {
+          expect(() => handlerFor(channel)(null, bad), `${channel} ${bad}`).toThrow("non-empty task id");
+        }
+      }
+    });
+
+    it("still do their job with a real id", () => {
+      const id = (create({ title: "Done soon" }) as { id: string }).id;
+      expect((handlerFor("tasks:complete")(null, id) as { status: string }).status).toBe("done");
+      expect(() => handlerFor("tasks:delete")(null, id)).not.toThrow();
+    });
+  });
+});

--- a/electron/main/ipc/tasks.ts
+++ b/electron/main/ipc/tasks.ts
@@ -3,14 +3,91 @@ import { createTask, deleteTask, listTasks, TaskCreateInput, TaskRow, TaskUpdate
 
 export type { TaskRow, TaskCreateInput, TaskUpdatePatch } from "../db/tasksStore";
 
+/**
+ * These handlers used to pass their arguments straight to the store, with the parameter types
+ * standing in for a check they never performed. Every other write surface in ipc/ asserts its
+ * input — mcp, httpTools, connectors, knowledgeBase, filesystem and agentData all do — and tasks
+ * was the last one that didn't. Tasks aren't inert either: tasks/scheduler.ts reads them back and
+ * runs their prompts.
+ *
+ * Same shape as the assertions in ipc/httpTools.ts, deliberately, so there is one idiom here.
+ */
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(message);
+  }
+}
+
+function assertPlainObject(value: unknown, message: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(message);
+  }
+}
+
+const STRING_FIELDS = ["title", "notes", "dueAt", "prompt", "promptTargetAgentId"] as const;
+const TASK_STATUSES = ["pending", "done", "cancelled"];
+
+/** Checks the fields create and update share. Absent is always fine — a patch names only what it
+ * changes, and create's other fields are genuinely optional. */
+function assertTaskFields(input: Record<string, unknown>, prefix: string): void {
+  for (const field of STRING_FIELDS) {
+    const value = input[field];
+    if (value !== undefined && typeof value !== "string") {
+      throw new Error(`${prefix}: ${field} must be a string`);
+    }
+  }
+
+  if (input.status !== undefined && (typeof input.status !== "string" || !TASK_STATUSES.includes(input.status))) {
+    throw new Error(`${prefix}: status must be one of ${TASK_STATUSES.join(", ")}`);
+  }
+
+  const interval = input.recurrenceIntervalMs;
+  if (interval !== undefined) {
+    // A recurring task's interval becomes a scheduler delay. Zero, negative or NaN would either
+    // never fire or fire continuously, and neither failure says why.
+    if (typeof interval !== "number" || !Number.isFinite(interval) || interval <= 0) {
+      throw new Error(`${prefix}: recurrenceIntervalMs must be a positive number`);
+    }
+  }
+
+  const params = input.recurrenceParams;
+  if (params !== undefined) {
+    assertPlainObject(params, `${prefix}: recurrenceParams must be a plain object`);
+    for (const value of Object.values(params)) {
+      // Stored as JSON and rendered into the task's prompt by scheduler.ts, so a non-string
+      // would reach the model as "[object Object]".
+      if (typeof value !== "string") throw new Error(`${prefix}: recurrenceParams values must be strings`);
+    }
+  }
+}
+
 export function registerTaskHandlers() {
   ipcMain.handle("tasks:list", (): TaskRow[] => listTasks());
 
-  ipcMain.handle("tasks:create", (_event, input: TaskCreateInput): TaskRow => createTask(input));
+  ipcMain.handle("tasks:create", (_event, input: unknown): TaskRow => {
+    assertPlainObject(input, "tasks:create requires a plain object input");
+    assertNonEmptyString(input.title, "tasks:create requires a non-empty title");
+    assertTaskFields(input, "tasks:create");
+    return createTask(input as unknown as TaskCreateInput);
+  });
 
-  ipcMain.handle("tasks:update", (_event, id: string, patch: TaskUpdatePatch): TaskRow => updateTask(id, patch));
+  ipcMain.handle("tasks:update", (_event, id: unknown, patch: unknown): TaskRow => {
+    assertNonEmptyString(id, "tasks:update requires a non-empty task id");
+    assertPlainObject(patch, "tasks:update requires a plain object patch");
+    // Title is optional in a patch, but an explicitly blank one would leave the task unnamed in
+    // every list that shows it.
+    if (patch.title !== undefined) assertNonEmptyString(patch.title, "tasks:update title cannot be empty");
+    assertTaskFields(patch, "tasks:update");
+    return updateTask(id, patch as unknown as TaskUpdatePatch);
+  });
 
-  ipcMain.handle("tasks:complete", (_event, id: string): TaskRow => updateTask(id, { status: "done" }));
+  ipcMain.handle("tasks:complete", (_event, id: unknown): TaskRow => {
+    assertNonEmptyString(id, "tasks:complete requires a non-empty task id");
+    return updateTask(id, { status: "done" });
+  });
 
-  ipcMain.handle("tasks:delete", (_event, id: string): void => deleteTask(id));
+  ipcMain.handle("tasks:delete", (_event, id: unknown): void => {
+    assertNonEmptyString(id, "tasks:delete requires a non-empty task id");
+    deleteTask(id);
+  });
 }


### PR DESCRIPTION
Closes **X10**.

## Root cause

The five `tasks:*` handlers passed their arguments straight to the store:

```ts
ipcMain.handle("tasks:create", (_event, input: TaskCreateInput): TaskRow => createTask(input));
ipcMain.handle("tasks:update", (_event, id: string, patch: TaskUpdatePatch): TaskRow => updateTask(id, patch));
```

The parameter types are assertions, not checks. **Every other write surface in `ipc/` guards its input** — `mcp`, `httpTools`, `connectors`, `knowledgeBase`, `filesystem` and `agentData` all do. This was the last one that didn't.

And tasks aren't inert: `tasks/scheduler.ts` reads them back and runs their prompts.

## What the guards catch

- **`recurrenceIntervalMs` of 0, negative, `NaN` or `Infinity`** — it becomes a scheduler delay, so it either never fires or fires continuously, and neither failure says why.
- **Non-string `recurrenceParams` values** — they're rendered into the task's prompt, so a nested object reaches the model as `[object Object]`.
- **A `status` outside the three the store knows.**
- **An explicitly blank title on update** — absent means "unchanged", blank would leave the task unnamed in every list showing it.

Same assertion idiom as `ipc/httpTools.ts`, so there's one shape for this in the codebase rather than two.

## Reproduced after fix

New tests against the pre-fix handlers: **10 failed / 5 passed**. Restored: **15/15**.

## Tests

+15 — the first this surface has had. Note for anyone extending them: `tasks.prompt_target_agent_id` is a real foreign key and migrations don't seed agents, so a test touching that field has to insert one.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **979 passed / 100 files** (964 before — +15) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)