### PR TITLE
Fix Browse Registry returning no results for every query

### DIFF
--- a/electron/main/ai/mcp.test.ts
+++ b/electron/main/ai/mcp.test.ts
@@ -63,6 +63,7 @@ import {
   updateMcpServer,
   deleteMcpServer,
   connectMcpServersForAgent,
+  searchMcpRegistry,
 } from "./mcp";
 
 describe("MCP server CRUD", () => {
@@ -166,5 +167,233 @@ describe("connectMcpServersForAgent", () => {
     const servers = await connectMcpServersForAgent([server.id]);
 
     expect(servers).toEqual([]);
+  });
+});
+
+// Trimmed to the fields the parser reads, but the *structure* is copied verbatim from a live
+// registry.modelcontextprotocol.io/v0/servers?search=filesystem response (2026-08-02). The
+// `{ server, _meta }` nesting is the whole point of this fixture: reading name/packages off the
+// wrapper instead of `server` returned zero results for every query in production, and the two
+// tests that existed at the time passed throughout because neither called this function.
+const REGISTRY_PAGE = {
+  servers: [
+    {
+      server: {
+        name: "com.pulsemcp/remote-filesystem",
+        description: "MCP server for remote filesystem operations on cloud storage.",
+        packages: [
+          {
+            registryType: "npm",
+            identifier: "remote-filesystem-mcp-server",
+            transport: { type: "stdio" },
+            runtimeArguments: [{ value: "-y", type: "positional" }],
+            environmentVariables: [
+              { name: "GCS_BUCKET", description: "Bucket name.", isRequired: true },
+              { name: "GCS_PROJECT_ID", description: "Project ID." },
+            ],
+          },
+        ],
+      },
+      _meta: { "io.modelcontextprotocol.registry/official": { isLatest: true } },
+    },
+    {
+      server: {
+        name: "io.github.bytedance/mcp-server-filesystem",
+        description: "MCP server for filesystem access",
+        packages: [
+          {
+            registryType: "npm",
+            identifier: "@agent-infra/mcp-server-filesystem",
+            transport: { type: "stdio" },
+          },
+        ],
+      },
+      _meta: { "io.modelcontextprotocol.registry/official": { isLatest: true } },
+    },
+    {
+      server: {
+        name: "io.github.example/py-only",
+        description: "Published for pypi only",
+        packages: [{ registryType: "pypi", identifier: "py-only-mcp", transport: { type: "stdio" } }],
+      },
+      _meta: { "io.modelcontextprotocol.registry/official": { isLatest: true } },
+    },
+  ],
+};
+
+function stubRegistry(page: unknown, response: Partial<{ ok: boolean; status: number; statusText: string }> = {}) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok ?? true,
+    status: response.status ?? 200,
+    statusText: response.statusText ?? "OK",
+    json: async () => page,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("searchMcpRegistry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads each entry through `server`, not off the wrapper", async () => {
+    stubRegistry(REGISTRY_PAGE);
+
+    const results = await searchMcpRegistry("filesystem");
+
+    // The regression guard: this returned [] for every query while the endpoint answered 200
+    // with 30 servers.
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.name)).toEqual([
+      "com.pulsemcp/remote-filesystem",
+      "io.github.bytedance/mcp-server-filesystem",
+    ]);
+    expect(results[0].description).toBe("MCP server for remote filesystem operations on cloud storage.");
+  });
+
+  it("emits -y exactly once, before the package identifier", async () => {
+    stubRegistry(REGISTRY_PAGE);
+
+    const results = await searchMcpRegistry("filesystem");
+
+    // The registry supplied `-y` itself for the first server and nothing for the second; both
+    // must come out identical. Appending runtimeArguments after the identifier, as this used to,
+    // produced `npx -y remote-filesystem-mcp-server -y`.
+    expect(results[0].args).toEqual(["-y", "remote-filesystem-mcp-server"]);
+    expect(results[1].args).toEqual(["-y", "@agent-infra/mcp-server-filesystem"]);
+  });
+
+  it("puts packageArguments after the identifier and runtimeArguments before it", async () => {
+    stubRegistry({
+      servers: [
+        {
+          server: {
+            name: "example/with-args",
+            packages: [
+              {
+                registryType: "npm",
+                identifier: "with-args-mcp",
+                runtimeArguments: [{ value: "-y" }],
+                packageArguments: [{ value: "--root" }, { value: "/tmp" }],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const [result] = await searchMcpRegistry("");
+
+    expect(result.args).toEqual(["-y", "with-args-mcp", "--root", "/tmp"]);
+  });
+
+  it("uses runtimeHint as the command and does not force -y onto a non-npx runtime", async () => {
+    stubRegistry({
+      servers: [
+        {
+          server: {
+            name: "example/bun",
+            packages: [{ registryType: "npm", identifier: "bun-mcp", runtimeHint: "bunx" }],
+          },
+        },
+      ],
+    });
+
+    const [result] = await searchMcpRegistry("");
+
+    expect(result.command).toBe("bunx");
+    expect(result.args).toEqual(["bun-mcp"]);
+  });
+
+  it("drops a package whose transport is not stdio, and keeps one that declares none", async () => {
+    stubRegistry({
+      servers: [
+        {
+          server: {
+            name: "example/remote",
+            packages: [{ registryType: "npm", identifier: "remote-mcp", transport: { type: "sse" } }],
+          },
+        },
+        {
+          server: {
+            name: "example/implicit-stdio",
+            packages: [{ registryType: "npm", identifier: "implicit-mcp" }],
+          },
+        },
+      ],
+    });
+
+    const results = await searchMcpRegistry("");
+
+    // MCPServerStdio is the only runtime here, so an sse package would install and then fail to
+    // start. A missing transport is the registry's own stdio default.
+    expect(results.map((r) => r.name)).toEqual(["example/implicit-stdio"]);
+  });
+
+  it("keys env by every declared variable but lists only the required ones", async () => {
+    stubRegistry(REGISTRY_PAGE);
+
+    const [result] = await searchMcpRegistry("filesystem");
+
+    expect(result.env).toEqual({ GCS_BUCKET: "", GCS_PROJECT_ID: "" });
+    expect(result.requiredEnv).toEqual(["GCS_BUCKET"]);
+  });
+
+  it("drops superseded versions but keeps an entry carrying no _meta", async () => {
+    stubRegistry({
+      servers: [
+        {
+          server: { name: "example/old", packages: [{ registryType: "npm", identifier: "old-mcp" }] },
+          _meta: { "io.modelcontextprotocol.registry/official": { isLatest: false } },
+        },
+        {
+          server: { name: "example/no-meta", packages: [{ registryType: "npm", identifier: "no-meta-mcp" }] },
+        },
+      ],
+    });
+
+    const results = await searchMcpRegistry("");
+
+    // Guarded on `=== false` rather than `!== true` precisely so the second entry survives.
+    expect(results.map((r) => r.name)).toEqual(["example/no-meta"]);
+  });
+
+  it("asks the registry for latest versions only, with the search term encoded", async () => {
+    const fetchMock = stubRegistry({ servers: [] });
+
+    await searchMcpRegistry("file system");
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain("version=latest");
+    expect(requestedUrl).toContain("search=file+system");
+  });
+
+  it("omits the search parameter entirely for an empty query", async () => {
+    const fetchMock = stubRegistry({ servers: [] });
+
+    await searchMcpRegistry("");
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain("version=latest");
+    expect(requestedUrl).not.toContain("search=");
+  });
+
+  it("aborts a slow registry rather than hanging the search", async () => {
+    const fetchMock = stubRegistry({ servers: [] });
+
+    await searchMcpRegistry("");
+
+    // The endpoint was observed timing out on two of three consecutive requests (2026-08-02);
+    // without a signal the Searching… state had no way back.
+    expect((fetchMock.mock.calls[0][1] as { signal?: AbortSignal }).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws with the status when the registry rejects the request", async () => {
+    stubRegistry({}, { ok: false, status: 503, statusText: "Service Unavailable" });
+
+    await expect(searchMcpRegistry("filesystem")).rejects.toThrow(
+      "MCP registry search failed (503): Service Unavailable"
+    );
   });
 });

--- a/electron/main/ai/mcp.ts
+++ b/electron/main/ai/mcp.ts
@@ -20,6 +20,9 @@ export interface McpServerInput {
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Defaults to enabled when omitted, which is what the manual Add form wants. Registry installs
+   * pass `false` so a third-party command is never briefly live between two writes. */
+  enabled?: boolean;
 }
 
 export interface McpServerUpdatePatch {
@@ -37,9 +40,40 @@ export interface McpSearchResult {
   command: string;
   args: string[];
   env: Record<string, string>;
+  /** Names of env vars the registry marks `isRequired`. Surfaced in the search results so an
+   * install that will fail without a key says so up front, rather than at connect time. */
+  requiredEnv: string[];
 }
 
 const MCP_REGISTRY_BASE_URL = "https://registry.modelcontextprotocol.io";
+const MCP_REGISTRY_TIMEOUT_MS = 15_000;
+const REGISTRY_OFFICIAL_META = "io.modelcontextprotocol.registry/official";
+
+interface RegistryArgument {
+  value?: string;
+}
+
+interface RegistryPackage {
+  registryType?: string;
+  identifier?: string;
+  runtimeHint?: string;
+  transport?: { type?: string };
+  runtimeArguments?: RegistryArgument[];
+  packageArguments?: RegistryArgument[];
+  environmentVariables?: { name?: string; description?: string; isRequired?: boolean }[];
+}
+
+/** One element of the registry's `servers` array. The server's own fields sit nested under
+ * `server`, not on this wrapper — reading them off the wrapper is what made every entry fail
+ * the identifier/name check and silently return zero results for every query. */
+interface RegistryEntry {
+  server?: {
+    name?: string;
+    description?: string;
+    packages?: RegistryPackage[];
+  };
+  _meta?: Record<string, { isLatest?: boolean } | undefined>;
+}
 
 function slugify(name: string): string {
   const slug = name
@@ -107,7 +141,7 @@ export function createMcpServer(input: McpServerInput): McpServerRow {
   const env = encryptEnv(input.env ?? {});
   db.prepare(
     "INSERT INTO mcp_servers (id, name, command, args, env, enabled) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(id, name, command, args, env, 1);
+  ).run(id, name, command, args, env, input.enabled === false ? 0 : 1);
   return db.prepare("SELECT * FROM mcp_servers WHERE id = ?").get(id) as McpServerRow;
 }
 
@@ -204,36 +238,72 @@ export async function testMcpServer(input: McpServerInput): Promise<{ tools: str
 /** Proxies the official MCP Registry (registry.modelcontextprotocol.io) server-side —
  * avoids a renderer-side fetch (CORS) and keeps the registry's response shape isolated
  * to this one place. Returns only stdio-installable candidates (command-based); remote/
- * URL-based servers are out of scope for this pass. */
+ * URL-based servers are out of scope for this pass.
+ *
+ * Verified against the live API (2026-08-02):
+ * - Every element of `servers` is a `{ server, _meta }` wrapper; the name/description/packages
+ *   live under `server`. Reading them off the wrapper returns **zero results for every query**,
+ *   which is what this function did before.
+ * - `?version=latest` is honoured server-side and is what keeps one server from filling the
+ *   page: `search=filesystem` returns 30 rows without it — 14 of them the same server — and 10
+ *   unique names with it, `nextCursor: null`.
+ * - `runtimeHint` is absent on most npm entries, so `npx` stays the fallback.
+ * - Non-npm packages (pypi/oci/nuget) are dropped: there is no runtime here that can start them.
+ */
 export async function searchMcpRegistry(query: string): Promise<McpSearchResult[]> {
-  const url = `${MCP_REGISTRY_BASE_URL}/v0/servers${query ? `?search=${encodeURIComponent(query)}` : ""}`;
-  const response = await fetch(url);
+  const params = new URLSearchParams({ version: "latest" });
+  if (query) params.set("search", query);
+  const response = await fetch(`${MCP_REGISTRY_BASE_URL}/v0/servers?${params.toString()}`, {
+    signal: AbortSignal.timeout(MCP_REGISTRY_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`MCP registry search failed (${response.status}): ${response.statusText}`);
   }
-  const data = (await response.json()) as {
-    servers?: {
-      name?: string;
-      description?: string;
-      packages?: { registryType?: string; identifier?: string; runtimeArguments?: { value?: string }[]; environmentVariables?: { name?: string; description?: string }[] }[];
-    }[];
-  };
+  const data = (await response.json()) as { servers?: RegistryEntry[] };
 
   const results: McpSearchResult[] = [];
   for (const entry of data.servers ?? []) {
-    const npmPackage = entry.packages?.find((pkg) => pkg.registryType === "npm");
-    if (!npmPackage?.identifier || !entry.name) continue;
+    const server = entry.server;
+    if (!server?.name) continue;
+    // Belt and braces for the `version=latest` param above: if the registry ever stops honouring
+    // it, this still collapses the list to one row per server. Tested `=== false` rather than
+    // `!== true` so an entry carrying no `_meta` at all is kept rather than silently dropped.
+    if (entry._meta?.[REGISTRY_OFFICIAL_META]?.isLatest === false) continue;
+
+    // A package can be npm-published and still speak a remote transport; `MCPServerStdio` is the
+    // only runtime here, so anything that isn't stdio would be installed and then fail to start.
+    // Missing `transport` is treated as stdio — that is the registry's own default.
+    const npmPackage = server.packages?.find(
+      (pkg) => pkg.registryType === "npm" && (pkg.transport?.type ?? "stdio") === "stdio"
+    );
+    if (!npmPackage?.identifier) continue;
+
+    // runtimeArguments are the *runtime's* flags (npx's `-y`); packageArguments are the server's
+    // own. They sit on opposite sides of the package identifier. Appending both after it, as this
+    // did before, produced `npx -y remote-filesystem-mcp-server -y`.
+    const runtimeArgs = (npmPackage.runtimeArguments ?? []).map((a) => a.value ?? "").filter(Boolean);
+    const packageArgs = (npmPackage.packageArguments ?? []).map((a) => a.value ?? "").filter(Boolean);
+    const command = npmPackage.runtimeHint ?? "npx";
+    // Without `-y`, npx stops to prompt for install confirmation and the server never starts.
+    // Only added when the registry didn't already supply it, so it can never appear twice.
+    if (command === "npx" && !runtimeArgs.includes("-y")) runtimeArgs.unshift("-y");
+
     const env: Record<string, string> = {};
+    const requiredEnv: string[] = [];
     for (const envVar of npmPackage.environmentVariables ?? []) {
-      if (envVar.name) env[envVar.name] = "";
+      if (!envVar.name) continue;
+      env[envVar.name] = "";
+      if (envVar.isRequired) requiredEnv.push(envVar.name);
     }
+
     results.push({
-      id: entry.name,
-      name: entry.name,
-      description: entry.description ?? "",
-      command: "npx",
-      args: ["-y", npmPackage.identifier, ...(npmPackage.runtimeArguments ?? []).map((a) => a.value ?? "").filter(Boolean)],
+      id: server.name,
+      name: server.name,
+      description: server.description ?? "",
+      command,
+      args: [...runtimeArgs, npmPackage.identifier, ...packageArgs],
       env,
+      requiredEnv,
     });
   }
   return results;

--- a/electron/main/ipc/mcp.ts
+++ b/electron/main/ipc/mcp.ts
@@ -52,6 +52,9 @@ export function registerMcpHandlers() {
       throw new Error("mcp:create requires a non-empty command");
     }
     assertArgsAndEnvShape(input, "mcp:create");
+    if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
+      throw new Error("mcp:create enabled must be a boolean");
+    }
     return createMcpServer(input);
   });
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -217,8 +217,13 @@ const agentsAPI = {
 
   mcp: {
     list: (): Promise<McpServerRow[]> => ipcRenderer.invoke("mcp:list"),
-    create: (input: { name: string; command: string; args?: string[]; env?: Record<string, string> }): Promise<McpServerRow> =>
-      ipcRenderer.invoke("mcp:create", input),
+    create: (input: {
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      enabled?: boolean;
+    }): Promise<McpServerRow> => ipcRenderer.invoke("mcp:create", input),
     update: (
       id: string,
       patch: { name?: string; command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }

--- a/src/components/organisms/McpServersTab.test.tsx
+++ b/src/components/organisms/McpServersTab.test.tsx
@@ -20,6 +20,27 @@ function server(id: string, name: string, overrides: Partial<McpServerRow> = {})
   };
 }
 
+function searchResult(name: string, overrides: Partial<McpSearchResult> = {}): McpSearchResult {
+  return {
+    id: name,
+    name,
+    description: `${name} server`,
+    command: "npx",
+    args: ["-y", `@modelcontextprotocol/server-${name}`],
+    env: {},
+    requiredEnv: [],
+    ...overrides,
+  };
+}
+
+/** Add → Browse Registry → Search, the three clicks every registry case starts with. */
+async function search(container: HTMLElement) {
+  fireEvent.click(screen.getByRole("button", { name: /Add MCP Server/ }));
+  fireEvent.click(screen.getByRole("button", { name: "Browse Registry" }));
+  fireEvent.click(screen.getByRole("button", { name: "Search" }));
+  await waitFor(() => expect(container.querySelector(".mcp-add-form")).not.toBeNull());
+}
+
 function renderTab(servers: McpServerRow[], overrides: Partial<Mcp> = {}) {
   const mcp: Mcp = {
     servers,
@@ -133,6 +154,7 @@ describe("McpServersTab", () => {
         command: "npx",
         args: ["-y", "@modelcontextprotocol/server-filesystem"],
         env: {},
+        requiredEnv: [],
       },
     ]);
     const { container } = renderTab([], { searchRegistry });
@@ -154,6 +176,62 @@ describe("McpServersTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
     await waitFor(() => expect(mcp.updateServer).toHaveBeenCalled());
     expect((mcp.updateServer as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe("b");
+  });
+
+  it("installs a registry result disabled, in a single write", async () => {
+    const searchRegistry = vi.fn(async () => [searchResult("filesystem")]);
+    const { container, mcp } = renderTab([], { searchRegistry });
+    await search(container);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Install" })).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: "Install" }));
+
+    await waitFor(() => expect(mcp.addServer).toHaveBeenCalledTimes(1));
+    expect((mcp.addServer as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({ enabled: false });
+    // The create-then-disable pair this replaced left a third-party command enabled whenever the
+    // second write failed — the one outcome installing-disabled exists to prevent.
+    expect(mcp.updateServer).not.toHaveBeenCalled();
+  });
+
+  it("says nothing matched only once a search has actually run", async () => {
+    const searchRegistry = vi.fn(async () => []);
+    renderTab([], { searchRegistry });
+    fireEvent.click(screen.getByRole("button", { name: /Add MCP Server/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse Registry" }));
+
+    // An empty list before the first search must not read as "no results". It was indistinguishable
+    // for as long as the parser returned nothing for every query.
+    expect(screen.queryByText(/No installable servers matched/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => expect(screen.getByText(/No installable servers matched/)).toBeTruthy());
+  });
+
+  it("names the keys a result needs before it is installed", async () => {
+    const searchRegistry = vi.fn(async () => [
+      searchResult("gcs", { requiredEnv: ["GCS_BUCKET", "GCS_PROJECT_ID"] }),
+      searchResult("plain"),
+    ]);
+    const { container } = renderTab([], { searchRegistry });
+    await search(container);
+    await waitFor(() => expect(container.querySelectorAll(".settings-folder-row")).toHaveLength(2));
+
+    // Installed servers land disabled with empty env values, so a required key that isn't named
+    // here surfaces only as an opaque Test connection failure later.
+    const warnings = container.querySelectorAll(".settings-warning");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].textContent).toContain("GCS_BUCKET, GCS_PROJECT_ID");
+  });
+
+  it("counts the results it is showing", async () => {
+    const searchRegistry = vi.fn(async () => [searchResult("a"), searchResult("b")]);
+    const { container } = renderTab([], { searchRegistry });
+    await search(container);
+
+    await waitFor(() => expect(container.querySelectorAll(".settings-folder-row")).toHaveLength(2));
+    // Scoped to the add form: the section's own .settings-hint sits outside it.
+    const form = container.querySelector(".mcp-add-form") as HTMLElement;
+    expect(form.querySelector(".settings-hint")?.textContent).toMatch(/2 servers — npm packages only/);
   });
 
   it("hides the empty-state message while the Add form is open", () => {

--- a/src/components/organisms/McpServersTab.tsx
+++ b/src/components/organisms/McpServersTab.tsx
@@ -28,6 +28,10 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
   const [query, setQuery] = useState("");
   const [searching, setSearching] = useState(false);
   const [results, setResults] = useState<McpSearchResult[]>([]);
+  // Distinguishes "searched and found nothing" from "hasn't searched yet" — both render an empty
+  // list otherwise, and the empty list is what a broken search looked like for as long as the
+  // registry parser was returning nothing.
+  const [searched, setSearched] = useState(false);
 
   const resetForm = () => {
     setName("");
@@ -108,6 +112,7 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
     setSearching(true);
     const found = await searchRegistry(query);
     setResults(found);
+    setSearched(true);
     setSearching(false);
   };
 
@@ -115,11 +120,19 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
   // remote third party (registry.modelcontextprotocol.io), so it lands off until the
   // user consciously reviews and enables it from the main list (where the resolved
   // command is shown), rather than a one-click "Install" silently starting to run it.
+  // Passed to create rather than applied by a follow-up update: a create-then-disable pair leaves
+  // the server enabled if the second write fails, which is the one outcome this is meant to prevent.
   const handleInstall = async (result: McpSearchResult) => {
-    const created = await addServer({ name: result.name, command: result.command, args: result.args, env: result.env });
-    if (created) await updateServer(created.id, { enabled: false });
+    await addServer({
+      name: result.name,
+      command: result.command,
+      args: result.args,
+      env: result.env,
+      enabled: false,
+    });
     setAdding(false);
     setResults([]);
+    setSearched(false);
     setQuery("");
   };
 
@@ -236,7 +249,11 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
                 <input
                   type="text"
                   value={query}
-                  onChange={(e) => setQuery(e.target.value)}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    // Otherwise the "nothing matched" line lingers over a query it never ran.
+                    setSearched(false);
+                  }}
                   onKeyDown={(e) => e.key === "Enter" && handleSearch()}
                   placeholder="e.g. filesystem, github, postgres"
                   autoComplete="off"
@@ -250,12 +267,25 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
                   className="settings-action-btn-sm settings-action-btn-ghost"
                   onClick={() => {
                     setResults([]);
+                    setSearched(false);
                     setAdding(false);
                   }}
                 >
                   Cancel
                 </button>
               </div>
+              {searched && results.length === 0 && (
+                <p className="settings-empty">
+                  No installable servers matched. The registry lists servers packaged for other runtimes
+                  too — only npm-based ones can run here.
+                </p>
+              )}
+              {results.length > 0 && (
+                <p className="settings-hint">
+                  {results.length} server{results.length === 1 ? "" : "s"} — npm packages only, latest
+                  version of each.
+                </p>
+              )}
               {/* Result rows stay flat: these are search hits with a single Install action,
                   not editable items, so they get no accordion of their own. */}
               <div className="settings-folder-list">
@@ -264,12 +294,21 @@ export default function McpServersTab({ mcp }: McpServersTabProps) {
                   return (
                     <div className="settings-folder-row" key={result.id}>
                       <TablerIcon name="ti-plug" />
-                      <span
-                        className="settings-folder-path"
-                        title={`${result.description}\n\nWill run: ${resolvedCommand}`}
-                      >
-                        {result.name} — {resolvedCommand}
-                      </span>
+                      <div className="mcp-result-text">
+                        <span
+                          className="settings-folder-path"
+                          title={`${result.description}\n\nWill run: ${resolvedCommand}`}
+                        >
+                          {result.name} — {resolvedCommand}
+                        </span>
+                        {result.requiredEnv.length > 0 && (
+                          // Installed servers land disabled with empty env values, so without this
+                          // the first Test connection fails with no clue which key is missing.
+                          <span className="settings-warning">
+                            Needs: {result.requiredEnv.join(", ")} — add values after installing.
+                          </span>
+                        )}
+                      </div>
                       <button className="settings-action-btn-sm" onClick={() => handleInstall(result)}>
                         Install
                       </button>

--- a/src/globals.css
+++ b/src/globals.css
@@ -2688,6 +2688,17 @@ svg#oc {
   margin-bottom: 12px;
 }
 
+/* A registry result row is a .settings-folder-row — a flex row whose path cell truncates on one
+   line — so the required-keys caution underneath needs its own column box rather than becoming a
+   third inline cell between the path and the Install button. min-width:0 is what still lets the
+   path shrink below its content width and keep its ellipsis. */
+.mcp-result-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .mcp-server-checkbox-row {
   display: flex;
   align-items: center;

--- a/src/hooks/useMcpServers.ts
+++ b/src/hooks/useMcpServers.ts
@@ -27,7 +27,13 @@ export function useMcpServers() {
   }, []);
 
   const addServer = useCallback(
-    async (input: { name: string; command: string; args?: string[]; env?: Record<string, string> }) => {
+    async (input: {
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+      enabled?: boolean;
+    }) => {
       if (!hasAgentsAPI()) return;
       setError(null);
       setLoading(true);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -142,6 +142,9 @@ interface McpSearchResult {
   command: string;
   args: string[];
   env: Record<string, string>;
+  /** Mirror of the main-process type in electron/main/ai/mcp.ts — env vars the registry marks
+   * `isRequired`, so a result that will fail without a key can say so before it is installed. */
+  requiredEnv: string[];
 }
 
 interface ConnectorSettingsField {
@@ -497,7 +500,13 @@ interface Window {
     };
     mcp: {
       list: () => Promise<McpServerRow[]>;
-      create: (input: { name: string; command: string; args?: string[]; env?: Record<string, string> }) => Promise<McpServerRow>;
+      create: (input: {
+        name: string;
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+        enabled?: boolean;
+      }) => Promise<McpServerRow>;
       update: (
         id: string,
         patch: { name?: string; command?: string; args?: string[]; env?: Record<string, string>; enabled?: boolean }


### PR DESCRIPTION
`searchMcpRegistry` had **never returned a result**. The MCP Registry wraps each entry as `{ server, _meta }`, and the parser read `name`/`description`/`packages` off the wrapper — so every entry failed the identifier check and a healthy `200` carrying 30 servers produced `[]`.

Nothing caught it. `mcp.test.ts` never called the function, and `McpServersTab.test.tsx` stubbed `searchRegistry` with canned rows, so a completely dead feature had a green suite for its entire life.

## What changed

**The parser** (`ai/mcp.ts`)

- Read each entry through `entry.server`.
- Request `?version=latest`. Verified server-side: `search=filesystem` returns 30 rows of which 14 are the same server; with the param, 10 unique names and `nextCursor: null`. A client-side `isLatest` guard stays as a fallback, testing `=== false` rather than `!== true` so an entry carrying no `_meta` is kept rather than dropped.
- Build args as `[...runtimeArguments, identifier, ...packageArguments]`. Those are the *runtime's* flags and the *server's* own, on opposite sides of the identifier — appending both after it produced `npx -y remote-filesystem-mcp-server -y`. `-y` is prepended only when the registry didn't supply it and the command is `npx`.
- Take the command from `runtimeHint`, absent on most npm entries.
- Skip packages whose `transport` isn't stdio. `MCPServerStdio` is the only runtime here, so an npm-published sse server would install and never start.
- Carry `requiredEnv` through, so an install that needs a key names it before you make it rather than at connect time.
- Bound the fetch with `AbortSignal.timeout(15s)`. The registry is intermittently unreachable — the same URL timed out twice at 20s and then answered in 1.5s. `humanizeError.ts:69` already maps this to "Request timed out".

**The tab** (`McpServersTab.tsx`)

- Distinguishes "found nothing" from "hasn't searched yet" — previously identical empty divs, which is what a broken search looked like.
- States what it is showing: result count, npm-only, latest-version-only.
- Names required keys per result.
- Installs with `enabled: false` passed to *create*. The previous create-then-disable pair left a third-party command **enabled** whenever the second write failed — the one outcome installing-disabled exists to prevent.

## Verification

`eslint` · `tsc -b` · `npm run build` · `npm run test` — all clean, **1070 tests / 106 files**, +15 from this branch.

Driven live in a sandboxed app (`--user-data-dir`, real database untouched):

| Check | Result |
|---|---|
| search `filesystem` | 7 rows, 7 unique names, `npx -y <pkg>` commands |
| count + caution lines | "7 servers — npm packages only…", "Needs: GCS_BUCKET…" |
| search `zzzqqqnonsense` | empty-state copy |
| Install | row present, toggle **off** |
| `SELECT … FROM mcp_servers` | `args: ["-y","remote-filesystem-mcp-server"]`, `enabled: 0` |
| Test connection | "Connected — 13 tool(s) found" |

Test connection was run from the **Manual** tab against `@modelcontextprotocol/server-everything` rather than a search result — running an arbitrary registry package is real third-party code execution, and `testMcpServer` is untouched by this PR.

## Not addressed

- **Cursor pagination.** `version=latest` returned `nextCursor: null` on every query tried; the count line makes truncation visible rather than silent.
- **pypi / oci / nuget servers** still can't run here — now stated in the UI instead of dropped silently.
- **Servers installed before this PR keep their wrong args** (`npx -y pkg -y`). Deliberately not migrated: a rewrite would clobber user-edited commands. Existing rows are editable in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
