### PR TITLE
S21: warn when a provider URL would send the API key in the clear

### DIFF
--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -23,6 +23,7 @@ import { useConnectors } from "@/hooks/useConnectors";
 import { useHttpTools } from "@/hooks/useHttpTools";
 import { useUserContext } from "@/hooks/useUserContext";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
+import { providerUrlWarning } from "@/lib/providerUrlWarning";
 import { DEFAULT_SETTINGS_SECTION, sectionOnTransition } from "@/lib/settingsSection";
 import { SoundFxEvent, sfxPreviewSrc } from "@/hooks/useSoundFX";
 
@@ -432,6 +433,9 @@ export default function SettingsPanel({
                           placeholder="https://api.openai.com/v1"
                           autoComplete="off"
                         />
+                        {providerUrlWarning(settings.chatApiUrl) && (
+                          <p className="settings-warning">{providerUrlWarning(settings.chatApiUrl)}</p>
+                        )}
                       </label>
                       <label className="row-field">
                         <span>Model ID</span>
@@ -491,6 +495,9 @@ export default function SettingsPanel({
                           placeholder="https://api.openai.com/v1"
                           autoComplete="off"
                         />
+                        {providerUrlWarning(settings.voiceApiUrl) && (
+                          <p className="settings-warning">{providerUrlWarning(settings.voiceApiUrl)}</p>
+                        )}
                       </label>
                       <label className="row-field">
                         <span>Transcription model</span>

--- a/src/globals.css
+++ b/src/globals.css
@@ -2054,6 +2054,15 @@ svg#oc {
 /* A hint under a row-field's label, matching .row-label small above. The API key fields use one
    to say a key is already stored — without the block display it runs on inline and reads as
    "API KeyA key is saved — type a new one to replace it". */
+/* A caution rather than a failure: the value is accepted and stored, it just carries a risk the
+   user should see. Distinct from .settings-error, which means the write was refused. */
+.settings-warning {
+  font-size: 11px;
+  line-height: 1.45;
+  color: rgba(255, 196, 120, 0.9);
+  margin-top: 4px;
+}
+
 .group .card .row-field span small {
   display: block;
   font-size: 10.5px;

--- a/src/lib/providerUrlWarning.test.ts
+++ b/src/lib/providerUrlWarning.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { providerUrlWarning } from "./providerUrlWarning";
+
+const warns = (url: string) => providerUrlWarning(url) !== null;
+
+describe("providerUrlWarning", () => {
+  it("says nothing for https", () => {
+    expect(providerUrlWarning("https://api.openai.com/v1")).toBeNull();
+    expect(providerUrlWarning("https://openrouter.ai/api/v1")).toBeNull();
+  });
+
+  it("says nothing when the field is empty or unparseable", () => {
+    // Empty means "use the default"; an unparseable value is already refused at the write
+    // boundary, so warning here would be noise on top of a rejection.
+    expect(providerUrlWarning("")).toBeNull();
+    expect(providerUrlWarning("   ")).toBeNull();
+    expect(providerUrlWarning("not a url")).toBeNull();
+  });
+
+  describe("plain http", () => {
+    it("warns when the traffic would leave the machine", () => {
+      expect(warns("http://api.example.com/v1")).toBe(true);
+      expect(warns("http://93.184.216.34/v1")).toBe(true);
+      expect(providerUrlWarning("http://api.example.com/v1")).toMatch(/unencrypted/i);
+    });
+
+    it("stays quiet for loopback, which is the self-hosted case the app invites", () => {
+      for (const url of [
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:8080/v1",
+        "http://[::1]:8080/v1",
+        "http://ollama.localhost/v1",
+      ]) {
+        expect(warns(url), url).toBe(false);
+      }
+    });
+
+    it("stays quiet on a private network, where a self-hosted server also lives", () => {
+      for (const url of [
+        "http://10.0.0.5/v1",
+        "http://192.168.1.20:11434/v1",
+        "http://172.16.4.9/v1",
+        "http://172.31.255.1/v1",
+        "http://nas.local:8080/v1",
+      ]) {
+        expect(warns(url), url).toBe(false);
+      }
+    });
+
+    it("still warns for addresses that only look private", () => {
+      // 172.32 is outside RFC1918, and 11.x is public space that starts like 10.x doesn't.
+      expect(warns("http://172.32.0.1/v1")).toBe(true);
+      expect(warns("http://11.0.0.1/v1")).toBe(true);
+      expect(warns("http://notlocalhost.com/v1")).toBe(true);
+    });
+
+    it("is not fooled by case or a trailing dot in the scheme host", () => {
+      expect(warns("http://LOCALHOST:11434/v1")).toBe(false);
+      expect(warns("HTTP://Api.Example.Com/v1")).toBe(true);
+    });
+  });
+});

--- a/src/lib/providerUrlWarning.ts
+++ b/src/lib/providerUrlWarning.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether a provider URL is about to send the API key across a network in the clear.
+ *
+ * Every provider call attaches `Authorization: Bearer <key>` to whatever host these settings
+ * name, so an `http://` endpoint puts the key on the wire unencrypted. Plain http isn't refused
+ * outright — the app explicitly invites pointing at Ollama or another self-hosted server, and
+ * those are http — so this warns instead, and only when the traffic would actually leave the
+ * machine or the local network.
+ *
+ * Deliberately its own small implementation rather than reaching for `net/urlSafety.ts`: that one
+ * is main-process code, imports `node:dns`, and its exported entry point is async because it
+ * resolves the hostname to defend against DNS rebinding. None of that belongs in a settings field
+ * that has to render a hint as you type. The two answer different questions — that one asks "is
+ * this safe to fetch", this one asks "would the key travel in the clear".
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1", "0.0.0.0"]);
+
+function isLocalHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (LOOPBACK_HOSTNAMES.has(host)) return true;
+  // `.localhost` is reserved for loopback, and `.local` is mDNS on the local network.
+  if (host.endsWith(".localhost") || host.endsWith(".local")) return true;
+  if (/^127\./.test(host)) return true;
+  // RFC1918 private space, plus link-local.
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (/^169\.254\./.test(host)) return true;
+  // IPv6 unique-local (fc00::/7) and link-local (fe80::/10), with or without brackets.
+  const bare = host.replace(/^\[|\]$/g, "");
+  if (/^f[cd][0-9a-f]{2}:/.test(bare)) return true;
+  if (/^fe[89ab][0-9a-f]:/.test(bare)) return true;
+  return false;
+}
+
+/**
+ * A warning to show under a provider URL field, or null when there is nothing to say.
+ *
+ * Empty and unparseable both return null: empty means "use the default", and an unparseable value
+ * is already refused at the write boundary, so warning about it here would be noise on top of a
+ * rejection.
+ */
+export function providerUrlWarning(url: string): string | null {
+  const trimmed = url.trim();
+  if (trimmed.length === 0) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:") return null;
+  if (isLocalHostname(parsed.hostname)) return null;
+
+  return "This is a plain http:// address, so your API key will be sent unencrypted. Use https:// unless this host is on your own machine or network.";
+}


### PR DESCRIPTION
Closes **S21**, the half of S8 that was split out rather than shipped.

## The gap

Every provider call attaches `Authorization: Bearer <key>` to whatever host these settings name, so an `http://` endpoint puts the key on the wire unencrypted. [#22](https://github.com/maneja81/OpenOrbit/pull/22) validated the format and stopped agents redirecting these URLs, but left the cleartext case with **no warning at all** — I flagged that in the PR rather than letting it be implied.

## Why warn rather than refuse

The app explicitly invites pointing at Ollama or another self-hosted server, and those are `http`. `settingsSchema.test.ts` asserts `http://localhost:11434/v1` keeps working. Blocking plain http would break a documented setup with no override.

So it warns — and only when the traffic would **actually leave the machine or the local network**. Loopback, RFC1918 space, link-local and `.local` stay quiet.

## Why not reuse `net/urlSafety.ts`

It already has a private/loopback classifier, but it's main-process code, imports `node:dns`, and its exported entry point is **async** because it resolves the hostname to defend against DNS rebinding. None of that belongs in a settings field rendering a hint as you type.

They also answer different questions: that one asks *"is this safe to fetch"*, this one asks *"would the key travel in the clear"*. Same data, different verdicts — a private address is a **refusal** there and **fine** here.

## Validated in the app

Both URL fields visible, `chatApiUrl` on a public http host and `voiceApiUrl` on Ollama:

```
warnings:  1
urlFields: ["http://api.example.com/v1", "http://localhost:11434/v1"]
```

## Tests

+7: https silent, empty and unparseable silent, public http warns, loopback quiet (four forms including `[::1]` and `.localhost`), private networks quiet (all three RFC1918 ranges and `.local`), and the near-misses that must still warn — `172.32` is outside RFC1918, `11.x` is public, `notlocalhost.com` isn't localhost.

Styled as a caution rather than an error, because unlike a refused value this one is accepted and stored.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1023 passed / 103 files** (1016 before — +7) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)