### PR TITLE
S15: remove the orchestrator's dead enabled-toggle handler

### DIFF
--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -26,7 +26,9 @@ interface AgentAccordionProps {
   /** Shown as a "Reset to default" control beside the prompt label. Only passed when the
    * prompt is actually customised, so its presence is what says so. */
   onResetPrompt?: () => void;
-  onChangeEnabled: (enabled: boolean) => void;
+  /** Omitted when the agent cannot be enabled or disabled at all — pass `enabledLocked` instead.
+   * Optional rather than required-with-a-no-op so a locked agent has no handler to read as live. */
+  onChangeEnabled?: (enabled: boolean) => void;
   defaultOpen?: boolean;
   availableMcpServers?: McpServerRow[];
   mcpServerIds?: string[];
@@ -122,7 +124,7 @@ export default function AgentAccordion({
         <span className="agent-accordion-spacer" />
         <Toggle
           checked={enabled}
-          onChange={onChangeEnabled}
+          onChange={(next) => onChangeEnabled?.(next)}
           label={`Toggle ${name}`}
           disabled={enabledLocked}
         />

--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -263,3 +263,46 @@ describe("Privacy & Safety", () => {
     expect(screen.queryByLabelText("Ask before DELETE requests")).toBeNull();
   });
 });
+
+describe("the orchestrator's enabled toggle", () => {
+  function renderAgentsTab() {
+    const onUpdate = vi.fn();
+    render(
+      <SettingsPanel
+        open
+        onClose={vi.fn()}
+        settings={mergeWithDefaults({})}
+        sessionElapsedMs={0}
+        onUpdate={onUpdate}
+        onReset={vi.fn()}
+        agents={[]}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^Agents$/i }));
+    const toggle = [...document.querySelectorAll('[role="switch"]')].find((t) =>
+      /Toggle Orbit/i.test(t.getAttribute("aria-label") ?? "")
+    );
+    return { onUpdate, toggle };
+  }
+
+  it("is disabled, because the orchestrator is singular", () => {
+    const { toggle } = renderAgentsTab();
+    expect(toggle).toBeTruthy();
+    expect(toggle).toBeDisabled();
+  });
+
+  it("writes nothing when clicked", () => {
+    // It used to call onUpdate({ orchestratorEnabled }), which ipc/settings.ts drops via
+    // LOCKED_KEYS and useSettings reconciles straight back — a live-looking write path for a
+    // value that can never change.
+    const { onUpdate, toggle } = renderAgentsTab();
+    fireEvent.click(toggle!);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -570,6 +570,10 @@ export default function SettingsPanel({
                     prompt={orchestratorPrompt}
                     promptLoading={orchestratorPromptLoading}
                     enabled={settings.orchestratorEnabled}
+                    // No onChangeEnabled: the orchestrator is singular and cannot be turned off.
+                    // ipc/settings.ts drops orchestratorEnabled via LOCKED_KEYS, so the handler
+                    // that used to be here was silently discarded and reconciled straight back —
+                    // a live-looking write path for a value that can never change.
                     enabledLocked
                     onChangeName={(name) => onUpdate({ agentName: name })}
                     onChangeDescription={(description) => onUpdate({ agentDescription: description })}
@@ -582,7 +586,6 @@ export default function SettingsPanel({
                         ? () => void resetOrchestratorPrompt()
                         : undefined
                     }
-                    onChangeEnabled={(enabled) => onUpdate({ orchestratorEnabled: enabled })}
                     availableMcpServers={mcpServers}
                     mcpServerIds={settings.orchestratorMcpServerIds}
                     onChangeMcpServerIds={(mcpServerIds) => onUpdate({ orchestratorMcpServerIds: mcpServerIds })}


### PR DESCRIPTION
Closes **S15**.

## Root cause

The orchestrator's accordion wired:

```tsx
onChangeEnabled={(enabled) => onUpdate({ orchestratorEnabled: enabled })}
```

`orchestratorEnabled` is in `LOCKED_KEYS` in `ipc/settings.ts`, so the write was silently dropped and reconciled straight back by `useSettings` — on a toggle already rendered `disabled`.

Nothing was broken. But the next person editing this component would read a live write path for a value that can never change, which is exactly the kind of thing that gets "fixed" into a real bug later.

## What changed

`onChangeEnabled` is now **optional** and simply not passed for the orchestrator, so its absence says what `enabledLocked` means. Optional rather than required-with-a-no-op, because a no-op is the same trap in a different shape.

## Tests

+2: the toggle is disabled, and clicking it writes nothing.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1010 passed / 102 files** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)