### PR TITLE
S18: apply the system-stats interval without a restart

### DIFF
--- a/electron/main/ipc/settings.test.ts
+++ b/electron/main/ipc/settings.test.ts
@@ -31,12 +31,14 @@ vi.mock("../db", () => ({ getDb: vi.fn() }));
 vi.mock("../db/migrations", () => ({ runMigrations: vi.fn() }));
 vi.mock("../ai/agents", () => ({ DEFAULT_MODEL: "gpt-4.1-mini" }));
 vi.mock("../ai/provider", () => ({ testChatConnection: vi.fn(), testVoiceConnection: vi.fn() }));
+vi.mock("./systemStats", () => ({ restartSystemStatsBroadcast: vi.fn() }));
 
 const devLogMock = vi.hoisted(() => vi.fn());
 vi.mock("../devLog", () => ({ devLog: devLogMock }));
 
 import { ipcMain } from "electron";
 import { registerSettingsHandlers } from "./settings";
+import { restartSystemStatsBroadcast } from "./systemStats";
 
 type Handler = (event: unknown, ...args: unknown[]) => unknown;
 
@@ -55,6 +57,7 @@ describe("settings:update", () => {
   beforeEach(() => {
     stored.clear();
     vi.mocked(ipcMain.handle).mockClear();
+    vi.mocked(restartSystemStatsBroadcast).mockClear();
     devLogMock.mockClear();
   });
 
@@ -179,5 +182,31 @@ describe("settings:update", () => {
     // out in the UI, so no caller can reach it.
     update({ orchestratorEnabled: false });
     expect(stored.has("appSettings.orchestratorEnabled")).toBe(false);
+  });
+});
+
+describe("settings that used to need a restart", () => {
+  beforeEach(() => {
+    stored.clear();
+    vi.mocked(ipcMain.handle).mockClear();
+    vi.mocked(restartSystemStatsBroadcast).mockClear();
+  });
+
+  it("rebuilds the system-stats timer when its interval changes", () => {
+    // The broadcast reads its interval when the timer is built, so a new value used to sit inert
+    // until the next launch — the only "Applies after restarting the app" hint in Settings.
+    update({ systemStatsPollIntervalMs: 5000 });
+    expect(vi.mocked(restartSystemStatsBroadcast)).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the timer alone for any other setting", () => {
+    // Rebuilt on demand rather than polled, so the common case costs nothing.
+    update({ userName: "Ada" });
+    expect(vi.mocked(restartSystemStatsBroadcast)).not.toHaveBeenCalled();
+  });
+
+  it("leaves it alone when the new interval was refused", () => {
+    update({ systemStatsPollIntervalMs: 1 });
+    expect(vi.mocked(restartSystemStatsBroadcast)).not.toHaveBeenCalled();
   });
 });

--- a/electron/main/ipc/settings.ts
+++ b/electron/main/ipc/settings.ts
@@ -7,6 +7,7 @@ import { DEFAULT_MODEL } from "../ai/agents";
 import { testChatConnection, testVoiceConnection } from "../ai/provider";
 import { devLog } from "../devLog";
 import { validateSettingsPatch } from "../settingsSchema";
+import { restartSystemStatsBroadcast } from "./systemStats";
 
 const NAMESPACE = "appSettings.";
 // Chat and Voice are independent credential slots (Settings → AI Models), each encrypted
@@ -110,6 +111,11 @@ export function registerSettingsHandlers() {
         devLog(`[settings:update] ${NAMESPACE}${key} = ${REDACTED_VALUE_KEYS.includes(key) ? "(redacted)" : value}`);
       }
     }
+    // The stats broadcast reads its interval when the timer is built, so a new value would
+    // otherwise sit inert until the next launch. Rebuilt here rather than polled, so the common
+    // case — any other setting changing — costs nothing.
+    if ("systemStatsPollIntervalMs" in accepted) restartSystemStatsBroadcast();
+
     return getVisibleSettings();
   });
 

--- a/electron/main/ipc/systemStats.ts
+++ b/electron/main/ipc/systemStats.ts
@@ -123,8 +123,6 @@ let broadcastInterval: NodeJS.Timeout | null = null;
 
 // Guards against duplicate intervals stacking (and sending duplicate system:stats-update
 // events to every window) if this is ever called more than once in the app's lifetime.
-// Interval is read once at startup (Settings → General) rather than per-tick — changing it
-// takes effect on the next app restart, same as most other main-process-only settings here.
 export function startSystemStatsBroadcast() {
   if (broadcastInterval) return;
   const intervalMs = readAppSetting("systemStatsPollIntervalMs", DEFAULT_POLL_INTERVAL_MS);
@@ -134,4 +132,21 @@ export function startSystemStatsBroadcast() {
       win.webContents.send("system:stats-update", stats);
     }
   }, intervalMs);
+}
+
+/**
+ * Re-reads the interval and rebuilds the timer, so a change in Settings applies immediately.
+ *
+ * This setting used to be the one place in the app that told the user to restart — the interval
+ * was read once at startup, so a new value sat inert until they did. Making it live is a better
+ * answer than documenting the wait, and it removes the only "Applies after restarting the app"
+ * hint in Settings. `agentRunTimeoutSeconds` and `chatHistoryMessageLimit` are already re-read
+ * per run for the same reason; this brings the third numeric tunable in line with them.
+ */
+export function restartSystemStatsBroadcast() {
+  if (broadcastInterval) {
+    clearInterval(broadcastInterval);
+    broadcastInterval = null;
+  }
+  startSystemStatsBroadcast();
 }

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -804,7 +804,6 @@ export default function SettingsPanel({
                   />
                   <NumberField
                     label="System Status refresh interval (ms)"
-                    hint="Applies after restarting the app"
                     value={settings.systemStatsPollIntervalMs}
                     bound={SETTING_BOUNDS.systemStatsPollIntervalMs}
                     onCommit={(systemStatsPollIntervalMs) => onUpdate({ systemStatsPollIntervalMs })}


### PR DESCRIPTION
Closes **S18** — by removing the thing it asked to be documented better.

## The finding, and a better answer

S18 was "restart-required behaviour documented in one place only": `systemStatsPollIntervalMs` carried an *"Applies after restarting the app"* hint, and it was genuinely the only such setting. The suggested fix was a restart prompt.

But the reason it needed a restart was that `startSystemStatsBroadcast` reads the interval **when the timer is built**, once, at launch. Making it live is a better answer than documenting the wait — and it removes the only restart hint in Settings rather than adding UI around it.

## What changed

`restartSystemStatsBroadcast()` rebuilds the timer. `settings:update` calls it when that key is among the **accepted** entries — on demand rather than polled, so every other setting change costs nothing, and a **refused** value doesn't trigger it either since it never reaches the accepted set.

`agentRunTimeoutSeconds` and `chatHistoryMessageLimit` are already re-read per run for exactly this reason. This brings the third numeric tunable in line with them.

## Tests

+3: the timer rebuilds when the interval changes, is left alone for any other setting, and is left alone when the new interval was refused.

One note for anyone adding to `settings.test.ts`: the new `describe` needs its own `beforeEach` to clear the mock — the existing one is scoped to `describe("settings:update")`, so a block appended outside it silently inherits accumulated calls.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1016 passed / 102 files** (1013 before — +3) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)