### PR TITLE
Show the logo at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # OpenOrbit
 
+<img src="public/openorbit-logo.svg" alt="OpenOrbit logo" width="120" height="120">
+
 A desktop app that runs a team of AI agents on your own machine — a central orchestrator
 that delegates to specialist sub-agents, each with its own tools, connected to your files,
 apps, and Google account.
-
-<img src="public/openorbit.webp" alt="OpenOrbit orbit UI screenshot">
 
 > **This is a personal side project — built evenings and weekends, around a full-time job.
 > No support, no roadmap commitments, no guarantees.**
 >
 > The app is built and works. There are no packaged downloads yet, so running it means
 > [building from source](#build-and-run). Dates aren't promised.
+
+<img src="public/openorbit.webp" alt="OpenOrbit orbit UI screenshot">
 
 ## How it works
 


### PR DESCRIPTION
Salvages the one thing `docs/readme-current-state` had that `develop` didn't, so that branch can be retired.

## What was actually on that branch

I'd twice described it as holding "unmerged README/favicon work". Checking properly:

| | |
|---|---|
| `openorbit-logo.svg`, `openorbit.webp` | already on `develop` |
| `favicon.svg` | the branch has the **pre-#14 original**, not an alternative — `develop` is newer |
| `openorbit-logo.jpg` / `.png` | on `develop`, absent from the branch |
| **README layout** | **the only thing `develop` lacked** |

## The change

Logo above the intro, screenshot moved below the callout — so the first thing on the page is the project rather than a wall of caveats.

Applied as a four-line edit rather than merging the branch, which would have reverted the README work from [#9](https://github.com/maneja81/OpenOrbit/pull/9) and [#14](https://github.com/maneja81/OpenOrbit/pull/14).

`public/openorbit-logo.svg` is confirmed present on `develop`, so the reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)