### PR TITLE
Take down an approval prompt that main already answered

### DIFF
--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -263,19 +263,37 @@ function createPausableDeadline(ms: number, message: string) {
   };
 }
 
+/** Why an approval was resolved by something other than the user answering it. */
+export type ApprovalSettledReason = "timeout" | "abandoned";
+
 /** Approvals awaiting a decision from the renderer, keyed by a main-generated approvalId.
  * Main-generated rather than reusing the SDK's callId so a renderer reply can only ever
- * resolve an approval this process actually asked for. */
+ * resolve an approval this process actually asked for.
+ *
+ * `sender` is held so the two paths that settle an approval *without* the user — the 5-minute
+ * timeout and run abandonment — can say so. Without that the prompt stayed on screen with the
+ * call already declined, and Approve became a silent no-op via the `!pending` guard below. */
 const pendingApprovals = new Map<
   string,
-  { requestId: string; resolve: (approved: boolean) => void; timer: NodeJS.Timeout }
+  {
+    requestId: string;
+    resolve: (approved: boolean) => void;
+    timer: NodeJS.Timeout;
+    sender: Electron.WebContents;
+  }
 >();
 
-function settleApproval(approvalId: string, approved: boolean): void {
+function settleApproval(approvalId: string, approved: boolean, reason?: ApprovalSettledReason): void {
   const pending = pendingApprovals.get(approvalId);
   if (!pending) return;
   clearTimeout(pending.timer);
   pendingApprovals.delete(approvalId);
+  // Only when something other than the user decided. A renderer that answered already knows,
+  // and telling it again would race its own queue removal. `isDestroyed` because a window
+  // closed mid-run is exactly when abandonment fires.
+  if (reason && !pending.sender.isDestroyed()) {
+    pending.sender.send("agent:stream-approval-settled", { approvalId, reason });
+  }
   pending.resolve(approved);
 }
 
@@ -284,9 +302,7 @@ function settleApproval(approvalId: string, approved: boolean): void {
 function abandonApprovalsFor(requestId: string): void {
   for (const [approvalId, pending] of pendingApprovals) {
     if (pending.requestId !== requestId) continue;
-    clearTimeout(pending.timer);
-    pendingApprovals.delete(approvalId);
-    pending.resolve(false);
+    settleApproval(approvalId, false, "abandoned");
   }
 }
 
@@ -395,8 +411,8 @@ export function registerAgentHandlers() {
         devLog(`[agent:runStream] requestId=${requestId} awaiting approval for tool=${meta.toolName ?? "(unknown)"}`);
         deadline.pause();
         return new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => settleApproval(approvalId, false), APPROVAL_TIMEOUT_MS);
-          pendingApprovals.set(approvalId, { requestId, resolve, timer });
+          const timer = setTimeout(() => settleApproval(approvalId, false, "timeout"), APPROVAL_TIMEOUT_MS);
+          pendingApprovals.set(approvalId, { requestId, resolve, timer, sender: event.sender });
           event.sender.send("agent:stream-approval", {
             requestId,
             approvalId,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -160,6 +160,12 @@ const agentsAPI = {
         args?: string;
       }) => void
     ): (() => void) => subscribeWithPayload("agent:stream-approval", callback),
+    /** Fires when an approval was resolved without the user — the 5-minute timeout expiring,
+     * or the run being abandoned. The prompt must come down: main has already answered on the
+     * user's behalf, so a later Approve resolves nothing and reads as the click doing nothing. */
+    onToolApprovalSettled: (
+      callback: (payload: { approvalId: string; reason: "timeout" | "abandoned" }) => void
+    ): (() => void) => subscribeWithPayload("agent:stream-approval-settled", callback),
     respondToApproval: (approvalId: string, approved: boolean): Promise<void> =>
       ipcRenderer.invoke("agent:approveTool", approvalId, approved),
     list: (): Promise<AgentDisplayRow[]> => ipcRenderer.invoke("agent:list"),

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -6,6 +6,7 @@ import SettingsPanel, { SettingsSection } from "@/components/organisms/SettingsP
 import KnowledgeModal from "@/components/organisms/KnowledgeModal";
 import ChatHistoryModal from "@/components/organisms/ChatHistoryModal";
 import HttpToolApprovalModal, { type PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
+import { approvalSettledMessage } from "@/lib/approvalSettledMessage";
 import ToolApprovalCard from "@/components/molecules/ToolApprovalCard";
 import OnboardingScreen, { type OnboardingAnswers } from "@/components/organisms/OnboardingScreen";
 import { useOrbitScene } from "@/hooks/useOrbitScene";
@@ -583,6 +584,32 @@ export default function AgentsApp() {
       setApprovalQueue((prev) => [...prev, { approvalId, toolName, agentName, args }]);
     });
   }, []);
+
+  // Mirrors approvalQueue so the settled handler below can name the tool that went away
+  // without taking the queue as a dependency — which would tear down and re-subscribe the
+  // IPC listener on every approval.
+  const approvalQueueRef = useRef<PendingToolApproval[]>([]);
+  useEffect(() => {
+    approvalQueueRef.current = approvalQueue;
+  }, [approvalQueue]);
+
+  // Main answers on the user's behalf when the 5-minute timeout expires or the run is
+  // abandoned. Nothing used to tell the renderer, so the prompt stayed up with the call
+  // already declined — and Approve then resolved nothing, which reads as the button being
+  // broken. Drop it here and say what happened, rather than letting it vanish silently.
+  useEffect(() => {
+    if (!hasAgentsAPI()) return;
+    return window.agentsAPI.agent.onToolApprovalSettled(({ approvalId, reason }) => {
+      const settled = approvalQueueRef.current.find((item) => item.approvalId === approvalId);
+      if (!settled) return;
+      setApprovalQueue((prev) => prev.filter((item) => item.approvalId !== approvalId));
+      appendMessage({
+        role: "assistant",
+        text: approvalSettledMessage(settled.toolName, reason),
+        avatarLabel: settings.agentName[0]?.toUpperCase() || "A",
+      });
+    });
+  }, [appendMessage, settings.agentName]);
 
   const pendingApproval = approvalQueue[0] ?? null;
 

--- a/src/lib/approvalSettledMessage.test.ts
+++ b/src/lib/approvalSettledMessage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { approvalSettledMessage } from "./approvalSettledMessage";
+
+describe("approvalSettledMessage", () => {
+  it("says a timed-out approval was declined and can be asked for again", () => {
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout");
+
+    expect(text).toContain("expired after 5 minutes");
+    expect(text).toContain("declined");
+    expect(text).toContain("Ask me again");
+  });
+
+  it("says an abandoned approval never ran, without inviting a retry", () => {
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "abandoned");
+
+    expect(text).toContain("the run ended");
+    expect(text).toContain("never ran");
+    // Retrying the approval alone achieves nothing once the run is gone — the user has to
+    // start a new turn, so this case must not suggest otherwise.
+    expect(text).not.toContain("Ask me again");
+  });
+
+  it("humanizes the tool name rather than showing the raw identifier", () => {
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout");
+
+    expect(text).not.toContain("jsonplaceholder_delete_post");
+  });
+
+  it("both reasons make clear the call did not run", () => {
+    expect(approvalSettledMessage("x_y", "timeout")).toMatch(/declined/);
+    expect(approvalSettledMessage("x_y", "abandoned")).toMatch(/never ran/);
+  });
+});

--- a/src/lib/approvalSettledMessage.ts
+++ b/src/lib/approvalSettledMessage.ts
@@ -1,0 +1,22 @@
+import { humanizeToolName } from "@/lib/humanizeToolName";
+
+/** Why an approval was resolved by something other than the user answering it. Mirrors
+ * `ApprovalSettledReason` in electron/main/ipc/agent.ts, which is the sender. */
+export type ApprovalSettledReason = "timeout" | "abandoned";
+
+/**
+ * What to tell the user when their approval prompt disappeared without them answering it.
+ *
+ * Both cases end the same way — the call did not run — but the reasons need different words:
+ * a timeout is worth retrying and the user's own delay caused it, while an abandoned run is
+ * not the user's doing and retrying the approval alone would achieve nothing.
+ *
+ * Silence was the old behaviour and the worst option: main had already declined the call while
+ * the prompt sat on screen, so pressing Approve resolved nothing and looked like a dead button.
+ */
+export function approvalSettledMessage(toolName: string, reason: ApprovalSettledReason): string {
+  const tool = humanizeToolName(toolName);
+  return reason === "timeout"
+    ? `The request to run ${tool} expired after 5 minutes, so it was declined. Ask me again if you still want it.`
+    : `The request to run ${tool} was dropped because the run ended, so it never ran.`;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -452,6 +452,9 @@ interface Window {
           args?: string;
         }) => void
       ) => () => void;
+      onToolApprovalSettled: (
+        callback: (payload: { approvalId: string; reason: "timeout" | "abandoned" }) => void
+      ) => () => void;
       respondToApproval: (approvalId: string, approved: boolean) => Promise<void>;
       list: () => Promise<AgentDisplayRow[]>;
       update: (


### PR DESCRIPTION
## What changed

When an approval is resolved by something other than the user — the 5-minute timeout expiring, or the run being abandoned — main now tells the renderer, and the renderer takes the prompt down and says what happened.

Found while implementing U6 (the auto-decline countdown). Shipping a countdown that reaches `0:00` and leaves a live-looking prompt behind would have been worse than shipping nothing, so this goes first. U6 follows separately.

## Root cause

`ipc/agent.ts:398` fired `settleApproval(approvalId, false)` on timeout: promise resolved, timer cleared, entry deleted — and **nothing sent to the renderer**. `AgentsApp.tsx` only ever *added* to `approvalQueue`; the sole removal path was the user answering.

Five minutes after a prompt appeared:

1. Main had already declined the call and told the agent.
2. The modal (or inline card) was still on screen, unchanged.
3. Pressing **Approve** invoked `agent:approveTool`, which hit `if (!pending) return` at `agent.ts:276` and did nothing. The prompt closed. Nothing ran. No error.

The `!pending` no-op is correct and stays — the comment at `agent.ts:538-540` explains it exists so a double-click or a late reply can't surface a failure. What was missing is that the renderer was never told to stop asking the question.

`abandonApprovalsFor` had the same shape and now routes through `settleApproval` rather than duplicating its bookkeeping.

## Design notes

- **Notify only when the user didn't decide.** A renderer that answered already knows; re-notifying would race its own queue removal. That's why `reason` is optional on `settleApproval` and absent on the `agent:approveTool` path.
- **`sender.isDestroyed()` guard** — a window closed mid-run is precisely when abandonment fires.
- **Both bridge declarations updated.** `preload/index.ts` and `src/vite-env.d.ts` each declare the surface and `tsc` does not catch editing only one — `session_logs.md` records that trap from the HTTP Tools work.
- **Different words per reason.** A timeout is the user's own delay and worth retrying; an abandoned run is neither, so it must not invite a retry that would achieve nothing.
- The settled handler reads the queue through a ref rather than taking it as a dependency, which would tear down and re-subscribe the IPC listener on every approval. The message is appended outside the state updater — a side effect inside one double-fires under StrictMode.

## Testing

- Unit/integration: **1055 passed** (baseline 1051, +4). New `lib/approvalSettledMessage.ts` with colocated tests pinning both branches and the humanized tool name.
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData` — `onToolApprovalSettled` is exposed on the bridge, returns a working unsubscribe, `onToolApproval` and `respondToApproval` are intact, and the app renders normally.

## Notes

**App validation is partial (⚠️).** Reaching a genuine approval needs an HTTP tool collection plus a live agent turn against a real API key, and then a five-minute wait to hit the timeout. The sandbox has neither the key nor the collection. What is verified live is the bridge surface; what is not is a real paused run expiring and clearing itself. Same gap `initial-fixes.md` records for S7.

There is no `AgentsApp.test.tsx` and mocking that surface would be fragile, so the queue-removal wiring is covered by the app check and the message logic by unit tests, rather than by a component test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)