### PR TITLE
Stop saying good night to someone who's still working

### DIFF
--- a/src/lib/greeting.test.ts
+++ b/src/lib/greeting.test.ts
@@ -12,21 +12,39 @@ describe("getTimeOfDayGreeting", () => {
     expect(getTimeOfDayGreeting(atHour(11))).toBe("Good morning");
   });
 
-  it("returns Good afternoon for 12pm-4pm", () => {
+  it("returns Good afternoon for 12pm-5pm", () => {
     expect(getTimeOfDayGreeting(atHour(12))).toBe("Good afternoon");
-    expect(getTimeOfDayGreeting(atHour(16))).toBe("Good afternoon");
+    expect(getTimeOfDayGreeting(atHour(17))).toBe("Good afternoon");
   });
 
-  it("returns Good evening for 5pm-8pm", () => {
-    expect(getTimeOfDayGreeting(atHour(17))).toBe("Good evening");
+  it("returns Good evening for 6pm-8pm", () => {
+    expect(getTimeOfDayGreeting(atHour(18))).toBe("Good evening");
     expect(getTimeOfDayGreeting(atHour(20))).toBe("Good evening");
   });
 
-  it("returns Good night for 9pm-4am", () => {
-    expect(getTimeOfDayGreeting(atHour(21))).toBe("Good night");
-    expect(getTimeOfDayGreeting(atHour(23))).toBe("Good night");
-    expect(getTimeOfDayGreeting(atHour(0))).toBe("Good night");
-    expect(getTimeOfDayGreeting(atHour(4))).toBe("Good night");
+  // Never "Good night" — the line only renders while the app is in use, so a send-off is
+  // wrong at exactly the moment the user sat down.
+  it("returns Still at it for 9pm-4am", () => {
+    expect(getTimeOfDayGreeting(atHour(21))).toBe("Still at it");
+    expect(getTimeOfDayGreeting(atHour(23))).toBe("Still at it");
+    expect(getTimeOfDayGreeting(atHour(0))).toBe("Still at it");
+    expect(getTimeOfDayGreeting(atHour(4))).toBe("Still at it");
+  });
+
+  // Moving a boundary is the one edit that can silently leave an hour in the wrong band,
+  // and the bands are ordered ifs rather than an exhaustive map, so pin all 24.
+  it("assigns every hour of the day to the expected band", () => {
+    const expected = [
+      ...Array<string>(5).fill("Still at it"), // 0-4
+      ...Array<string>(7).fill("Good morning"), // 5-11
+      ...Array<string>(6).fill("Good afternoon"), // 12-17
+      ...Array<string>(3).fill("Good evening"), // 18-20
+      ...Array<string>(3).fill("Still at it"), // 21-23
+    ];
+    expect(expected).toHaveLength(24);
+    for (let hour = 0; hour < 24; hour++) {
+      expect(getTimeOfDayGreeting(atHour(hour))).toBe(expected[hour]);
+    }
   });
 });
 

--- a/src/lib/greeting.ts
+++ b/src/lib/greeting.ts
@@ -1,12 +1,19 @@
 /** Time-of-day greeting bands, using the machine's own local time (same convention as
- * agents.ts's getCurrentDateTime on the main-process side) — 5–11 morning, 12–16
- * afternoon, 17–20 evening, everything else (21–4) night. */
+ * agents.ts's getCurrentDateTime on the main-process side) — 5–11 morning, 12–17
+ * afternoon, 18–20 evening, everything else (21–4) late.
+ *
+ * The late band deliberately does not say "Good night". This line only renders while
+ * someone is actively using the app, so a send-off is precisely the wrong thing to say at
+ * the moment they sat down — "Good night, Mohit!" greeted an 11pm working session.
+ * "Still at it" acknowledges the hour without assuming they're on their way to bed, and
+ * stays true across the whole 9pm–5am stretch, so the small hours need no band of their
+ * own. Afternoon runs to 18:00 because 5pm reads as afternoon on a working day. */
 export function getTimeOfDayGreeting(date: Date = new Date()): string {
   const hour = date.getHours();
   if (hour >= 5 && hour < 12) return "Good morning";
-  if (hour >= 12 && hour < 17) return "Good afternoon";
-  if (hour >= 17 && hour < 21) return "Good evening";
-  return "Good night";
+  if (hour >= 12 && hour < 18) return "Good afternoon";
+  if (hour >= 18 && hour < 21) return "Good evening";
+  return "Still at it";
 }
 
 /** The status-bar line. Falls back to "there" because userName defaults to "" and is only


### PR DESCRIPTION
## What changed

The status-bar greeting no longer wishes the user good night while they're actively using the app. The 21:00–04:59 band now reads **"Still at it"** — an acknowledgement of the hour rather than a send-off at the moment someone sat down. The afternoon/evening boundary also moves from 17:00 to 18:00, since 5pm reads as afternoon on a working day.

| Hour | Before | After |
|---|---|---|
| 5–11 | Good morning | Good morning |
| 12–16 | Good afternoon | Good afternoon |
| **17** | Good evening | **Good afternoon** |
| 18–20 | Good evening | Good evening |
| **21–04** | **Good night** | **Still at it** |

## Root cause

`getTimeOfDayGreeting` reused conventional time-of-day salutations, but this line only ever renders while the app is open — so "Good night" was structurally wrong for the one context it appears in, not merely mistimed.

## Testing

- **Unit:** 1071 passed / 106 files (baseline 1070, plus one new test). Greeting suite 7/7. Lint, `tsc -b` and build all exit 0.
- **E2E:** not configured. `playwright-core` is in the tree only as the `run-openorbit` driver's dependency — no config, no script, no suite.
- **Manual:** launched the real app via `run-openorbit` at 00:59 IST — inside the changed band — sandboxed to `/private/tmp/orbit-run/userdata`. The status line rendered "Still at it, Mohit!", sampled steady across 3.3s and confirmed by screenshot. That is the exact clock condition which previously produced "Good night, Mohit!".

## Notes

- The new test pins all 24 hours to their band. These are ordered `if`s rather than an exhaustive map, and moving a boundary is precisely the edit that can leave one hour silently in the wrong band.
- Pre-onboarding, `userName` is empty and the line falls back to **"Still at it, there!"**, which reads worse than the old "Good night, there!" did. Left alone deliberately — a separate copy decision, not a regression introduced here.
- No consumer changes needed: `AgentsApp.tsx:219` is the only caller, and the once-a-minute tick at `AgentsApp.tsx:209-214` already re-renders so the band updates live on a long-open session.
- This repo has no CI, so the verify gate above is the only automated check that ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)