### PR TITLE
S14: detach the orchestrator when a tool it uses is deleted

### DIFF
--- a/electron/main/ai/mcp.ts
+++ b/electron/main/ai/mcp.ts
@@ -3,6 +3,7 @@ import { getDb } from "../db";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
 import { devLog } from "../devLog";
 import { parseIdList, parseStringMap } from "../db/jsonColumn";
+import { detachFromOrchestrator } from "../db/orchestratorAttachments";
 
 export interface McpServerRow {
   id: string;
@@ -132,6 +133,7 @@ export function updateMcpServer(id: string, patch: McpServerUpdatePatch): McpSer
 export function deleteMcpServer(id: string): void {
   const db = getDb();
   db.prepare("DELETE FROM mcp_servers WHERE id = ?").run(id);
+  detachFromOrchestrator("mcp", id);
   // Detach from any agent that had it selected, so a deleted server never lingers as a
   // dangling id in an agent's mcp_server_ids and silently fails to connect on the next run.
   const agents = db.prepare("SELECT id, mcp_server_ids FROM agents").all() as { id: string; mcp_server_ids: string }[];

--- a/electron/main/db/connectorsStore.ts
+++ b/electron/main/db/connectorsStore.ts
@@ -1,6 +1,7 @@
 import { getDb } from "./index";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
 import { UNPARSEABLE, parseIdList, parseJsonColumn } from "./jsonColumn";
+import { detachFromOrchestrator } from "./orchestratorAttachments";
 
 export interface ConnectorCredentials {
   accessToken: string;
@@ -113,6 +114,7 @@ export function disconnectConnector(id: string): void {
   db.prepare(
     "UPDATE connectors SET status = 'disconnected', credentials = NULL, account_label = NULL, updated_at = datetime('now') WHERE id = ?"
   ).run(id);
+  detachFromOrchestrator("connector", id);
 
   const agents = db.prepare("SELECT id, connector_ids FROM agents").all() as { id: string; connector_ids: string }[];
   for (const agent of agents) {

--- a/electron/main/db/httpToolsStore.ts
+++ b/electron/main/db/httpToolsStore.ts
@@ -1,6 +1,7 @@
 import { getDb } from "./index";
 import { encryptSecret, decryptSecret } from "../security/secretStorage";
 import { parseIdList, parseStringMap } from "./jsonColumn";
+import { detachFromOrchestrator } from "./orchestratorAttachments";
 
 /** One user-declared input to an HTTP tool. `location` decides where the value ends up in
  * the outgoing request — see ai/httpToolRequest.ts, which is the only place that reads it. */
@@ -260,6 +261,7 @@ export function updateHttpToolCollection(id: string, patch: HttpToolCollectionPa
 export function deleteHttpToolCollection(id: string): void {
   const db = getDb();
   db.prepare("DELETE FROM http_tool_collections WHERE id = ?").run(id);
+  detachFromOrchestrator("httpToolCollection", id);
 
   const agents = db.prepare("SELECT id, http_tool_collection_ids FROM agents").all() as {
     id: string;

--- a/electron/main/db/orchestratorAttachments.test.ts
+++ b/electron/main/db/orchestratorAttachments.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "./migrations";
+
+let db: Database.Database;
+
+vi.mock("./index", () => ({ getDb: () => db }));
+vi.mock("../db", () => ({ getDb: () => db }));
+vi.mock("../db/index", () => ({ getDb: () => db }));
+vi.mock("../devLog", () => ({ devLog: () => {} }));
+
+import { detachFromOrchestrator } from "./orchestratorAttachments";
+import { getSetting, setSetting } from "./settingsStore";
+
+describe("detachFromOrchestrator", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    runMigrations(db);
+  });
+
+  const stored = (key: string) => getSetting<string[]>(`appSettings.${key}`, []);
+
+  it("drops the id and keeps the rest", () => {
+    setSetting("appSettings.orchestratorMcpServerIds", ["a", "b", "c"]);
+    detachFromOrchestrator("mcp", "b");
+    expect(stored("orchestratorMcpServerIds")).toEqual(["a", "c"]);
+  });
+
+  it("does nothing when the id was never attached", () => {
+    setSetting("appSettings.orchestratorConnectorIds", ["gmail"]);
+    detachFromOrchestrator("connector", "drive");
+    expect(stored("orchestratorConnectorIds")).toEqual(["gmail"]);
+  });
+
+  it("copes with the setting never having been written", () => {
+    // A fresh install has no row at all; readAppSetting supplies the default.
+    expect(() => detachFromOrchestrator("httpToolCollection", "anything")).not.toThrow();
+    expect(stored("orchestratorHttpToolCollectionIds")).toEqual([]);
+  });
+
+  it("empties the list when the last attachment goes", () => {
+    setSetting("appSettings.orchestratorHttpToolCollectionIds", ["only"]);
+    detachFromOrchestrator("httpToolCollection", "only");
+    expect(stored("orchestratorHttpToolCollectionIds")).toEqual([]);
+  });
+
+  it("touches only its own kind", () => {
+    setSetting("appSettings.orchestratorMcpServerIds", ["shared-id"]);
+    setSetting("appSettings.orchestratorConnectorIds", ["shared-id"]);
+    detachFromOrchestrator("mcp", "shared-id");
+    expect(stored("orchestratorMcpServerIds")).toEqual([]);
+    expect(stored("orchestratorConnectorIds")).toEqual(["shared-id"]);
+  });
+
+  it("recovers rather than throwing if the stored list is corrupt", () => {
+    // readAppSetting validates against the schema, so a non-array degrades to the default.
+    setSetting("appSettings.orchestratorMcpServerIds", "not-a-list");
+    expect(() => detachFromOrchestrator("mcp", "a")).not.toThrow();
+  });
+});

--- a/electron/main/db/orchestratorAttachments.ts
+++ b/electron/main/db/orchestratorAttachments.ts
@@ -1,0 +1,32 @@
+import { setSetting } from "./settingsStore";
+import { readAppSetting } from "../appSettings";
+import type { SettingKey } from "../settingsSchema";
+import { devLog } from "../devLog";
+
+/**
+ * The orchestrator's tool attachments, unlike every other agent's, live in settings rather than
+ * an `agents` row — so the delete handlers that prune `agents.*_ids` never touched them.
+ *
+ * A deleted MCP server, connector or HTTP tool collection therefore stayed listed against the
+ * orchestrator forever. Mostly harmless, because the attach helpers skip ids they can't resolve,
+ * but the lists grew unboundedly across delete/recreate cycles and — the part that isn't
+ * harmless — recreating something that reused a previous id silently re-attached it to the
+ * orchestrator without anyone asking for it.
+ */
+const ATTACHMENT_KEYS = {
+  mcp: "orchestratorMcpServerIds",
+  connector: "orchestratorConnectorIds",
+  httpToolCollection: "orchestratorHttpToolCollectionIds",
+} as const satisfies Record<string, SettingKey>;
+
+export type AttachmentKind = keyof typeof ATTACHMENT_KEYS;
+
+/** Drops `id` from the orchestrator's list of that kind. Call it wherever the thing itself is
+ * deleted, alongside the existing agents-table prune. */
+export function detachFromOrchestrator(kind: AttachmentKind, id: string): void {
+  const key = ATTACHMENT_KEYS[kind];
+  const current = readAppSetting(key);
+  if (!current.includes(id)) return;
+  setSetting(`appSettings.${key}`, current.filter((existing) => existing !== id));
+  devLog(`[settings] detached ${id} from ${key}`);
+}


### PR DESCRIPTION
Closes **S14**.

## Root cause

Deleting an MCP server, disconnecting a connector, or deleting an HTTP tool collection already pruned the id from **every `agents` row**. The orchestrator's attachments don't live in an `agents` row — they're settings (`orchestratorMcpServerIds`, `orchestratorConnectorIds`, `orchestratorHttpToolCollectionIds`) — so nothing pruned those.

A deleted thing stayed listed against the orchestrator forever.

Mostly harmless, since the attach helpers skip ids they can't resolve. Two parts aren't:

- the lists grew unboundedly across delete/recreate cycles
- **recreating something that reused a previous id silently re-attached it to the orchestrator** without anyone asking

## What changed

`detachFromOrchestrator(kind, id)` sits **next to the existing agents-table prune** in all three delete paths, so the two halves of the same cleanup are written in the same place and are hard to forget separately in future.

## Tests

+6: drops the id and keeps the rest, no-ops when it was never attached, copes with the setting never having been written (fresh install has no row), empties cleanly on the last attachment, touches only its own kind when two lists share an id, and recovers rather than throwing when the stored list is corrupt.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1008 passed / 102 files** (1002 before — +6) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)