### PR TITLE
X5: save the text settings on blur rather than on every keystroke

### DIFF
--- a/src/components/molecules/TextField.test.tsx
+++ b/src/components/molecules/TextField.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import TextField from "./TextField";
+
+afterEach(cleanup);
+
+function setup(value = "gpt-4.1-mini", warningFor?: (v: string) => string | null) {
+  const onCommit = vi.fn();
+  const { container, rerender } = render(
+    <TextField label="Model ID" value={value} onCommit={onCommit} warningFor={warningFor} />
+  );
+  const input = container.querySelector("input");
+  if (!input) throw new Error("no input rendered");
+  return { onCommit, input, rerender };
+}
+
+const type = (input: HTMLInputElement, v: string) => fireEvent.change(input, { target: { value: v } });
+
+describe("TextField", () => {
+  it("saves once on blur, not per keystroke", () => {
+    // Each keystroke used to be an IPC round trip and a SQLite write, with the whole settings
+    // blob coming back to re-render the panel.
+    const { onCommit, input } = setup();
+    type(input, "g");
+    type(input, "gp");
+    type(input, "gpt-5");
+    expect(onCommit).not.toHaveBeenCalled();
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("gpt-5");
+  });
+
+  it("saves on Enter too", () => {
+    const { onCommit, input } = setup();
+    type(input, "gpt-5");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenCalledWith("gpt-5");
+  });
+
+  it("trims what it saves", () => {
+    const { onCommit, input } = setup();
+    type(input, "  gpt-5  ");
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith("gpt-5");
+  });
+
+  it("does not save an unchanged value", () => {
+    const { onCommit, input } = setup();
+    fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("does not save when only whitespace was added", () => {
+    const { onCommit, input } = setup();
+    type(input, "  gpt-4.1-mini  ");
+    fireEvent.blur(input);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("saves an emptied field, which is how a value is cleared", () => {
+    // Unlike the API key field, blank is meaningful here — it is how a URL or model returns to
+    // the provider default.
+    const { onCommit, input } = setup();
+    type(input, "");
+    fireEvent.blur(input);
+    expect(onCommit).toHaveBeenCalledWith("");
+  });
+
+  it("follows the stored value when it changes underneath", () => {
+    const { input, rerender } = setup();
+    rerender(<TextField label="Model ID" value="claude-opus-5" onCommit={vi.fn()} />);
+    expect(input.value).toBe("claude-opus-5");
+  });
+
+  describe("the optional warning", () => {
+    const warn = (v: string) => (v.startsWith("http://") ? "plain http" : null);
+
+    it("reacts to what is typed, before it is saved", () => {
+      // Computed from the draft rather than the stored value, so it appears while the value is
+      // being considered instead of only after committing it.
+      const { input } = setup("https://api.openai.com/v1", warn);
+      expect(screen.queryByText("plain http")).not.toBeInTheDocument();
+      type(input, "http://example.com/v1");
+      expect(screen.getByText("plain http")).toBeInTheDocument();
+    });
+
+    it("goes away when the value is corrected", () => {
+      const { input } = setup("http://example.com/v1", warn);
+      expect(screen.getByText("plain http")).toBeInTheDocument();
+      type(input, "https://example.com/v1");
+      expect(screen.queryByText("plain http")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/molecules/TextField.tsx
+++ b/src/components/molecules/TextField.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+
+interface TextFieldProps {
+  label: string;
+  hint?: string;
+  value: string;
+  placeholder?: string;
+  onCommit: (value: string) => void;
+  /** Optional caution shown under the field, computed from what is currently typed rather than
+   * what is stored — so it appears while the value is being considered, not after it is saved. */
+  warningFor?: (value: string) => string | null;
+}
+
+/**
+ * A text setting that saves when you finish, not on every keystroke.
+ *
+ * Every field here wrote per character: one IPC round trip and one SQLite write each, with the
+ * full settings blob coming back to re-render the panel. Pasting a long URL was dozens of writes
+ * for one edit, and the read-back meant a value the write boundary refused snapped away
+ * mid-typing.
+ *
+ * The API key and numeric fields already work this way — ApiKeyField was forced into it when the
+ * keys stopped being returned, NumberField when the bounds started being enforced. This is the
+ * same shape for the plain text fields, which is what finding X5 asked for.
+ */
+export default function TextField({ label, hint, value, placeholder, onCommit, warningFor }: TextFieldProps) {
+  const [draft, setDraft] = useState(value);
+
+  // Follow the stored value when it changes underneath — an agent renaming the orchestrator
+  // mid-run, or a reset. Adjusted during render rather than in an effect, which is what React
+  // documents and what react-hooks/set-state-in-effect requires.
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setDraft(value);
+  }
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed !== value) onCommit(trimmed);
+    setDraft(trimmed);
+  };
+
+  const warning = warningFor?.(draft) ?? null;
+
+  return (
+    <label className="row-field">
+      <span>
+        {label}
+        {hint && <small>{hint}</small>}
+      </span>
+      <input
+        type="text"
+        value={draft}
+        placeholder={placeholder}
+        autoComplete="off"
+        aria-label={label}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          }
+        }}
+      />
+      {warning && <p className="settings-warning">{warning}</p>}
+    </label>
+  );
+}

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import AgentAccordion from "@/components/molecules/AgentAccordion";
 import SettingsAccordion from "@/components/molecules/SettingsAccordion";
 import AddAgentForm from "@/components/molecules/AddAgentForm";
 import ApiKeyField from "@/components/molecules/ApiKeyField";
+import TextField from "@/components/molecules/TextField";
 import NumberField from "@/components/molecules/NumberField";
 import FilesAppsTab from "@/components/organisms/FilesAppsTab";
 import McpServersTab from "@/components/organisms/McpServersTab";
@@ -424,29 +425,19 @@ export default function SettingsPanel({
                         isSet={settings.chatApiKeySet}
                         onSave={(key) => onUpdate({ chatApiKey: key })}
                       />
-                      <label className="row-field">
-                        <span>API URL</span>
-                        <input
-                          type="text"
-                          value={settings.chatApiUrl}
-                          onChange={(e) => onUpdate({ chatApiUrl: e.target.value })}
-                          placeholder="https://api.openai.com/v1"
-                          autoComplete="off"
-                        />
-                        {providerUrlWarning(settings.chatApiUrl) && (
-                          <p className="settings-warning">{providerUrlWarning(settings.chatApiUrl)}</p>
-                        )}
-                      </label>
-                      <label className="row-field">
-                        <span>Model ID</span>
-                        <input
-                          type="text"
-                          value={settings.orchestratorModel}
-                          onChange={(e) => onUpdate({ orchestratorModel: e.target.value })}
-                          placeholder={DEFAULT_ORCHESTRATOR_MODEL}
-                          autoComplete="off"
-                        />
-                      </label>
+                      <TextField
+                        label="API URL"
+                        value={settings.chatApiUrl}
+                        placeholder="https://api.openai.com/v1"
+                        warningFor={providerUrlWarning}
+                        onCommit={(chatApiUrl) => onUpdate({ chatApiUrl })}
+                      />
+                      <TextField
+                        label="Model ID"
+                        value={settings.orchestratorModel}
+                        placeholder={DEFAULT_ORCHESTRATOR_MODEL}
+                        onCommit={(orchestratorModel) => onUpdate({ orchestratorModel })}
+                      />
                     </div>
                   </div>
                 </SettingsAccordion>
@@ -486,39 +477,25 @@ export default function SettingsPanel({
                         isSet={settings.voiceApiKeySet}
                         onSave={(key) => onUpdate({ voiceApiKey: key })}
                       />
-                      <label className="row-field">
-                        <span>API URL</span>
-                        <input
-                          type="text"
-                          value={settings.voiceApiUrl}
-                          onChange={(e) => onUpdate({ voiceApiUrl: e.target.value })}
-                          placeholder="https://api.openai.com/v1"
-                          autoComplete="off"
-                        />
-                        {providerUrlWarning(settings.voiceApiUrl) && (
-                          <p className="settings-warning">{providerUrlWarning(settings.voiceApiUrl)}</p>
-                        )}
-                      </label>
-                      <label className="row-field">
-                        <span>Transcription model</span>
-                        <input
-                          type="text"
-                          value={settings.voiceTranscriptionModel}
-                          onChange={(e) => onUpdate({ voiceTranscriptionModel: e.target.value })}
-                          placeholder="whisper-1"
-                          autoComplete="off"
-                        />
-                      </label>
-                      <label className="row-field">
-                        <span>Speech (TTS) model</span>
-                        <input
-                          type="text"
-                          value={settings.voiceTtsModel}
-                          onChange={(e) => onUpdate({ voiceTtsModel: e.target.value })}
-                          placeholder="gpt-4o-mini-tts"
-                          autoComplete="off"
-                        />
-                      </label>
+                      <TextField
+                        label="API URL"
+                        value={settings.voiceApiUrl}
+                        placeholder="https://api.openai.com/v1"
+                        warningFor={providerUrlWarning}
+                        onCommit={(voiceApiUrl) => onUpdate({ voiceApiUrl })}
+                      />
+                      <TextField
+                        label="Transcription model"
+                        value={settings.voiceTranscriptionModel}
+                        placeholder="whisper-1"
+                        onCommit={(voiceTranscriptionModel) => onUpdate({ voiceTranscriptionModel })}
+                      />
+                      <TextField
+                        label="Speech (TTS) model"
+                        value={settings.voiceTtsModel}
+                        placeholder="gpt-4o-mini-tts"
+                        onCommit={(voiceTtsModel) => onUpdate({ voiceTtsModel })}
+                      />
                       <label className="row-field">
                         <span>Speech (TTS) voice</span>
                         <Combobox
@@ -683,16 +660,12 @@ export default function SettingsPanel({
                     plain setting; the rest live in the cross-agent user-fact store and reach
                     every agent's prompt, so they are saved through useUserContext. */}
                 <div className="card" id="settings-about-you">
-                  <label className="row-field">
-                    <span>What should I call you?</span>
-                    <input
-                      type="text"
-                      value={settings.userName}
-                      onChange={(e) => onUpdate({ userName: e.target.value })}
-                      placeholder="Your name"
-                      autoComplete="off"
-                    />
-                  </label>
+                  <TextField
+                    label="What should I call you?"
+                    value={settings.userName}
+                    placeholder="Your name"
+                    onCommit={(userName) => onUpdate({ userName })}
+                  />
                   {USER_CONTEXT_FIELDS.map((field) => (
                     <label className="row-field" key={field.key}>
                       <span>{field.label}</span>


### PR DESCRIPTION
Closes **X5** — the last open finding on the worklist.

## Root cause

Every text field in Settings wrote **per character**: one IPC round trip and one SQLite write each, with the full settings blob coming back to re-render the panel. Pasting a long URL was dozens of writes for a single edit.

And because the response was reconciled into state, a value the write boundary refused **snapped away mid-typing**.

## What changed

`TextField` is the same shape the other fields already grew into:

- `ApiKeyField` was forced into it by [#24](https://github.com/maneja81/OpenOrbit/pull/24), when the keys stopped being returned
- `NumberField` by [#36](https://github.com/maneja81/OpenOrbit/pull/36), when the bounds started being enforced
- `AgentAccordion`'s prompt textarea has always committed on blur

This brings the last six into line: both API URLs, the three model ids, and the user's name. `grep` for `onChange={(e) => onUpdate({` now returns nothing.

**Blank is meaningful here**, unlike an API key — an emptied field commits, because that's how a URL or model returns to the provider default. Whitespace-only changes don't, since the value is trimmed before comparing.

The provider-URL warning from [#42](https://github.com/maneja81/OpenOrbit/pull/42) moves onto the **draft** rather than the stored value, so it appears while a URL is being typed instead of only after it's saved.

## Validated in the app

Focused the name field, typed `Ada` (three keystrokes), then read the stored settings before and after blur:

```
BEFORE blur: undefined
AFTER  blur: "Ada"
```

Three keystrokes, zero writes; one write on blur.

## Tests

+9: one commit for many keystrokes, Enter, trimming, no commit when unchanged or whitespace-only, an emptied field committing, following the stored value when it changes underneath, and the warning reacting to the draft in both directions.

## Verify

| | |
|---|---|
| `npm run lint` | ✓ clean |
| `npx tsc -b` | ✓ clean |
| `npm run build` | ✓ clean |
| `npm test` | ✓ **1032 passed / 104 files** (1023 before — +9) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)