### PR TITLE
Record the worktree base rule and the verify-gate baseline

### DIFF
--- a/.claude/skills/run-openorbit/SKILL.md
+++ b/.claude/skills/run-openorbit/SKILL.md
@@ -32,6 +32,20 @@ npm install          # once per worktree — node_modules is not shared
 npm run build        # main is dist-electron/main/index.js; the driver checks it exists
 ```
 
+⚠ **Check the Electron binary after installing — the install lies.** `npm ci` / `npm install` in a
+fresh worktree regularly exits 0 having left no usable Electron. Two variants seen: the binary
+missing entirely (`dist` and `path.txt` both absent), and a half-extracted app (`failed to create
+directory …/Electron.app/Contents/Resources/kn.lproj: File exists`). The driver then can't launch,
+and vitest quietly loses `electron/main/ai/agents.test.ts` — 45 tests.
+
+```bash
+ls node_modules/electron/path.txt node_modules/electron/dist    # both must exist
+# repair:
+rm -rf node_modules/electron/dist node_modules/electron/path.txt && node node_modules/electron/install.js
+```
+
+`path.txt` should read `Electron.app/Contents/MacOS/Electron`.
+
 ## Run
 
 ```bash
@@ -123,6 +137,13 @@ settings                     # agentName absent; everything else intact
   tells you rather than hanging for 60s.
 - **`node_modules` is per-worktree** and untracked, so a fresh worktree needs `npm install`
   (~minutes: it builds `better-sqlite3` natively and runs `electron-builder install-app-deps`).
+  Verify the Electron binary afterwards — see the Build section; a successful-looking install
+  routinely leaves none.
+- **A worktree cut from `main` contains no app.** `main` is a README-only "idea phase" commit —
+  four files, no `src/` or `electron/`. Branch worktrees from `develop`
+  (`git worktree add -b <branch> .claude/worktrees/<name> develop`), and if you inherit one,
+  confirm the base with `git log --oneline <branch> ^develop` before concluding anything about
+  what is or isn't in the tree.
 - **Wait for `window.agentsAPI`, not a fixed sleep.** The renderer renders nothing until settings
   have loaded, so the bridge appearing is the real ready signal.
 - **`[aria-label*="Close"]` quits the app** — it matches the window's X before any modal's close

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,45 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - ⚠ **Never launch the app from a worktree without `--user-data-dir`.** `app.getPath("userData")` resolves to the same `~/Library/Application Support/OpenOrbit` from *every* checkout and worktree, so an exploratory launch writes into the real database — settings, chat history, agents, encrypted API keys. The `run-openorbit` driver sandboxes it and aborts if the isolation doesn't take; use it rather than launching by hand.
 - **Env required**: none at runtime. Credentials are entered in-app and stored encrypted in SQLite — chat/voice API key + base URL under `appSettings.*` (`ai/provider.ts`), per-connector OAuth client id/secret in the `connectors` table (`connectors/registry.ts`, migration 26). Optional at build time: `GITHUB_RELEASE_REPO` (`scripts/releaseInfo.ts`); `PORT` overrides the dev renderer port.
 
+## Worktrees
+
+- ⚠ **Branch every new worktree from `develop`.** `develop` is the default working branch and carries the entire app. `main` sits at `ca1f8d8` — a README-only "idea phase" commit with no `src/`, no `electron/`, no `package.json`. A worktree cut from `main` (or from whatever HEAD happened to be) reads as an *empty project*, and has now misled three separate sessions into concluding the feature they were sent to fix doesn't exist.
+
+  ```bash
+  git worktree add -b <branch> .claude/worktrees/<name> develop
+  ```
+
+- **Check the base before trusting an existing worktree** — one command, before reading anything into its contents:
+
+  ```bash
+  git log --oneline <branch> ^develop     # empty = no unique commits, safe to reset onto develop
+  git merge-base develop <branch>         # should be develop's tip or an ancestor of it
+  ```
+
+  Recovery, when the tree is clean and nothing unique is on the branch: `git fetch origin && git reset --hard origin/develop`.
+
+- **`node_modules` and `dist-electron/` are per-worktree** and untracked — a fresh worktree needs its own install (see the Electron caveat below). `0-cowork/`, `MEMORY.md` and `.env` are gitignored and exist **only in the main checkout** at `/Users/mohitaneja/Projects/OpenOrbit`; write shared plans, fixes and memory to that absolute path or the workspace silently forks.
+
+## Verify Gate
+
+- **Run all four, every time, before reporting work done** — a green vitest run alone is not validation:
+
+  ```bash
+  npx eslint src electron     # exit 0
+  npx tsc -b                  # exit 0
+  npm run build               # exit 0
+  npm test                    # all pass
+  ```
+
+- **eslint and `tsc -b` print nothing when they pass**, so "no output" proves nothing on its own — check the exit code. Capture `$?` on its own line: `${PIPESTATUS[0]}` is bash-only and expands to an empty string under zsh, which renders as `lint exit:` and reads exactly like success.
+- **Green baseline — `a2fa46f`, verified 2026-08-03: 106 test files / 1070 tests**, eslint 0, `tsc -b` 0, build 0. A materially *lower* test count almost always means a broken Electron binary rather than a removed test — see below.
+- ⚠ **`npm ci` in a fresh worktree regularly leaves Electron unusable while still exiting 0.** Two observed variants: no binary at all (`node_modules/electron/dist` and `path.txt` both absent), or a half-extracted app (`failed to create directory …/Electron.app/Contents/Resources/kn.lproj: File exists`). Either way `electron/main/ai/agents.test.ts` — **45 tests** — fails with "Electron failed to install correctly" or disappears from the run. It reads as one broken suite; it is ~4% of the suite. Verify and repair:
+
+  ```bash
+  ls node_modules/electron/path.txt node_modules/electron/dist    # both must exist
+  rm -rf node_modules/electron/dist node_modules/electron/path.txt && node node_modules/electron/install.js
+  ```
+
 ## Conventions
 
 - TypeScript strict throughout, two project refs: `tsconfig.node.json` (electron/, scripts/, configs) and `tsconfig.web.json` (src/). `@/*` → `./src`, aliased in both electron-vite and vitest.


### PR DESCRIPTION
Docs only — no source, test, or config file is touched.

## Why

Three worktrees in a row (`fix+initial-issues`, `v1-end-to-end-testing`, `fix+greeing-message`) were cut from `ca1f8d8` — the README-only "idea phase" commit on `main` — so each contained four files and no app. Every time it read as *"this project is still idea-phase"* rather than *"wrong branch"*, and every time it cost the opening of a session. Three occurrences is a rule, not bad luck.

## What changed

**`CLAUDE.md`** — two new sections between Build & Run and Conventions:

- `## Worktrees` — branch from `develop` (`git worktree add -b <branch> .claude/worktrees/<name> develop`), the two commands that check an inherited worktree's base *before* concluding anything about its contents, the recovery path, and a reminder that `0-cowork/`, `MEMORY.md` and `.env` are main-checkout-only.
- `## Verify Gate` — the four commands, plus the two ways this gate fails *quietly*:
  - eslint and `tsc -b` print **nothing** on success, so "no output" is not evidence — check the exit code.
  - `${PIPESTATUS[0]}` is bash-only and expands to an empty string under zsh, rendering as `lint exit:` — which reads exactly like a pass.
- Baseline corrected to **1070 tests / 106 files** at `a2fa46f`. The previously recorded 1047/104 was measured inside PR #49's own worktree before merge; #47 and #48 landed alongside it.
- The Electron-binary caveat: `npm ci` in a fresh worktree keeps leaving Electron unusable while exiting 0 — twice half-extracted (`kn.lproj: File exists`), once with no binary at all. Costs exactly 45 tests from `electron/main/ai/agents.test.ts` and presents as one broken suite.

**`.claude/skills/run-openorbit/SKILL.md`** — the post-install binary check and repair in `## Build` (where anyone hitting a failed launch will be looking), and a wrong-base gotcha alongside the existing `node_modules`-is-per-worktree note.

## Verification

`npx eslint src electron` → 0 · `npx tsc -b` → 0. `npm run build` and `npm test` were **not** re-run after the edits — the diff is two markdown files, unreachable from any build or test path. Both were green at this same commit immediately prior: build 0, 1070/106.

## Note

The `allowScripts` warning covering 7 packages (better-sqlite3, esbuild ×2, fsevents, koffi, node, electron-winstaller) is a *plausible but unverified* root cause of the recurring Electron failures. Deliberately not asserted as the cause anywhere in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)