### PR TITLE
X9: guard the remaining JSON column reads

### DIFF
--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -47,6 +47,7 @@ import {
   saveConnectorCredentials,
   disconnectConnector,
 } from "../db/connectorsStore";
+import { parseIdList } from "../db/jsonColumn";
 
 // Derived rather than re-declared: this used to be a fourth hand-maintained copy of the same
 // string. Still exported because ipc/settings.ts uses it as the "blank means default" fallback
@@ -563,7 +564,7 @@ const attachConnectorToAgentTool = tool({
     }
     const updated = patchAgentConnectorIds(agentId, (ids) => (ids.includes(connectorId) ? ids : [...ids, connectorId]));
     devLog(`[attach_connector_to_agent] attached ${connectorId} to ${agentId}`);
-    return { id: updated.id, name: updated.name, connectorIds: JSON.parse(updated.connector_ids) };
+    return { id: updated.id, name: updated.name, connectorIds: parseIdList(`agents ${updated.id}/connector_ids`, updated.connector_ids) };
   },
 });
 
@@ -574,7 +575,7 @@ const detachConnectorFromAgentTool = tool({
   execute: async ({ agentId, connectorId }) => {
     const updated = patchAgentConnectorIds(agentId, (ids) => ids.filter((id) => id !== connectorId));
     devLog(`[detach_connector_from_agent] detached ${connectorId} from ${agentId}`);
-    return { id: updated.id, name: updated.name, connectorIds: JSON.parse(updated.connector_ids) };
+    return { id: updated.id, name: updated.name, connectorIds: parseIdList(`agents ${updated.id}/connector_ids`, updated.connector_ids) };
   },
 });
 

--- a/electron/main/ai/mcp.ts
+++ b/electron/main/ai/mcp.ts
@@ -2,6 +2,7 @@ import { MCPServerStdio } from "@openai/agents";
 import { getDb } from "../db";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
 import { devLog } from "../devLog";
+import { parseIdList, parseStringMap } from "../db/jsonColumn";
 
 export interface McpServerRow {
   id: string;
@@ -67,7 +68,7 @@ function encryptEnv(env: Record<string, string>): string {
 }
 
 function decryptEnv(envJson: string): Record<string, string> {
-  const stored = JSON.parse(envJson) as Record<string, string>;
+  const stored = parseStringMap("mcp_servers.env", envJson);
   const decrypted: Record<string, string> = {};
   for (const [key, value] of Object.entries(stored)) {
     decrypted[key] = decryptSecret(value);
@@ -135,7 +136,7 @@ export function deleteMcpServer(id: string): void {
   // dangling id in an agent's mcp_server_ids and silently fails to connect on the next run.
   const agents = db.prepare("SELECT id, mcp_server_ids FROM agents").all() as { id: string; mcp_server_ids: string }[];
   for (const agent of agents) {
-    const ids = JSON.parse(agent.mcp_server_ids) as string[];
+    const ids = parseIdList(`agents ${agent.id}/mcp_server_ids`, agent.mcp_server_ids);
     if (!ids.includes(id)) continue;
     db.prepare("UPDATE agents SET mcp_server_ids = ? WHERE id = ?").run(
       JSON.stringify(ids.filter((existingId) => existingId !== id)),
@@ -148,7 +149,7 @@ function buildStdioServer(row: McpServerRow): MCPServerStdio {
   return new MCPServerStdio({
     name: row.name,
     command: row.command,
-    args: JSON.parse(row.args) as string[],
+    args: parseIdList(`mcp_servers ${row.id}/args`, row.args),
     env: decryptEnv(row.env),
   });
 }

--- a/electron/main/db/connectorsStore.ts
+++ b/electron/main/db/connectorsStore.ts
@@ -1,5 +1,6 @@
 import { getDb } from "./index";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
+import { UNPARSEABLE, parseIdList, parseJsonColumn } from "./jsonColumn";
 
 export interface ConnectorCredentials {
   accessToken: string;
@@ -43,7 +44,10 @@ export function getDecryptedCredentials(id: string): ConnectorCredentials | null
     | { credentials: string | null }
     | undefined;
   if (!row || !row.credentials) return null;
-  return JSON.parse(decryptSecret(row.credentials)) as ConnectorCredentials;
+  const parsed = parseJsonColumn(`connectors ${id}/credentials`, decryptSecret(row.credentials));
+  // null is already how this says "not configured", and every caller handles it — so a row that
+  // cannot be read reports the same thing rather than taking the connector surface down.
+  return parsed === UNPARSEABLE ? null : (parsed as ConnectorCredentials);
 }
 
 /** Persists a connector as connected — inserts the row if this is the first time this
@@ -79,7 +83,8 @@ export function getDecryptedSettings(id: string): Record<string, string> | null 
     | { settings: string | null }
     | undefined;
   if (!row || !row.settings) return null;
-  return JSON.parse(decryptSecret(row.settings)) as Record<string, string>;
+  const parsed = parseJsonColumn(`connectors ${id}/settings`, decryptSecret(row.settings));
+  return parsed === UNPARSEABLE ? null : (parsed as Record<string, string>);
 }
 
 /** Persists a connector's user-entered settings (client id/secret/etc.), independent of
@@ -111,7 +116,7 @@ export function disconnectConnector(id: string): void {
 
   const agents = db.prepare("SELECT id, connector_ids FROM agents").all() as { id: string; connector_ids: string }[];
   for (const agent of agents) {
-    const ids = JSON.parse(agent.connector_ids) as string[];
+    const ids = parseIdList(`agents ${agent.id}/connector_ids`, agent.connector_ids);
     if (!ids.includes(id)) continue;
     db.prepare("UPDATE agents SET connector_ids = ? WHERE id = ?").run(
       JSON.stringify(ids.filter((existingId) => existingId !== id)),

--- a/electron/main/db/httpToolsStore.ts
+++ b/electron/main/db/httpToolsStore.ts
@@ -1,5 +1,6 @@
 import { getDb } from "./index";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
+import { parseIdList, parseStringMap } from "./jsonColumn";
 
 /** One user-declared input to an HTTP tool. `location` decides where the value ends up in
  * the outgoing request — see ai/httpToolRequest.ts, which is the only place that reads it. */
@@ -143,7 +144,7 @@ function encryptHeaders(headers: Record<string, string>): string {
 }
 
 function decryptHeaders(headersJson: string): Record<string, string> {
-  const stored = JSON.parse(headersJson) as Record<string, string>;
+  const stored = parseStringMap("http_tools.headers", headersJson);
   const decrypted: Record<string, string> = {};
   for (const [key, value] of Object.entries(stored)) {
     decrypted[key] = decryptSecret(value);
@@ -265,7 +266,7 @@ export function deleteHttpToolCollection(id: string): void {
     http_tool_collection_ids: string;
   }[];
   for (const agent of agents) {
-    const ids = JSON.parse(agent.http_tool_collection_ids) as string[];
+    const ids = parseIdList(`agents ${agent.id}/http_tool_collection_ids`, agent.http_tool_collection_ids);
     if (!ids.includes(id)) continue;
     db.prepare("UPDATE agents SET http_tool_collection_ids = ? WHERE id = ?").run(
       JSON.stringify(ids.filter((existingId) => existingId !== id)),

--- a/electron/main/db/jsonColumn.test.ts
+++ b/electron/main/db/jsonColumn.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const devLogMock = vi.hoisted(() => vi.fn());
 vi.mock("../devLog", () => ({ devLog: devLogMock }));
 
-import { parseJsonColumn, UNPARSEABLE } from "./jsonColumn";
+import { parseIdList, parseJsonColumn, parseStringMap, UNPARSEABLE } from "./jsonColumn";
 
 describe("parseJsonColumn", () => {
   beforeEach(() => {
@@ -59,5 +59,45 @@ describe("parseJsonColumn", () => {
   it("stays silent when the value parses", () => {
     parseJsonColumn("x", "1");
     expect(devLogMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseIdList", () => {
+  beforeEach(() => devLogMock.mockClear());
+
+  it("returns the ids for a well-formed list", () => {
+    expect(parseIdList("x", '["a","b"]')).toEqual(["a", "b"]);
+    expect(parseIdList("x", "[]")).toEqual([]);
+  });
+
+  it("degrades to nothing attached when the column is corrupt", () => {
+    expect(parseIdList("x", "{not json")).toEqual([]);
+  });
+
+  it("degrades when the value parses but isn't an array of ids", () => {
+    // Callers .includes() or iterate the result, so a parsed non-array would throw a line later.
+    for (const bad of ["null", '"gmail"', "{}", '["ok",3]']) {
+      expect(parseIdList("x", bad), bad).toEqual([]);
+    }
+  });
+
+  it("says which column it ignored", () => {
+    parseIdList("agents cipher/connector_ids", "null");
+    expect(String(devLogMock.mock.calls.at(-1)?.[0])).toContain("agents cipher/connector_ids");
+  });
+});
+
+describe("parseStringMap", () => {
+  beforeEach(() => devLogMock.mockClear());
+
+  it("returns the map for a well-formed object", () => {
+    expect(parseStringMap("x", '{"a":"1"}')).toEqual({ a: "1" });
+    expect(parseStringMap("x", "{}")).toEqual({});
+  });
+
+  it("degrades to an empty map on anything else", () => {
+    for (const bad of ["{not json", "null", "[]", '"a=1"', "42"]) {
+      expect(parseStringMap("x", bad), bad).toEqual({});
+    }
   });
 });

--- a/electron/main/db/jsonColumn.ts
+++ b/electron/main/db/jsonColumn.ts
@@ -31,3 +31,35 @@ export function parseJsonColumn(label: string, raw: string): unknown {
     return UNPARSEABLE;
   }
 }
+
+/**
+ * A JSON id-array column, degrading to an empty list.
+ *
+ * Four tables store attachments this way (agents.mcp_server_ids, connector_ids,
+ * http_tool_collection_ids). Callers immediately `.includes()` or iterate the result, so a
+ * corrupt row is not just unparseable — a parsed non-array would throw one line later. "Nothing
+ * attached" is the safe reading of both.
+ */
+export function parseIdList(label: string, raw: string): string[] {
+  const parsed = parseJsonColumn(label, raw);
+  if (parsed === UNPARSEABLE) return [];
+  if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === "string")) {
+    devLog(`[db] ignoring ${label}: not an array of ids`);
+    return [];
+  }
+  return parsed;
+}
+
+/**
+ * A JSON string-map column, degrading to an empty map. Used for the encrypted header/env maps and
+ * a task's recurrence params, all of which are iterated by their callers.
+ */
+export function parseStringMap(label: string, raw: string): Record<string, string> {
+  const parsed = parseJsonColumn(label, raw);
+  if (parsed === UNPARSEABLE) return {};
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    devLog(`[db] ignoring ${label}: not an object`);
+    return {};
+  }
+  return parsed as Record<string, string>;
+}

--- a/electron/main/tasks/scheduler.ts
+++ b/electron/main/tasks/scheduler.ts
@@ -13,6 +13,7 @@ import { buildOrchestrator, listAgents } from "../ai/agents";
 import { closeMcpServers } from "../ai/mcp";
 import { getDueTasks, recordTaskRun, TaskRow } from "../db/tasksStore";
 import { devLog } from "../devLog";
+import { parseStringMap } from "../db/jsonColumn";
 
 const POLL_INTERVAL_MS = 30_000;
 // Truncated in the OS notification body so a long agent reply doesn't overflow the
@@ -76,7 +77,7 @@ async function runPromptTask(task: TaskRow): Promise<string> {
       if (match) runTarget = match;
     }
     const now = new Date();
-    const prompt = renderTaskPrompt(task.prompt!, JSON.parse(task.recurrence_params) as Record<string, string>, {
+    const prompt = renderTaskPrompt(task.prompt!, parseStringMap(`tasks ${task.id}/recurrence_params`, task.recurrence_params), {
       lastResult: task.last_result ?? "",
       currentDateTime: now.toLocaleString(),
     });


### PR DESCRIPTION
Closes **X9**.

## Root cause

[#8](https://github.com/maneja81/OpenOrbit/pull/8) and [#11](https://github.com/maneja81/OpenOrbit/pull/11) fixed the two key/value stores and left `db/jsonColumn.ts` behind. Every other column storing JSON was still parsed inline, so one corrupt row took down whatever read it:

| column | consequence |
|---|---|
| `connectors.credentials` / `.settings` | connector surface throws |
| `http_tools.headers`, `mcp_servers.env` | tool/server unusable |
| `tasks.recurrence_params` | scheduled task throws on fire |
| `agents.*_ids` (×4) | attachment read throws |

## What changed

Two helpers join `parseJsonColumn`, because the id lists and string maps have a failure mode **beyond** unparseable: a value that parses but isn't an array — or isn't an object — throws one line later when the caller iterates it. `parseIdList` and `parseStringMap` fold both into the same degraded answer: *nothing attached*, or *an empty map*.

The two connector reads already returned `null` for "not configured" and every caller handles it, so a corrupt row now reports the same rather than taking the surface down.

**Four sites were already guarded and are left alone**: `httpToolsStore`'s params, `agents.ts`'s three id-list readers, and `ipc/agent.ts`'s argument parse. I checked each rather than assuming.

## Tests

+6 on the two new helpers: well-formed input, corrupt input, and the parses-but-wrong-shape cases (`null`, a bare string, `{}` where a list belongs, a list with a non-string in it) — plus that the log names which column was ignored.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1002 passed / 101 files** (996 before — +6) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)