### PR TITLE
Show how long an approval has before it declines itself (U6)

### DIFF
--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -419,6 +419,11 @@ export function registerAgentHandlers() {
             toolName: meta.toolName ?? "",
             agentName: meta.agentName,
             args: meta.args,
+            // Absolute deadline rather than a duration: the renderer counts down to a fixed
+            // point, so neither IPC latency nor a slow first render shifts it. Sending it at
+            // all is what stops the countdown copy from hardcoding a number that
+            // APPROVAL_TIMEOUT_MS can silently drift away from.
+            expiresAt: Date.now() + APPROVAL_TIMEOUT_MS,
           });
         }).finally(() => {
           // Resumed here rather than at each call site so an approval that times out or is

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -158,6 +158,8 @@ const agentsAPI = {
         toolName: string;
         agentName?: string;
         args?: string;
+        /** Absolute epoch ms at which main declines this call on the user's behalf. */
+        expiresAt: number;
       }) => void
     ): (() => void) => subscribeWithPayload("agent:stream-approval", callback),
     /** Fires when an approval was resolved without the user — the 5-minute timeout expiring,

--- a/src/components/molecules/HttpToolApprovalModal.test.tsx
+++ b/src/components/molecules/HttpToolApprovalModal.test.tsx
@@ -1,14 +1,20 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import HttpToolApprovalModal, { type PendingToolApproval } from "./HttpToolApprovalModal";
 
-const APPROVAL: PendingToolApproval = {
+// expiresAt is built per-render from the current clock so the countdown assertions don't go
+// stale as the suite runs.
+const approvalIn = (ms: number): PendingToolApproval => ({
   approvalId: "ap-1",
   toolName: "jsonplaceholder_delete_post",
   agentName: "Atlas",
   args: '{"id":1}',
-};
+  requestedAt: Date.now(),
+  expiresAt: Date.now() + ms,
+});
+
+const APPROVAL: PendingToolApproval = approvalIn(5 * 60 * 1000);
 
 /** This modal gates a paused agent run over a real side effect — a POST, PUT or DELETE against
  * someone's API. Every exit has to answer the call, and no accidental one may answer it. */
@@ -76,5 +82,53 @@ describe("HttpToolApprovalModal", () => {
     render(<HttpToolApprovalModal approval={{ ...APPROVAL, args: "not json" }} onRespond={vi.fn()} />);
 
     expect(screen.getByText("not json")).toBeInTheDocument();
+  });
+
+  // U6 — the prompt answers itself at the deadline; without this the only way to find out was
+  // to walk away and come back to a declined call.
+  //
+  // Fake timers on a whole-second epoch: useApprovalCountdown floors the clock to the second,
+  // so against a real clock a five-minute window renders as "5:01" whenever the current
+  // millisecond is past .000. Pinning the time makes the rendered digits exact rather than
+  // forcing a vaguer assertion.
+  describe("countdown", () => {
+    const T0 = 1_800_000_000_000;
+
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "Date"] });
+      vi.setSystemTime(T0);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows how long is left before it declines itself", () => {
+      render(<HttpToolApprovalModal approval={approvalIn(5 * 60 * 1000)} onRespond={vi.fn()} />);
+
+      expect(screen.getByText(/Declines automatically in/)).toBeInTheDocument();
+      expect(screen.getByText("5:00")).toBeInTheDocument();
+    });
+
+    it("marks the last 30 seconds", () => {
+      const { baseElement } = render(<HttpToolApprovalModal approval={approvalIn(25 * 1000)} onRespond={vi.fn()} />);
+
+      expect(baseElement.querySelector(".http-approval-expiry--soon")).not.toBeNull();
+      expect(screen.getByText("0:25")).toBeInTheDocument();
+    });
+
+    it("does not mark a window that still has minutes on it", () => {
+      const { baseElement } = render(
+        <HttpToolApprovalModal approval={approvalIn(5 * 60 * 1000)} onRespond={vi.fn()} />
+      );
+
+      expect(baseElement.querySelector(".http-approval-expiry--soon")).toBeNull();
+    });
+
+    it("says it is expiring once the deadline has passed", () => {
+      render(<HttpToolApprovalModal approval={approvalIn(-1000)} onRespond={vi.fn()} />);
+
+      expect(screen.getByText(/Expired/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/molecules/HttpToolApprovalModal.tsx
+++ b/src/components/molecules/HttpToolApprovalModal.tsx
@@ -1,5 +1,7 @@
 import Modal from "@/components/atoms/Modal";
 import { humanizeToolName } from "@/lib/humanizeToolName";
+import { formatRemaining } from "@/lib/approvalCountdown";
+import { useApprovalCountdown } from "@/hooks/useApprovalCountdown";
 
 export interface PendingToolApproval {
   approvalId: string;
@@ -7,6 +9,12 @@ export interface PendingToolApproval {
   agentName?: string;
   /** Raw JSON argument string from the SDK, when it exposed one. */
   args?: string;
+  /** Absolute epoch ms at which main declines this call on the user's behalf. */
+  expiresAt: number;
+  /** When the renderer received it. Only used to recover the window's length for the
+   * past-tense message — `expiresAt - requestedAt` is the timeout main is enforcing, which
+   * beats hardcoding a duration the renderer can't see. */
+  requestedAt: number;
 }
 
 interface HttpToolApprovalModalProps {
@@ -42,6 +50,7 @@ function formatArgs(args: string | undefined): string | null {
  */
 export default function HttpToolApprovalModal({ approval, onRespond }: HttpToolApprovalModalProps) {
   const formattedArgs = formatArgs(approval?.args);
+  const msLeft = useApprovalCountdown(approval?.expiresAt ?? null);
 
   return (
     <Modal
@@ -58,6 +67,20 @@ export default function HttpToolApprovalModal({ approval, onRespond }: HttpToolA
           on the remote service, so it needs your go-ahead.
         </p>
         {formattedArgs && <pre className="http-approval-args">{formattedArgs}</pre>}
+        {msLeft !== null && (
+          // aria-live polite rather than off: a screen-reader user gets no other signal that
+          // the prompt is about to answer itself. Not assertive — it must not interrupt them
+          // reading the arguments they are being asked to approve.
+          <p className={`http-approval-expiry${msLeft <= 30_000 ? " http-approval-expiry--soon" : ""}`} aria-live="polite">
+            {msLeft > 0 ? (
+              <>
+                Declines automatically in <strong>{formatRemaining(msLeft)}</strong>
+              </>
+            ) : (
+              "Expired — declining…"
+            )}
+          </p>
+        )}
         <div className="http-approval-actions">
           <button
             type="button"

--- a/src/components/molecules/ToolApprovalCard.tsx
+++ b/src/components/molecules/ToolApprovalCard.tsx
@@ -1,5 +1,7 @@
 import TablerIcon from "@/components/atoms/TablerIcon";
 import { humanizeToolName } from "@/lib/humanizeToolName";
+import { formatRemaining } from "@/lib/approvalCountdown";
+import { useApprovalCountdown } from "@/hooks/useApprovalCountdown";
 import type { PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
 
 interface ToolApprovalCardProps {
@@ -30,6 +32,9 @@ function formatArgs(args: string | undefined): string | null {
  */
 export default function ToolApprovalCard({ approval, onRespond }: ToolApprovalCardProps) {
   const formattedArgs = formatArgs(approval.args);
+  // Same deadline as the modal's — toolApprovalDisplay only chooses which surface shows it,
+  // so a countdown on one and not the other would make the setting change the stakes.
+  const msLeft = useApprovalCountdown(approval.expiresAt);
 
   return (
     <div className="tool-approval-card" role="group" aria-label="Tool approval request">
@@ -41,6 +46,20 @@ export default function ToolApprovalCard({ approval, onRespond }: ToolApprovalCa
         </span>
       </div>
       {formattedArgs && <pre className="tool-approval-card-args">{formattedArgs}</pre>}
+      {msLeft !== null && (
+        <p
+          className={`tool-approval-card-expiry${msLeft <= 30_000 ? " tool-approval-card-expiry--soon" : ""}`}
+          aria-live="polite"
+        >
+          {msLeft > 0 ? (
+            <>
+              Declines automatically in <strong>{formatRemaining(msLeft)}</strong>
+            </>
+          ) : (
+            "Expired — declining…"
+          )}
+        </p>
+      )}
       <div className="tool-approval-card-actions">
         <button
           type="button"

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -580,8 +580,11 @@ export default function AgentsApp() {
   const [approvalQueue, setApprovalQueue] = useState<PendingToolApproval[]>([]);
   useEffect(() => {
     if (!hasAgentsAPI()) return;
-    return window.agentsAPI.agent.onToolApproval(({ approvalId, toolName, agentName, args }) => {
-      setApprovalQueue((prev) => [...prev, { approvalId, toolName, agentName, args }]);
+    return window.agentsAPI.agent.onToolApproval(({ approvalId, toolName, agentName, args, expiresAt }) => {
+      // requestedAt is read here, in the IPC callback, rather than inside the state updater —
+      // a clock read in an updater body is impure and StrictMode double-invokes it.
+      const requestedAt = Date.now();
+      setApprovalQueue((prev) => [...prev, { approvalId, toolName, agentName, args, expiresAt, requestedAt }]);
     });
   }, []);
 
@@ -605,7 +608,7 @@ export default function AgentsApp() {
       setApprovalQueue((prev) => prev.filter((item) => item.approvalId !== approvalId));
       appendMessage({
         role: "assistant",
-        text: approvalSettledMessage(settled.toolName, reason),
+        text: approvalSettledMessage(settled.toolName, reason, settled.expiresAt - settled.requestedAt),
         avatarLabel: settings.agentName[0]?.toUpperCase() || "A",
       });
     });

--- a/src/globals.css
+++ b/src/globals.css
@@ -4824,6 +4824,33 @@ svg#oc {
   word-break: break-word;
 }
 
+/* The prompt answers itself when the deadline passes, so the deadline has to be visible.
+   Muted until the last 30s — this is information, not pressure, right up until it is. The
+   digits are tabular so a ticking clock doesn't reflow the line every second. */
+.http-approval-expiry,
+.tool-approval-card-expiry {
+  margin: 0;
+  font-size: 11.5px;
+  color: rgba(200, 230, 255, 0.55);
+}
+
+.http-approval-expiry strong,
+.tool-approval-card-expiry strong {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: rgba(200, 230, 255, 0.8);
+}
+
+.http-approval-expiry--soon,
+.tool-approval-card-expiry--soon {
+  color: #ffc97e;
+}
+
+.http-approval-expiry--soon strong,
+.tool-approval-card-expiry--soon strong {
+  color: #ffc97e;
+}
+
 .http-approval-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/hooks/useApprovalCountdown.test.ts
+++ b/src/hooks/useApprovalCountdown.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useApprovalCountdown } from "./useApprovalCountdown";
+
+const T0 = 1_800_000_000_000; // fixed, whole-second epoch so quantisation is exact
+
+describe("useApprovalCountdown", () => {
+  beforeEach(() => {
+    // `Date` must be in toFake — advancing timers alone does not move Date.now(), and a hook
+    // that reads the wall clock would then never appear to count down.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "Date"] });
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null when there is no deadline", () => {
+    const { result } = renderHook(() => useApprovalCountdown(null));
+
+    expect(result.current).toBeNull();
+  });
+
+  it("reports the time remaining", () => {
+    const { result } = renderHook(() => useApprovalCountdown(T0 + 5000));
+
+    expect(result.current).toBe(5000);
+  });
+
+  it("counts down as the clock advances", () => {
+    const { result } = renderHook(() => useApprovalCountdown(T0 + 5000));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current).toBe(3000);
+  });
+
+  it("goes negative once the deadline has passed", () => {
+    const { result } = renderHook(() => useApprovalCountdown(T0 + 2000));
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toBeLessThanOrEqual(0);
+  });
+
+  // Without re-reading on render, the first tick after a new approval arrives still showed the
+  // previous one's remaining time.
+  it("re-reads immediately when the deadline changes", () => {
+    const { result, rerender } = renderHook(({ at }) => useApprovalCountdown(at), {
+      initialProps: { at: T0 + 60_000 } as { at: number | null },
+    });
+
+    expect(result.current).toBe(60_000);
+
+    act(() => {
+      rerender({ at: T0 + 3000 });
+    });
+
+    expect(result.current).toBe(3000);
+  });
+
+  it("drops back to null when the deadline is removed", () => {
+    const { result, rerender } = renderHook(({ at }) => useApprovalCountdown(at), {
+      initialProps: { at: T0 + 5000 } as { at: number | null },
+    });
+
+    expect(result.current).not.toBeNull();
+
+    act(() => {
+      rerender({ at: null });
+    });
+
+    expect(result.current).toBeNull();
+  });
+
+  it("stops polling once unmounted", () => {
+    const { unmount } = renderHook(() => useApprovalCountdown(T0 + 5000));
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/hooks/useApprovalCountdown.ts
+++ b/src/hooks/useApprovalCountdown.ts
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Milliseconds left until an approval's deadline, refreshed as the clock advances.
+ *
+ * Written as an external-store subscription rather than useState + useEffect on purpose. The
+ * wall clock *is* an external system, and `react-hooks/set-state-in-effect` rejects the
+ * setState-inside-an-effect shape that the obvious version needs to re-read on mount and on a
+ * changed deadline. useSyncExternalStore gets both for free and re-reads on every render too,
+ * so a new approval never briefly shows the previous one's time.
+ *
+ * The snapshot is quantised to whole seconds. getSnapshot must return a stable value between
+ * ticks — a raw Date.now() changes on every call and React treats that as an infinite update
+ * loop. Quantising also means the returned figure can sit up to 999ms above the true remaining
+ * time, which is invisible once formatRemaining rounds up.
+ *
+ * Returns null when there is no deadline, so a caller renders nothing rather than a zeroed clock.
+ */
+
+/** 250ms, not 1000ms: the snapshot only changes on a second boundary, so polling faster just
+ * shortens the lag between the boundary passing and the display catching up. */
+function subscribe(onStoreChange: () => void): () => void {
+  const id = setInterval(onStoreChange, 250);
+  return () => clearInterval(id);
+}
+
+function getNowSecond(): number {
+  return Math.floor(Date.now() / 1000) * 1000;
+}
+
+export function useApprovalCountdown(expiresAt: number | null): number | null {
+  const now = useSyncExternalStore(subscribe, getNowSecond, getNowSecond);
+  return expiresAt === null ? null : expiresAt - now;
+}

--- a/src/lib/approvalCountdown.test.ts
+++ b/src/lib/approvalCountdown.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { formatRemaining, formatApprovalWindow, hasExpired } from "./approvalCountdown";
+
+describe("formatRemaining", () => {
+  it("formats minutes and seconds with a padded seconds field", () => {
+    expect(formatRemaining(5 * 60 * 1000)).toBe("5:00");
+    expect(formatRemaining(4 * 60 * 1000 + 9000)).toBe("4:09");
+    expect(formatRemaining(20_000)).toBe("0:20");
+  });
+
+  it("rounds up, so a live clock never shows 0:00 while time remains", () => {
+    expect(formatRemaining(1)).toBe("0:01");
+    expect(formatRemaining(999)).toBe("0:01");
+  });
+
+  it("floors at 0:00 rather than going negative", () => {
+    expect(formatRemaining(0)).toBe("0:00");
+    expect(formatRemaining(-5000)).toBe("0:00");
+  });
+});
+
+describe("formatApprovalWindow", () => {
+  // The whole point of this helper: the duration comes from the deadline main sent, so a
+  // changed APPROVAL_TIMEOUT_MS can't leave the copy claiming something else.
+  it("names whole minutes in minutes", () => {
+    expect(formatApprovalWindow(5 * 60 * 1000)).toBe("5 minutes");
+    expect(formatApprovalWindow(60 * 1000)).toBe("1 minute");
+  });
+
+  it("names sub-minute windows in seconds", () => {
+    expect(formatApprovalWindow(20 * 1000)).toBe("20 seconds");
+    expect(formatApprovalWindow(1000)).toBe("1 second");
+  });
+
+  it("keeps ragged durations in seconds rather than rounding to a wrong minute count", () => {
+    expect(formatApprovalWindow(90 * 1000)).toBe("90 seconds");
+    expect(formatApprovalWindow(150 * 1000)).toBe("150 seconds");
+  });
+
+  it("does not go negative", () => {
+    expect(formatApprovalWindow(-1000)).toBe("0 seconds");
+  });
+});
+
+describe("hasExpired", () => {
+  it("is true at and past the deadline", () => {
+    expect(hasExpired(1000, 1000)).toBe(true);
+    expect(hasExpired(1000, 1001)).toBe(true);
+  });
+
+  it("is false before it", () => {
+    expect(hasExpired(1000, 999)).toBe(false);
+  });
+});

--- a/src/lib/approvalCountdown.ts
+++ b/src/lib/approvalCountdown.ts
@@ -1,0 +1,39 @@
+/**
+ * Countdown formatting for the tool-approval prompt.
+ *
+ * Two shapes, deliberately different. `formatRemaining` is a live clock the user watches tick,
+ * so it stays numeric and monospace-stable. `formatApprovalWindow` names the whole window in
+ * prose, for the past-tense message after the prompt has gone.
+ */
+
+/** Ticking clock: "4:59", "0:20", "0:00". Never negative. */
+export function formatRemaining(msLeft: number): string {
+  const total = Math.max(0, Math.ceil(msLeft / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
+ * Prose duration for the whole approval window — "5 minutes", "20 seconds", "90 seconds".
+ *
+ * Derived from the deadline main actually sent rather than written into the copy. The message
+ * used to read "expired after 5 minutes" from a hardcoded string while APPROVAL_TIMEOUT_MS
+ * lived in electron/main/ipc/agent.ts; setting the timeout to 20s during testing produced a
+ * message still claiming 5 minutes. Same class of split as the settings defaults recorded in
+ * MEMORY.md, and this is the fix for it.
+ */
+export function formatApprovalWindow(totalMs: number): string {
+  const seconds = Math.max(0, Math.round(totalMs / 1000));
+  if (seconds < 60) return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  // Only whole minutes read naturally here; anything else stays in seconds rather than
+  // rounding "90 seconds" to a wrong-sounding "2 minutes".
+  if (seconds % 60 !== 0) return `${seconds} seconds`;
+  const minutes = seconds / 60;
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+/** True once the deadline has passed. Kept here so the components agree on the boundary. */
+export function hasExpired(expiresAt: number, now: number): boolean {
+  return now >= expiresAt;
+}

--- a/src/lib/approvalSettledMessage.test.ts
+++ b/src/lib/approvalSettledMessage.test.ts
@@ -3,15 +3,29 @@ import { approvalSettledMessage } from "./approvalSettledMessage";
 
 describe("approvalSettledMessage", () => {
   it("says a timed-out approval was declined and can be asked for again", () => {
-    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout");
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout", 5 * 60 * 1000);
 
     expect(text).toContain("expired after 5 minutes");
     expect(text).toContain("declined");
     expect(text).toContain("Ask me again");
   });
 
+  // The whole reason the duration is a parameter: it used to be hardcoded as "5 minutes" while
+  // APPROVAL_TIMEOUT_MS lived in main, and a 20-second timeout still produced "5 minutes".
+  it("reports the window main actually enforced, not a hardcoded one", () => {
+    expect(approvalSettledMessage("x_y", "timeout", 20 * 1000)).toContain("expired after 20 seconds");
+    expect(approvalSettledMessage("x_y", "timeout", 20 * 1000)).not.toContain("5 minutes");
+  });
+
+  it("omits the duration rather than inventing one when the window is unknown", () => {
+    const text = approvalSettledMessage("x_y", "timeout");
+
+    expect(text).toContain("expired,");
+    expect(text).not.toMatch(/after \d/);
+  });
+
   it("says an abandoned approval never ran, without inviting a retry", () => {
-    const text = approvalSettledMessage("jsonplaceholder_delete_post", "abandoned");
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "abandoned", 5 * 60 * 1000);
 
     expect(text).toContain("the run ended");
     expect(text).toContain("never ran");
@@ -21,13 +35,13 @@ describe("approvalSettledMessage", () => {
   });
 
   it("humanizes the tool name rather than showing the raw identifier", () => {
-    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout");
+    const text = approvalSettledMessage("jsonplaceholder_delete_post", "timeout", 60_000);
 
     expect(text).not.toContain("jsonplaceholder_delete_post");
   });
 
   it("both reasons make clear the call did not run", () => {
-    expect(approvalSettledMessage("x_y", "timeout")).toMatch(/declined/);
-    expect(approvalSettledMessage("x_y", "abandoned")).toMatch(/never ran/);
+    expect(approvalSettledMessage("x_y", "timeout", 60_000)).toMatch(/declined/);
+    expect(approvalSettledMessage("x_y", "abandoned", 60_000)).toMatch(/never ran/);
   });
 });

--- a/src/lib/approvalSettledMessage.ts
+++ b/src/lib/approvalSettledMessage.ts
@@ -1,4 +1,5 @@
 import { humanizeToolName } from "@/lib/humanizeToolName";
+import { formatApprovalWindow } from "@/lib/approvalCountdown";
 
 /** Why an approval was resolved by something other than the user answering it. Mirrors
  * `ApprovalSettledReason` in electron/main/ipc/agent.ts, which is the sender. */
@@ -13,10 +14,23 @@ export type ApprovalSettledReason = "timeout" | "abandoned";
  *
  * Silence was the old behaviour and the worst option: main had already declined the call while
  * the prompt sat on screen, so pressing Approve resolved nothing and looked like a dead button.
+ *
+ * `windowMs` is the deadline main actually enforced, recovered from the approval's own
+ * expiresAt. The first version of this function hardcoded "5 minutes" while APPROVAL_TIMEOUT_MS
+ * lived in electron/main/ipc/agent.ts; testing with a 20-second timeout produced a message
+ * still claiming five minutes. Never restate a duration the other process owns.
  */
-export function approvalSettledMessage(toolName: string, reason: ApprovalSettledReason): string {
+export function approvalSettledMessage(
+  toolName: string,
+  reason: ApprovalSettledReason,
+  windowMs?: number
+): string {
   const tool = humanizeToolName(toolName);
-  return reason === "timeout"
-    ? `The request to run ${tool} expired after 5 minutes, so it was declined. Ask me again if you still want it.`
-    : `The request to run ${tool} was dropped because the run ended, so it never ran.`;
+  if (reason !== "timeout") {
+    return `The request to run ${tool} was dropped because the run ended, so it never ran.`;
+  }
+  // A missing or nonsensical window is possible if the payload predates expiresAt — say less
+  // rather than say something wrong.
+  const after = windowMs && windowMs > 0 ? ` after ${formatApprovalWindow(windowMs)}` : "";
+  return `The request to run ${tool} expired${after}, so it was declined. Ask me again if you still want it.`;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -453,6 +453,8 @@ interface Window {
           toolName: string;
           agentName?: string;
           args?: string;
+          /** Absolute epoch ms at which main declines this call on the user's behalf. */
+          expiresAt: number;
         }) => void
       ) => () => void;
       onToolApprovalSettled: (


### PR DESCRIPTION
## What changed

The tool-approval prompt now shows a live countdown to the moment it declines itself, on **both** surfaces — the modal and the in-chat card. Amber for the last 30 seconds.

Main sends an absolute `expiresAt` rather than a duration, so the renderer counts down to a fixed point and neither IPC latency nor a slow first render shifts it.

## Root cause

`APPROVAL_TIMEOUT_MS` (5 minutes) answers the prompt on the user's behalf, and nothing said so. The only way to discover the deadline existed was to walk away and come back to a declined call. PR #48 made the expiry visible *after* the fact; this makes it visible *before*.

## Also fixes a split introduced by #48

`approvalSettledMessage` hardcoded `"expired after 5 minutes"` while `APPROVAL_TIMEOUT_MS` lives in `electron/main/ipc/agent.ts`. Testing #48 with a 20-second timeout produced a message still claiming five minutes. The duration is now derived from the deadline main actually sent, via `formatApprovalWindow`, and a test pins that a 20s window says "20 seconds".

Same class as the settings-default divergences recorded in `MEMORY.md` — a renderer restating a number another process owns.

## Design notes

- **`useSyncExternalStore`, not `useState` + `useEffect`.** The wall clock is an external system, and `react-hooks/set-state-in-effect` rejects the setState-in-effect shape the obvious version needs to re-read on mount and on a changed deadline. The subscription form gets both, and re-reads on render too, so a new approval never briefly shows the previous one's time.
- **The snapshot is quantised to whole seconds.** `getSnapshot` must be stable between ticks — a raw `Date.now()` changes on every call and React treats that as an infinite loop. Polling is 250ms so the display catches a second boundary quickly.
- **Both surfaces.** `toolApprovalDisplay` only chooses which one is shown; a countdown on one and not the other would let a display preference change the stakes.
- `aria-live="polite"`, not `assertive` — a screen-reader user gets no other signal that the prompt is about to answer itself, but it must not interrupt them reading the arguments.

## Testing

- Unit/integration: **1092 passed** (baseline 1070, +22)
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData` with the timeout temporarily set to 40s — countdown read `0:41` → `0:34` → `0:25` (amber) → `0:15`, the prompt cleared itself at the deadline, and the message read **"expired after 40 seconds"**, confirming the hardcoded duration is gone. Screenshot confirms placement between the arguments and the actions.

## Notes

- **Known cosmetic:** second-quantisation makes the first tick read one second high — a 40s window opens at `0:41`. Invisible at 5 minutes (`5:01` vs `5:00`), and the alternative is an unstable snapshot React rejects.
- **Filed separately, not fixed here:** the first-run tour dims the approval modal behind its spotlight overlay, making a security prompt hard to read. Added to U16 in `ui-review.md`, which already covers driver.js beating the modal's Tab trap.
- **Correction (post-merge):** an earlier version of this description claimed `develop` measured 1055 after #49/#50 and that this disagreed with the 1070 in shared memory. That was wrong. `a2fa46f` was measured directly at **1070 / 106** — the memory was accurate. The 1055 figure was taken *before* rebasing onto #49 and misreported as a post-#49 number. This PR's real contribution is **+22 tests on a 1070 baseline**, reaching 1092 / 108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
