### PR TITLE
Give modals a name, a focus trap, and focus restoration (U1–U4)

### DIFF
--- a/src/components/atoms/Combobox.test.tsx
+++ b/src/components/atoms/Combobox.test.tsx
@@ -30,7 +30,7 @@ describe("Combobox", () => {
   it("does not close the modal it is opened inside", () => {
     const onClose = vi.fn();
     render(
-      <Modal open onClose={onClose}>
+      <Modal open onClose={onClose} label="Settings">
         <Combobox value="docs" options={OPTIONS} onChange={vi.fn()} ariaLabel="Category" />
       </Modal>
     );
@@ -47,7 +47,7 @@ describe("Combobox", () => {
   it("leaves Escape to the modal once its menu is closed", () => {
     const onClose = vi.fn();
     render(
-      <Modal open onClose={onClose}>
+      <Modal open onClose={onClose} label="Settings">
         <Combobox value="docs" options={OPTIONS} onChange={vi.fn()} ariaLabel="Category" />
       </Modal>
     );

--- a/src/components/atoms/Modal.test.tsx
+++ b/src/components/atoms/Modal.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { useState } from "react";
 import Modal from "./Modal";
@@ -12,7 +13,7 @@ describe("Modal", () => {
   it("closes on Escape", () => {
     const onClose = vi.fn();
     render(
-      <Modal open onClose={onClose}>
+      <Modal open onClose={onClose} label="Body">
         <p>body</p>
       </Modal>
     );
@@ -32,9 +33,9 @@ describe("Modal", () => {
       // the two listeners.
       const [innerOpen, setInnerOpen] = useState(false);
       return (
-        <Modal open onClose={onCloseOuter}>
+        <Modal open onClose={onCloseOuter} label="Outer">
           <button onClick={() => setInnerOpen(true)}>open inner</button>
-          <Modal open={innerOpen} onClose={onCloseInner}>
+          <Modal open={innerOpen} onClose={onCloseInner} label="Inner">
             <p>inner</p>
           </Modal>
         </Modal>
@@ -56,9 +57,9 @@ describe("Modal", () => {
     function Nested() {
       const [innerOpen, setInnerOpen] = useState(true);
       return (
-        <Modal open onClose={onCloseOuter}>
+        <Modal open onClose={onCloseOuter} label="Outer">
           <button onClick={() => setInnerOpen(false)}>close inner</button>
-          <Modal open={innerOpen} onClose={() => setInnerOpen(false)}>
+          <Modal open={innerOpen} onClose={() => setInnerOpen(false)} label="Inner">
             <p>inner</p>
           </Modal>
         </Modal>
@@ -76,7 +77,7 @@ describe("Modal", () => {
   it("ignores Escape while closed", () => {
     const onClose = vi.fn();
     render(
-      <Modal open={false} onClose={onClose}>
+      <Modal open={false} onClose={onClose} label="Body">
         <p>body</p>
       </Modal>
     );
@@ -84,5 +85,171 @@ describe("Modal", () => {
     fireEvent.keyDown(document, { key: "Escape" });
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // U1 — `aria-modal="true"` with no name announces as an unnamed "dialog".
+  it("gives the dialog an accessible name", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="Add from URL">
+        <p>body</p>
+      </Modal>
+    );
+
+    expect(screen.getByRole("dialog", { name: "Add from URL" })).toBeInTheDocument();
+  });
+
+  // U4 — the focus-on-open query only matched input/textarea, so a modal built from buttons
+  // alone (HttpToolApprovalModal, AgentInfoModal) moved focus nowhere at all.
+  it("focuses the first text field when the modal has one", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="With field">
+        <button>first</button>
+        <input aria-label="name" />
+      </Modal>
+    );
+
+    expect(document.activeElement).toBe(screen.getByLabelText("name"));
+  });
+
+  it("focuses the panel when the modal has no text field, not its first action", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="Run this tool?">
+        <button>Don't run</button>
+        <button>Approve</button>
+      </Modal>
+    );
+
+    // Deliberately the panel and not "Don't run": opening with an action focused makes Enter
+    // answer a question the user has not read yet.
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+  });
+
+  it("ignores checkboxes when choosing what to focus", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="Knowledge">
+        <input type="checkbox" aria-label="select row" />
+        <input aria-label="search" />
+      </Modal>
+    );
+
+    expect(document.activeElement).toBe(screen.getByLabelText("search"));
+  });
+
+  // U2 — `aria-modal="true"` asserts the background is inert; nothing enforced it for focus.
+  it("wraps Tab from the last control back to the first", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="Trapped">
+        <button>first</button>
+        <button>last</button>
+      </Modal>
+    );
+
+    const first = screen.getByText("first");
+    const last = screen.getByText("last");
+    last.focus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("wraps Shift+Tab from the first control back to the last", () => {
+    render(
+      <Modal open onClose={vi.fn()} label="Trapped">
+        <button>first</button>
+        <button>last</button>
+      </Modal>
+    );
+
+    const first = screen.getByText("first");
+    const last = screen.getByText("last");
+    first.focus();
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("traps Tab in the inner modal only, leaving the outer one alone", () => {
+    // Inner opens on click, not on mount — same as the Escape tests above, and the same as the
+    // only nesting the app actually does (KnowledgeModal opens AddUrlModal). Mounting both
+    // already-open registers them child-effect-first, which is not a state the app reaches.
+    function Nested() {
+      const [innerOpen, setInnerOpen] = useState(false);
+      return (
+        <Modal open onClose={vi.fn()} label="Outer">
+          <button onClick={() => setInnerOpen(true)}>open inner</button>
+          <Modal open={innerOpen} onClose={vi.fn()} label="Inner">
+            <button>inner first</button>
+            <button>inner last</button>
+          </Modal>
+        </Modal>
+      );
+    }
+
+    render(<Nested />);
+    fireEvent.click(screen.getByText("open inner"));
+    const innerFirst = screen.getByText("inner first");
+    screen.getByText("inner last").focus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(document.activeElement).toBe(innerFirst);
+  });
+
+  // U3 — nothing recorded the trigger, so closing any modal dropped focus to <body> and a
+  // keyboard user restarted from the top of the document.
+  it("restores focus to whatever was focused before it opened", () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>trigger</button>
+          <Modal open={open} onClose={() => setOpen(false)} label="Body">
+            <button onClick={() => setOpen(false)}>close</button>
+          </Modal>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByText("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    fireEvent.click(screen.getByText("close"));
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not throw when the trigger was removed while the modal was open", () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      const [triggerPresent, setTriggerPresent] = useState(true);
+      return (
+        <>
+          {triggerPresent && (
+            <button
+              onClick={() => {
+                setOpen(true);
+                setTriggerPresent(false);
+              }}
+            >
+              trigger
+            </button>
+          )}
+          <Modal open={open} onClose={() => setOpen(false)} label="Body">
+            <button onClick={() => setOpen(false)}>close</button>
+          </Modal>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByText("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    expect(() => fireEvent.click(screen.getByText("close"))).not.toThrow();
   });
 });

--- a/src/components/atoms/Modal.tsx
+++ b/src/components/atoms/Modal.tsx
@@ -6,6 +6,10 @@ interface ModalProps {
   onClose: () => void;
   children: ReactNode;
   className?: string;
+  /** Accessible name for the dialog. Required rather than optional: `aria-modal="true"` without
+   * a name announces as an unnamed "dialog", which is what every modal in the app did before.
+   * Pass the same words as the visible heading so the two can't drift. */
+  label: string;
 }
 
 /** Every open Modal listens on `document` for Escape, so one keypress reached all of them — a
@@ -16,27 +20,72 @@ interface ModalProps {
  * the component and unique per instance. */
 const openModals: RefObject<HTMLDivElement | null>[] = [];
 
-export default function Modal({ open, onClose, children, className = "" }: ModalProps) {
+/** Tab order inside the panel. `:not([disabled])` matters for the type-to-confirm modals, whose
+ * primary button is disabled until the confirm word matches — a trap that cycled onto it would
+ * strand the keyboard on a control that does nothing. */
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export default function Modal({ open, onClose, children, className = "", label }: ModalProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const returnFocusTo = useRef<HTMLElement | null>(null);
 
   // Registration is deliberately kept in its own effect keyed on `open` alone. Folding it into
   // the keydown effect below would re-order the stack every time the parent re-rendered with a
   // fresh `onClose`, putting an outer modal back on top of the inner one it just opened.
+  //
+  // Focus restoration rides along here because it wants exactly this lifecycle: capture on the
+  // way in, restore on the way out, once per open — not once per `onClose` identity change.
   useEffect(() => {
     if (!open) return;
+    const previouslyFocused = document.activeElement;
+    returnFocusTo.current = previouslyFocused instanceof HTMLElement ? previouslyFocused : null;
     openModals.push(panelRef);
     return () => {
       const i = openModals.indexOf(panelRef);
       if (i !== -1) openModals.splice(i, 1);
+      // `isConnected` guards the case where the trigger was itself removed while the modal was
+      // open (deleting a row from its own row-level button), where focusing it does nothing and
+      // focus would silently fall to <body> anyway.
+      const target = returnFocusTo.current;
+      if (target?.isConnected) target.focus();
+      returnFocusTo.current = null;
     };
   }, [open]);
 
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
       if (openModals[openModals.length - 1] !== panelRef) return;
-      onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      // `aria-modal="true"` tells assistive tech the rest of the page is inert. Nothing enforced
+      // that for actual keyboard focus, so Tab from the last control walked out of the dialog
+      // and into the page behind the backdrop — where the user could operate the app while a
+      // modal claimed to be modal.
+      if (e.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (focusable.length === 0) {
+        // Nothing to cycle between: keep focus on the panel rather than letting Tab escape.
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      // Focus sitting on the panel itself (the U4 fallback below) counts as "before the first
+      // control", so a plain Tab from there should land on `first`, not escape.
+      if (e.shiftKey && (active === first || active === panel)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
@@ -47,19 +96,39 @@ export default function Modal({ open, onClose, children, className = "" }: Modal
   // rather than per-modal so every current and future Modal user gets it automatically.
   // Checkboxes/radios are excluded since they're rarely the field a modal "is about" (e.g.
   // KnowledgeModal's per-row selection checkboxes shouldn't steal focus on open).
+  //
+  // The fallbacks matter as much as the preferred case: HttpToolApprovalModal and
+  // AgentInfoModal contain no text field at all, so this used to move focus nowhere and left
+  // a keyboard user tabbing in from the document start to reach Approve / Don't run.
   useEffect(() => {
     if (!open) return;
-    const firstField = panelRef.current?.querySelector<HTMLElement>(
+    const panel = panelRef.current;
+    if (!panel) return;
+    const firstField = panel.querySelector<HTMLElement>(
       'input:not([type="checkbox"]):not([type="radio"]), textarea'
     );
-    firstField?.focus();
+    if (firstField) {
+      firstField.focus();
+      return;
+    }
+    // No text field. Prefer the panel itself over the first button: on a consequential confirm
+    // the first control is an action, and opening with it focused makes Enter approve something
+    // the user has not read yet.
+    panel.focus();
   }, [open]);
 
   if (!open) return null;
 
   return createPortal(
     <div className="modal-backdrop" onMouseDown={(e) => e.target === e.currentTarget && onClose()}>
-      <div className={`modal-panel${className ? ` ${className}` : ""}`} role="dialog" aria-modal="true" ref={panelRef}>
+      <div
+        className={`modal-panel${className ? ` ${className}` : ""}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        tabIndex={-1}
+        ref={panelRef}
+      >
         {children}
       </div>
     </div>,

--- a/src/components/atoms/TagMultiSelect.test.tsx
+++ b/src/components/atoms/TagMultiSelect.test.tsx
@@ -29,7 +29,7 @@ describe("TagMultiSelect", () => {
   it("does not close the modal it is opened inside", () => {
     const onClose = vi.fn();
     render(
-      <Modal open onClose={onClose}>
+      <Modal open onClose={onClose} label="Settings">
         <TagMultiSelect values={[]} options={OPTIONS} onChange={vi.fn()} ariaLabel="Tools" />
       </Modal>
     );

--- a/src/components/molecules/AgentInfoModal.tsx
+++ b/src/components/molecules/AgentInfoModal.tsx
@@ -28,7 +28,7 @@ export default function AgentInfoModal({
   connectorToolCount,
 }: AgentInfoModalProps) {
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal open={open} onClose={onClose} label={name}>
       <div className="km-header">
         <span className="km-title">
           {icon && <TablerIcon name={icon} />} {name}

--- a/src/components/molecules/DeleteConfirmModal.tsx
+++ b/src/components/molecules/DeleteConfirmModal.tsx
@@ -27,7 +27,7 @@ export default function DeleteConfirmModal({ open, itemLabel, onConfirm, onCance
   };
 
   return (
-    <Modal open={open} onClose={handleCancel}>
+    <Modal open={open} onClose={handleCancel} label={`Delete ${itemLabel}?`}>
       <div className="delete-confirm-modal danger-zone">
         <h3>Delete {itemLabel}?</h3>
         <p className="danger-zone-desc">This cannot be undone.</p>

--- a/src/components/molecules/HttpToolApprovalModal.tsx
+++ b/src/components/molecules/HttpToolApprovalModal.tsx
@@ -37,7 +37,11 @@ export default function HttpToolApprovalModal({ approval, onRespond }: HttpToolA
   const formattedArgs = formatArgs(approval?.args);
 
   return (
-    <Modal open={approval !== null} onClose={() => approval && onRespond(approval.approvalId, false)}>
+    <Modal
+      open={approval !== null}
+      onClose={() => approval && onRespond(approval.approvalId, false)}
+      label="Run this tool?"
+    >
       <div className="http-approval-body">
         <h3>Run this tool?</h3>
         <p className="http-approval-lead">

--- a/src/components/organisms/AddUrlModal.tsx
+++ b/src/components/organisms/AddUrlModal.tsx
@@ -69,7 +69,7 @@ export default function AddUrlModal({ open, onClose }: AddUrlModalProps) {
   };
 
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} label="Add from URL">
       <div className="km-header">
         <span className="km-title">Add from URL</span>
         <button className="widget-icon-btn" aria-label="Close" onClick={handleClose}>

--- a/src/components/organisms/ChatHistoryModal.tsx
+++ b/src/components/organisms/ChatHistoryModal.tsx
@@ -52,7 +52,7 @@ export default function ChatHistoryModal({ open, onClose, autoLoadRemoteImages }
   const newerDisabled = loading || safePage <= 0;
 
   return (
-    <Modal open={open} onClose={onClose} className="modal-panel--chat-history">
+    <Modal open={open} onClose={onClose} className="modal-panel--chat-history" label="Chat History">
       <div className="km-header">
         <span className="km-title">Chat History</span>
         <div className="widget-header-actions">

--- a/src/components/organisms/KnowledgeModal.tsx
+++ b/src/components/organisms/KnowledgeModal.tsx
@@ -70,7 +70,7 @@ export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
   };
 
   return (
-    <Modal open={open} onClose={handleClose}>
+    <Modal open={open} onClose={handleClose} label="Knowledge">
       <div className="km-header">
         <span className="km-title">Knowledge</span>
         <div className="widget-header-actions">

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -363,7 +363,7 @@ export default function SettingsPanel({
   const meta = SECTION_META[activeSection];
 
   return (
-    <Modal open={open} onClose={onClose} className="modal-panel--settings">
+    <Modal open={open} onClose={onClose} className="modal-panel--settings" label="Settings">
       <div className="settings-window-body">
         <SettingsSidebar
           groups={NAV_GROUPS}


### PR DESCRIPTION
## What changed

`Modal` declared `aria-modal="true"` but implemented none of what that asserts. It now takes a required `label`, keeps Tab inside the dialog, restores focus to whatever opened it, and focuses *something* even when the modal has no text field. All 7 call sites pass a label mirroring their visible heading.

## Root cause

Four separate gaps in the same ~20 lines of `atoms/Modal.tsx`:

- **U1** — `role="dialog"` with no `aria-label`/`aria-labelledby`, and no prop to supply one. Every modal announced as an unnamed "dialog".
- **U2** — no focus trap. Tab from the last control walked into the page behind the backdrop, so the user could operate the app while a modal claimed the rest was inert.
- **U3** — nothing recorded the trigger, so closing any modal dropped focus to `<body>`.
- **U4** — the focus-on-open query only matched `input`/`textarea`. `HttpToolApprovalModal` and `AgentInfoModal` contain neither, so focus moved nowhere and a keyboard user tabbed in from the document start to reach Approve / Don't run.

Batched into one PR because they are four faces of the same missing capability and conflict with each other by construction.

## Testing

- Unit/integration: **1041 passed** (baseline 1032, +9 new Modal tests)
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData`.
  - Settings: `aria-label="Settings"`, focus landed on the search `<input>`, Tab from the last of 17 controls wrapped to the first, Escape closed it and returned focus to `#setbtn`.
  - AgentInfoModal: `aria-label="Cipher"`, 0 text fields, focus landed on the panel itself (the U4 fallback), Tab stayed on its single control.

## Notes

Two things found while validating, both filed rather than fixed here:

- **driver.js's tour popover wins Tab over the modal.** With the first-run tour active, Tab from inside a modal lands on `.driver-popover-close-btn`. `preventDefault()` stops the browser's default Tab but not driver.js's own document-level handler. Pre-existing; unrelated to this change.
- **The orbit's agent nodes are not keyboard reachable at all.** `AgentOrb.tsx:38` and `OrchestratorOrb.tsx:39` are `motion.div` with `onClick` and no `role`/`tabIndex`/`onKeyDown`. Fixing the modal's focus handling doesn't help if the thing that opens it can't be reached by keyboard.

Nesting behaviour is unchanged: the Escape stack still closes innermost-first, and the Tab trap applies only to the topmost modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)