### PR TITLE
Stop a mis-aimed click from declining a tool call (U5)

### DIFF
--- a/src/components/atoms/Modal.test.tsx
+++ b/src/components/atoms/Modal.test.tsx
@@ -87,6 +87,51 @@ describe("Modal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("closes on a backdrop click by default", () => {
+    const onClose = vi.fn();
+    const { baseElement } = render(
+      <Modal open onClose={onClose} label="Body">
+        <p>body</p>
+      </Modal>
+    );
+
+    fireEvent.mouseDown(baseElement.querySelector(".modal-backdrop")!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // U5 — for a modal whose onClose is an answer rather than a dismissal, a mis-aimed click must
+  // not decide it. Escape stays live; it is deliberate.
+  it("ignores a backdrop click when closeOnBackdrop is false", () => {
+    const onClose = vi.fn();
+    const { baseElement } = render(
+      <Modal open onClose={onClose} label="Body" closeOnBackdrop={false}>
+        <p>body</p>
+      </Modal>
+    );
+
+    fireEvent.mouseDown(baseElement.querySelector(".modal-backdrop")!);
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a click that lands inside the panel", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} label="Body">
+        <p>body</p>
+      </Modal>
+    );
+
+    fireEvent.mouseDown(screen.getByText("body"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   // U1 — `aria-modal="true"` with no name announces as an unnamed "dialog".
   it("gives the dialog an accessible name", () => {
     render(

--- a/src/components/atoms/Modal.tsx
+++ b/src/components/atoms/Modal.tsx
@@ -10,6 +10,13 @@ interface ModalProps {
    * a name announces as an unnamed "dialog", which is what every modal in the app did before.
    * Pass the same words as the visible heading so the two can't drift. */
   label: string;
+  /** Whether a click on the backdrop closes the modal. Default true.
+   *
+   * Set false for a modal whose `onClose` is itself an answer rather than a dismissal —
+   * HttpToolApprovalModal declines the tool call, so a mis-aimed click would silently answer a
+   * security prompt. Escape stays live either way: it is a deliberate keypress, and WAI-ARIA
+   * expects a dialog to honour it. */
+  closeOnBackdrop?: boolean;
 }
 
 /** Every open Modal listens on `document` for Escape, so one keypress reached all of them — a
@@ -26,7 +33,14 @@ const openModals: RefObject<HTMLDivElement | null>[] = [];
 const FOCUSABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-export default function Modal({ open, onClose, children, className = "", label }: ModalProps) {
+export default function Modal({
+  open,
+  onClose,
+  children,
+  className = "",
+  label,
+  closeOnBackdrop = true,
+}: ModalProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const returnFocusTo = useRef<HTMLElement | null>(null);
 
@@ -120,7 +134,10 @@ export default function Modal({ open, onClose, children, className = "", label }
   if (!open) return null;
 
   return createPortal(
-    <div className="modal-backdrop" onMouseDown={(e) => e.target === e.currentTarget && onClose()}>
+    <div
+      className="modal-backdrop"
+      onMouseDown={(e) => closeOnBackdrop && e.target === e.currentTarget && onClose()}
+    >
       <div
         className={`modal-panel${className ? ` ${className}` : ""}`}
         role="dialog"

--- a/src/components/molecules/HttpToolApprovalModal.test.tsx
+++ b/src/components/molecules/HttpToolApprovalModal.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import HttpToolApprovalModal, { type PendingToolApproval } from "./HttpToolApprovalModal";
+
+const APPROVAL: PendingToolApproval = {
+  approvalId: "ap-1",
+  toolName: "jsonplaceholder_delete_post",
+  agentName: "Atlas",
+  args: '{"id":1}',
+};
+
+/** This modal gates a paused agent run over a real side effect — a POST, PUT or DELETE against
+ * someone's API. Every exit has to answer the call, and no accidental one may answer it. */
+describe("HttpToolApprovalModal", () => {
+  afterEach(cleanup);
+
+  it("approves on Approve", () => {
+    const onRespond = vi.fn();
+    render(<HttpToolApprovalModal approval={APPROVAL} onRespond={onRespond} />);
+
+    fireEvent.click(screen.getByText("Approve"));
+
+    expect(onRespond).toHaveBeenCalledWith("ap-1", true);
+  });
+
+  it("declines on Don't run", () => {
+    const onRespond = vi.fn();
+    render(<HttpToolApprovalModal approval={APPROVAL} onRespond={onRespond} />);
+
+    fireEvent.click(screen.getByText("Don't run"));
+
+    expect(onRespond).toHaveBeenCalledWith("ap-1", false);
+  });
+
+  // U5 — the backdrop used to reach Modal's onClose, which for this modal is a decline. A click
+  // that missed the panel silently answered a security prompt.
+  it("ignores a click on the backdrop", () => {
+    const onRespond = vi.fn();
+    const { baseElement } = render(<HttpToolApprovalModal approval={APPROVAL} onRespond={onRespond} />);
+    const backdrop = baseElement.querySelector(".modal-backdrop");
+
+    expect(backdrop).not.toBeNull();
+    fireEvent.mouseDown(backdrop!);
+
+    expect(onRespond).not.toHaveBeenCalled();
+  });
+
+  it("still declines on Escape", () => {
+    const onRespond = vi.fn();
+    render(<HttpToolApprovalModal approval={APPROVAL} onRespond={onRespond} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onRespond).toHaveBeenCalledWith("ap-1", false);
+  });
+
+  it("renders nothing and answers nothing when there is no approval", () => {
+    const onRespond = vi.fn();
+    render(<HttpToolApprovalModal approval={null} onRespond={onRespond} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onRespond).not.toHaveBeenCalled();
+  });
+
+  it("names the dialog and pretty-prints the call arguments", () => {
+    render(<HttpToolApprovalModal approval={APPROVAL} onRespond={vi.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Run this tool?" })).toBeInTheDocument();
+    expect(screen.getByText(/"id": 1/)).toBeInTheDocument();
+  });
+
+  it("falls back to the raw string when the arguments are not JSON", () => {
+    render(<HttpToolApprovalModal approval={{ ...APPROVAL, args: "not json" }} onRespond={vi.fn()} />);
+
+    expect(screen.getByText("not json")).toBeInTheDocument();
+  });
+});

--- a/src/components/molecules/HttpToolApprovalModal.tsx
+++ b/src/components/molecules/HttpToolApprovalModal.tsx
@@ -30,8 +30,15 @@ function formatArgs(args: string | undefined): string | null {
  * paused while this is open (its timeout clock is stopped in ipc/agent.ts), so there is no
  * time pressure to answer — but leaving it unanswered for five minutes declines the call.
  *
- * Deliberately not dismissible by clicking away: closing without an answer would leave the
- * run hanging with no visible reason, so the only exits are Approve and Don't run.
+ * Every exit answers the call; none of them leave the run hanging. Approve runs the tool,
+ * Don't run and Escape decline it. Backdrop clicks are ignored (`closeOnBackdrop={false}`):
+ * this modal's onClose is an *answer*, not a dismissal, and a mis-aimed click landing outside
+ * the panel should not decide whether a POST or DELETE goes out. Escape is kept because it is
+ * a deliberate keypress that already means cancel, and a dialog that swallows it is worse for
+ * keyboard users than one that treats it as "no".
+ *
+ * An earlier version of this comment claimed the modal was not dismissible by clicking away.
+ * It was — backdrop mousedown reached Modal's onClose and silently declined the call.
  */
 export default function HttpToolApprovalModal({ approval, onRespond }: HttpToolApprovalModalProps) {
   const formattedArgs = formatArgs(approval?.args);
@@ -41,6 +48,7 @@ export default function HttpToolApprovalModal({ approval, onRespond }: HttpToolA
       open={approval !== null}
       onClose={() => approval && onRespond(approval.approvalId, false)}
       label="Run this tool?"
+      closeOnBackdrop={false}
     >
       <div className="http-approval-body">
         <h3>Run this tool?</h3>


### PR DESCRIPTION
## What changed

`Modal` gains `closeOnBackdrop` (default `true`, so every other modal behaves exactly as before). `HttpToolApprovalModal` opts out, so clicking outside the panel no longer answers the approval. Escape still declines. The doc comment now matches the code.

## Root cause

The component documented itself as *"deliberately not dismissible by clicking away… the only exits are Approve and Don't run"* — and then passed an `onClose` that declines the call. `Modal` closes on backdrop mousedown **and** Escape, so both ran it. The modal was dismissible, and dismissing it silently declined a tool call gating a POST/PUT/DELETE against a real API — no confirmation, no undo, no indication of what happened. The next thing the user saw was the agent reporting it couldn't run the tool.

Failing closed meant this was never dangerous, only wrong and invisible.

## Testing

- Unit/integration: **1051 passed** (baseline 1041, +10). New `HttpToolApprovalModal.test.tsx` covers approve, decline, backdrop-ignored, Escape-still-declines, the null-approval case, the accessible name, and the non-JSON args fallback. Three new `Modal` tests cover the default, the opt-out, and clicks landing inside the panel.
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData` — Settings still closes on a backdrop mousedown dispatched at the backdrop's own coordinates, and AgentInfoModal stays open when the mousedown lands inside the panel. Both confirm the default path is unregressed.

## Notes

**App validation is partial (⚠️).** Reaching the approval modal itself needs an HTTP tool collection plus a live agent turn against a real API key, which this sandbox has neither of — the same gap `initial-fixes.md` records for S7's `needsApproval` path. The backdrop and Escape behaviour is covered by unit tests; what has *not* been exercised in the running app is a genuine paused run being declined by Escape.

**Not addressed here:** U6 — the five-minute auto-decline still has no visible countdown, so the one remaining way to answer this modal without meaning to is to walk away from it. That is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)