### PR TITLE
S3/S4/S5/S2: make the numeric settings enforce the range they advertise

### DIFF
--- a/src/components/molecules/NumberField.test.tsx
+++ b/src/components/molecules/NumberField.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import NumberField from "./NumberField";
+import { SETTING_BOUNDS, type NumericBound } from "@/lib/settings";
+
+// vitest runs with globals: false, so RTL cannot register its own cleanup.
+afterEach(cleanup);
+
+function setup(bound: NumericBound = SETTING_BOUNDS.agentRunTimeoutSeconds, value = 60) {
+  const onCommit = vi.fn();
+  const { container, rerender } = render(
+    <NumberField label="Agent run timeout (seconds)" value={value} bound={bound} onCommit={onCommit} />
+  );
+  const input = container.querySelector("input");
+  if (!input) throw new Error("no input rendered");
+  return { onCommit, input, rerender };
+}
+
+const type = (input: HTMLInputElement, value: string) => fireEvent.change(input, { target: { value } });
+
+describe("NumberField", () => {
+  it("commits a valid value on blur", () => {
+    const { onCommit, input } = setup();
+    type(input, "120");
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith(120);
+  });
+
+  it("commits on Enter too", () => {
+    const { onCommit, input } = setup();
+    type(input, "120");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenCalledWith(120);
+  });
+
+  it("does not commit an unchanged value", () => {
+    const { onCommit, input } = setup();
+    fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  describe("the range it advertises is the range it enforces", () => {
+    it("refuses a value below the floor, and says why", () => {
+      // `min` on a number input binds the spinner only. A 1-second agent timeout and a 1 ms
+      // system-stats poll were both reachable by typing.
+      const { onCommit, input } = setup();
+      type(input, "1");
+      fireEvent.blur(input);
+      expect(onCommit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Must be between 5–3600/)).toBeInTheDocument();
+    });
+
+    it("refuses a value above the ceiling", () => {
+      const { onCommit, input } = setup();
+      type(input, "600000");
+      fireEvent.blur(input);
+      expect(onCommit).not.toHaveBeenCalled();
+      expect(screen.getByText(/Must be between 5–3600/)).toBeInTheDocument();
+    });
+
+    it("accepts values sitting exactly on each bound", () => {
+      const { onCommit, input } = setup();
+      type(input, "5");
+      fireEvent.blur(input);
+      type(input, "3600");
+      fireEvent.blur(input);
+      expect(onCommit).toHaveBeenNthCalledWith(1, 5);
+      expect(onCommit).toHaveBeenNthCalledWith(2, 3600);
+    });
+
+    it("refuses a fraction where only whole numbers make sense", () => {
+      const { onCommit, input } = setup();
+      type(input, "1.5");
+      fireEvent.blur(input);
+      expect(onCommit).not.toHaveBeenCalled();
+      expect(screen.getByText(/whole number/i)).toBeInTheDocument();
+    });
+
+    it("allows a fraction where the setting is fractional", () => {
+      const { onCommit, input } = setup(SETTING_BOUNDS.bgMusicVolume, 0.1);
+      type(input, "0.35");
+      fireEvent.blur(input);
+      expect(onCommit).toHaveBeenCalledWith(0.35);
+    });
+
+    it("advertises the real range on the input itself", () => {
+      const { input } = setup();
+      expect(input.getAttribute("min")).toBe("5");
+      expect(input.getAttribute("max")).toBe("3600");
+    });
+  });
+
+  describe("clearing the box", () => {
+    it("restores the stored value rather than committing zero", () => {
+      // Number("") is 0, which the old guard rejected — so the field snapped back mid-edit and
+      // the number could not be changed by deleting first. For bgMusicVolume 0 is legal, so the
+      // same coercion silently muted the music instead.
+      const { onCommit, input } = setup();
+      type(input, "");
+      fireEvent.blur(input);
+      expect(onCommit).not.toHaveBeenCalled();
+      expect(input.value).toBe("60");
+    });
+
+    it("does not mute the music when the volume box is cleared", () => {
+      const { onCommit, input } = setup(SETTING_BOUNDS.bgMusicVolume, 0.1);
+      type(input, "");
+      fireEvent.blur(input);
+      expect(onCommit).not.toHaveBeenCalled();
+      expect(input.value).toBe("0.1");
+    });
+
+    it("lets a value be deleted and retyped, which it previously could not be", () => {
+      const { onCommit, input } = setup();
+      type(input, "");
+      type(input, "9");
+      type(input, "90");
+      fireEvent.blur(input);
+      expect(onCommit).toHaveBeenCalledExactlyOnceWith(90);
+    });
+  });
+
+  describe("recovering from a rejection", () => {
+    it("clears the error as soon as the user types again", () => {
+      const { input } = setup();
+      type(input, "1");
+      fireEvent.blur(input);
+      expect(screen.getByText(/Must be between/)).toBeInTheDocument();
+      type(input, "10");
+      expect(screen.queryByText(/Must be between/)).not.toBeInTheDocument();
+    });
+
+    it("keeps the rejected text on screen so it can be corrected", () => {
+      // Snapping straight back was the old behaviour, and it lost what the user had typed.
+      const { input } = setup();
+      type(input, "1");
+      fireEvent.blur(input);
+      expect(input.value).toBe("1");
+    });
+  });
+
+  it("follows the stored value when it changes underneath", () => {
+    const { input, rerender } = setup();
+    rerender(
+      <NumberField
+        label="Agent run timeout (seconds)"
+        value={300}
+        bound={SETTING_BOUNDS.agentRunTimeoutSeconds}
+        onCommit={vi.fn()}
+      />
+    );
+    expect(input.value).toBe("300");
+  });
+});

--- a/src/components/molecules/NumberField.tsx
+++ b/src/components/molecules/NumberField.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { NumericBound } from "@/lib/settings";
+
+interface NumberFieldProps {
+  label: string;
+  hint?: string;
+  value: number;
+  bound: NumericBound;
+  onCommit: (value: number) => void;
+}
+
+/**
+ * A numeric setting input that enforces the range it advertises.
+ *
+ * `min` on a number input constrains the spinner and nothing else — typed and pasted values sail
+ * straight past it. Every numeric setting here relied on that, backed only by a `value > 0` guard,
+ * which is how a 1 ms system-stats poll interval and a 1-second agent timeout were reachable
+ * (findings S2, S3, S4).
+ *
+ * The draft is local so the box can be cleared and retyped. Bound directly to the stored value it
+ * could not be: clearing gives `Number("") === 0`, which the old guard rejected, so the field
+ * snapped back to its previous value mid-edit and the number could not be changed by deleting
+ * first. The same coercion silently muted background music, because 0 is a legal volume (S5).
+ *
+ * A rejected value now says why. The write boundary refuses out-of-range values since the
+ * settings schema landed, but the refusal was invisible — the field just reverted with no
+ * explanation, which is the tail S2 was reduced to.
+ */
+export default function NumberField({ label, hint, value, bound, onCommit }: NumberFieldProps) {
+  const [draft, setDraft] = useState(String(value));
+  const [error, setError] = useState<string | null>(null);
+
+  // Follow the stored value when it changes underneath us — a Danger Zone reset, or an agent
+  // writing it mid-run — but not while the user is mid-edit, which is what a pending error means.
+  // Adjusted during render rather than in an effect: React documents this as the way to react to
+  // a changed prop, SettingsPanel already does it for its section state, and the effect form is
+  // rejected by react-hooks/set-state-in-effect.
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    if (error === null) setDraft(String(value));
+  }
+
+  const rangeText = `${bound.min}–${bound.max}`;
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) {
+      // Empty means "I deleted it to retype", not "set this to zero".
+      setDraft(String(value));
+      setError(null);
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) return setError(`Must be a number between ${rangeText}`);
+    if (bound.integer && !Number.isInteger(parsed)) return setError("Must be a whole number");
+    if (parsed < bound.min || parsed > bound.max) return setError(`Must be between ${rangeText}`);
+    setError(null);
+    setDraft(String(parsed));
+    if (parsed !== value) onCommit(parsed);
+  };
+
+  return (
+    <label className="row-field">
+      <span>
+        {label}
+        {hint && <small>{hint}</small>}
+      </span>
+      <input
+        type="number"
+        min={bound.min}
+        max={bound.max}
+        step={bound.integer ? 1 : 0.05}
+        value={draft}
+        aria-label={label}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          setError(null);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          }
+        }}
+      />
+      {error && <p className="settings-error">{error}</p>}
+    </label>
+  );
+}

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -8,13 +8,14 @@ import AgentAccordion from "@/components/molecules/AgentAccordion";
 import SettingsAccordion from "@/components/molecules/SettingsAccordion";
 import AddAgentForm from "@/components/molecules/AddAgentForm";
 import ApiKeyField from "@/components/molecules/ApiKeyField";
+import NumberField from "@/components/molecules/NumberField";
 import FilesAppsTab from "@/components/organisms/FilesAppsTab";
 import McpServersTab from "@/components/organisms/McpServersTab";
 import ConnectorsTab from "@/components/organisms/ConnectorsTab";
 import HttpToolsTab from "@/components/organisms/HttpToolsTab";
 import AboutTab from "@/components/organisms/AboutTab";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
-import { ToolApprovalDisplay, DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
+import { SETTING_BOUNDS, ToolApprovalDisplay, DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { hasAgentsAPI } from "@/lib/agentsApi";
 import { useMcpServers } from "@/hooks/useMcpServers";
@@ -745,20 +746,12 @@ export default function SettingsPanel({
                     />
                   </div>
                   {settings.bgMusicEnabled && (
-                    <label className="row-field">
-                      <span>Background music volume</span>
-                      <input
-                        type="number"
-                        min={0}
-                        max={1}
-                        step={0.05}
-                        value={settings.bgMusicVolume}
-                        onChange={(e) => {
-                          const value = Number(e.target.value);
-                          if (!Number.isNaN(value)) onUpdate({ bgMusicVolume: Math.min(1, Math.max(0, value)) });
-                        }}
-                      />
-                    </label>
+                    <NumberField
+                      label="Background music volume"
+                      value={settings.bgMusicVolume}
+                      bound={SETTING_BOUNDS.bgMusicVolume}
+                      onCommit={(bgMusicVolume) => onUpdate({ bgMusicVolume })}
+                    />
                   )}
                   <div className="row">
                     <span className="row-label">Type anywhere to focus chat</span>
@@ -771,45 +764,26 @@ export default function SettingsPanel({
                 </div>
 
                 <div className="card">
-                  <label className="row-field">
-                    <span>Agent run timeout (seconds)</span>
-                    <input
-                      type="number"
-                      min={5}
-                      value={settings.agentRunTimeoutSeconds}
-                      onChange={(e) => {
-                        const value = Number(e.target.value);
-                        if (!Number.isNaN(value) && value > 0) onUpdate({ agentRunTimeoutSeconds: value });
-                      }}
-                    />
-                  </label>
-                  <label className="row-field">
-                    <span>Chat history sent to the orchestrator (messages)</span>
-                    <input
-                      type="number"
-                      min={1}
-                      value={settings.chatHistoryMessageLimit}
-                      onChange={(e) => {
-                        const value = Number(e.target.value);
-                        if (!Number.isNaN(value) && value > 0) onUpdate({ chatHistoryMessageLimit: value });
-                      }}
-                    />
-                  </label>
-                  <label className="row-field">
-                    <span>
-                      System Status refresh interval (ms)<small>Applies after restarting the app</small>
-                    </span>
-                    <input
-                      type="number"
-                      min={500}
-                      step={500}
-                      value={settings.systemStatsPollIntervalMs}
-                      onChange={(e) => {
-                        const value = Number(e.target.value);
-                        if (!Number.isNaN(value) && value > 0) onUpdate({ systemStatsPollIntervalMs: value });
-                      }}
-                    />
-                  </label>
+                  <NumberField
+                    label="Agent run timeout (seconds)"
+                    value={settings.agentRunTimeoutSeconds}
+                    bound={SETTING_BOUNDS.agentRunTimeoutSeconds}
+                    onCommit={(agentRunTimeoutSeconds) => onUpdate({ agentRunTimeoutSeconds })}
+                  />
+                  <NumberField
+                    label="Chat history sent to the orchestrator (messages)"
+                    hint="A bigger window keeps more of a long conversation in view, and costs more per run"
+                    value={settings.chatHistoryMessageLimit}
+                    bound={SETTING_BOUNDS.chatHistoryMessageLimit}
+                    onCommit={(chatHistoryMessageLimit) => onUpdate({ chatHistoryMessageLimit })}
+                  />
+                  <NumberField
+                    label="System Status refresh interval (ms)"
+                    hint="Applies after restarting the app"
+                    value={settings.systemStatsPollIntervalMs}
+                    bound={SETTING_BOUNDS.systemStatsPollIntervalMs}
+                    onCommit={(systemStatsPollIntervalMs) => onUpdate({ systemStatsPollIntervalMs })}
+                  />
                 </div>
               </div>
             )}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -10,6 +10,29 @@ export const DEFAULT_SYSTEM_STATS_POLL_INTERVAL_MS = 3000;
 /** Number of pre-rendered variations available per SFX event (public/audio/sfx/<event>/v1..v5.wav). */
 export const SOUND_FX_VARIANT_COUNT = 5;
 
+/** The range a numeric setting is allowed to hold. */
+export interface NumericBound {
+  min: number;
+  max: number;
+  integer?: boolean;
+}
+
+/**
+ * Must match the number kinds in `electron/main/settingsSchema.ts`, which is what actually
+ * enforces them at the write boundary. The renderer declares its own copy because `electron/` and
+ * `src/` are separate TypeScript projects — the same reason DEFAULT_SETTINGS is duplicated — and
+ * `settingsDefaults.test.ts` asserts the two agree, so a bound changed on one side alone fails.
+ *
+ * Here they make the UI honest: the input advertises the real range, and a value outside it is
+ * refused with a reason instead of snapping back silently.
+ */
+export const SETTING_BOUNDS = {
+  agentRunTimeoutSeconds: { min: 5, max: 3600, integer: true },
+  chatHistoryMessageLimit: { min: 1, max: 200, integer: true },
+  bgMusicVolume: { min: 0, max: 1 },
+  systemStatsPollIntervalMs: { min: 500, max: 600_000, integer: true },
+} as const satisfies Record<string, NumericBound>;
+
 export const TOOL_APPROVAL_DISPLAY_OPTIONS = ["modal", "inline"] as const;
 export type ToolApprovalDisplay = (typeof TOOL_APPROVAL_DISPLAY_OPTIONS)[number];
 

--- a/src/lib/settingsDefaults.test.ts
+++ b/src/lib/settingsDefaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_ORCHESTRATOR_MODEL, DEFAULT_SETTINGS } from "./settings";
-import { SETTING_DEFAULTS } from "../../electron/main/settingsSchema";
+import { DEFAULT_ORCHESTRATOR_MODEL, DEFAULT_SETTINGS, SETTING_BOUNDS } from "./settings";
+import { SETTING_DEFAULTS, SETTINGS_SCHEMA } from "../../electron/main/settingsSchema";
 
 /**
  * The renderer and the main process each hold their own copy of the settings defaults, because
@@ -54,5 +54,38 @@ describe("the orchestrator model default", () => {
     // remaining way they could diverge.
     expect(SETTING_DEFAULTS.orchestratorModel).toBe(DEFAULT_ORCHESTRATOR_MODEL);
     expect(DEFAULT_SETTINGS.orchestratorModel).toBe(DEFAULT_ORCHESTRATOR_MODEL);
+  });
+});
+
+
+describe("numeric bounds, renderer vs main", () => {
+  it("agree on every bound", () => {
+    // main's schema is what enforces these at the write boundary; the renderer's copy is what the
+    // input advertises and validates against. A bound changed on one side alone would mean the UI
+    // promising a range the boundary doesn't keep, or refusing a value it would have accepted.
+    for (const [key, bound] of Object.entries(SETTING_BOUNDS)) {
+      const kind = SETTINGS_SCHEMA[key as keyof typeof SETTINGS_SCHEMA] as {
+        type: string;
+        min?: number;
+        max?: number;
+        integer?: boolean;
+      };
+      expect(kind.type, key).toBe("number");
+      expect({ min: kind.min, max: kind.max, integer: kind.integer ?? false }, key).toEqual({
+        min: bound.min,
+        max: bound.max,
+        integer: "integer" in bound ? bound.integer : false,
+      });
+    }
+  });
+
+  it("covers every numeric setting the schema declares", () => {
+    const numericKeys = Object.entries(SETTINGS_SCHEMA)
+      .filter(([, kind]) => (kind as { type: string }).type === "number")
+      // The sound variants are clamped on merge rather than typed into a field, so they have no
+      // input to advertise a range on.
+      .filter(([key]) => !key.startsWith("soundVariant"))
+      .map(([key]) => key);
+    expect(numericKeys.sort()).toEqual(Object.keys(SETTING_BOUNDS).sort());
   });
 });


### PR DESCRIPTION
Closes **S3**, **S4**, **S5** and **S2** — one shared helper replacing four copies of the same broken guard. The worklist's batching rule names this exact group.

## Root cause

`min` on a number input constrains the spinner and nothing else. Typed and pasted values go straight past it, and all four settings were backed only by:

```ts
if (!Number.isNaN(value) && value > 0) onUpdate({ ... })
```

That's how a **1-second agent run timeout** and a **1 ms system-stats poll interval** were both reachable by typing.

Two more consequences of the same line:

- `Number("")` is `0`, which fails `> 0` — so clearing the box to retype snapped it back mid-edit, and the number couldn't be changed by deleting first.
- For `bgMusicVolume`, `0` *is* legal — so the same coercion **silently muted the music**.

## What changed

`NumberField` takes the bound as data and enforces it, with a local draft so the box can be cleared and retyped. A rejected value **says why**, and the typed text stays on screen to be corrected.

That last part is what S2 had been reduced to: the write boundary has refused out-of-range values since [#16](https://github.com/maneja81/OpenOrbit/pull/16), but the refusal was invisible — the field just reverted with no explanation. It applied to all four settings, not just the poll interval.

`SETTING_BOUNDS` mirrors the number kinds in `settingsSchema.ts`, which is what actually enforces them. The renderer needs its own copy for the same reason `DEFAULT_SETTINGS` is duplicated — separate TypeScript projects — so `settingsDefaults.test.ts` now asserts **the two agree**, and that every numeric setting the schema declares has a bound here. Sound variants are excluded deliberately: they're clamped on merge rather than typed into a field.

## Validated in the app

Selected the agent-timeout field, typed `1`, pressed Tab:

```
error: "Must be between 5–3600"
kept:  "1"
```

Rejected, explained, and the typed text preserved. A separate run confirmed the value never reached the database.

## Tests

+17: `NumberField.test.tsx` (15) covering commit on blur and Enter, floor and ceiling refusal with the message, values exactly on each bound, whole-number enforcement, fractional volumes allowed, the advertised `min`/`max` attributes, all three clearing cases including the music-mute one, error recovery, and following the stored value when it changes underneath. Plus 2 cross-project bound-agreement tests.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **996 passed / 101 files** (979 before — +17) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)