### PR TITLE
S17: let onboarding be run again without wiping the database

### DIFF
--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -306,3 +306,51 @@ describe("the orchestrator's enabled toggle", () => {
     expect(onUpdate).not.toHaveBeenCalled();
   });
 });
+
+describe("running onboarding again", () => {
+  function renderGeneral() {
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SettingsPanel
+        open
+        onClose={onClose}
+        settings={mergeWithDefaults({ onboardingDone: true })}
+        sessionElapsedMs={0}
+        onUpdate={onUpdate}
+        onReset={vi.fn()}
+        agents={[]}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^General$/i }));
+    const button = [...document.querySelectorAll("button")].find((b) => /^Start$/i.test(b.textContent?.trim() ?? ""));
+    return { onUpdate, onClose, button };
+  }
+
+  it("offers a way back into onboarding", () => {
+    // The tour has had a replay path since it shipped; onboarding's only route was a Danger Zone
+    // reset, which also destroys chat history, agents, memory and the knowledge base.
+    expect(renderGeneral().button).toBeTruthy();
+  });
+
+  it("clears the flag and gets out of the way", () => {
+    const { onUpdate, onClose, button } = renderGeneral();
+    fireEvent.click(button!);
+    expect(onUpdate).toHaveBeenCalledWith({ onboardingDone: false });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clears nothing else", () => {
+    // AgentsApp shows onboarding whenever onboardingDone is false; the stored answers stay put
+    // and become the starting point.
+    const { onUpdate, button } = renderGeneral();
+    fireEvent.click(button!);
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith({ onboardingDone: false });
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -710,6 +710,28 @@ export default function SettingsPanel({
                       )}
                     </label>
                   ))}
+                  <div className="row">
+                    <span className="row-label">
+                      Run onboarding again
+                      <small>Walks through the setup questions. Nothing is cleared — your answers are the starting point</small>
+                    </span>
+                    <button
+                      type="button"
+                      className="settings-action-btn-sm settings-action-btn-ghost"
+                      onClick={() => {
+                        // The tour has had a replay path since it shipped; onboarding never did,
+                        // so the only way back through it was a Danger Zone reset — which also
+                        // destroys chat history, agents, memory and the knowledge base.
+                        // Clearing the flag is all it takes: AgentsApp shows onboarding whenever
+                        // onboardingDone is false. Closing the panel gets it out of the way.
+                        onUpdate({ onboardingDone: false });
+                        onClose();
+                      }}
+                    >
+                      <TablerIcon name="ti-refresh" />
+                      <span>Start</span>
+                    </button>
+                  </div>
                 </div>
                 <div className="card">
                   <div className="row">


### PR DESCRIPTION
Closes **S17**.

## Root cause

`tourCompleted` has had a deliberate replay path since it shipped (`useTour.ts`). `onboardingDone` never did — so the only route back through onboarding was a **Danger Zone reset**, which also destroys chat history, agents, memory and the knowledge base. To re-ask four questions.

## What changed

Clearing the flag is all it takes: `AgentsApp` shows onboarding whenever `onboardingDone` is false. The control sits in **Settings → General**, next to the About You fields — which is where those same answers are edited the rest of the time — and closes the panel so onboarding isn't behind it.

**Nothing else is cleared.** The stored answers stay put and become the starting point, which is the whole difference between this and the reset it replaces. A test asserts the patch contains only that one key.

## Validated in the app

Clicked it with onboarding already complete:

```
onboardingVisible: true
settingsOpen:      false
```

## Tests

+3: the control exists, it clears the flag and closes the panel, and it clears nothing else.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1013 passed / 102 files** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)