### PR TITLE
Stop a second click queueing a duplicate knowledge operation (U10)

### DIFF
--- a/src/components/organisms/FilesAppsTab.test.tsx
+++ b/src/components/organisms/FilesAppsTab.test.tsx
@@ -29,7 +29,17 @@ function entry(id: number, overrides: Partial<KnowledgebaseFileRecord> = {}): Kn
 }
 
 function setFiles(files: KnowledgebaseFileRecord[]) {
-  useSharedKnowledgeFiles.mockReturnValue({ files, error: null, addFolder, pickAndAdd, removeFile });
+  // pendingIds/loading are part of the hook's contract now — a mock that omits them renders
+  // `pendingIds.has(...)` against undefined and the component throws.
+  useSharedKnowledgeFiles.mockReturnValue({
+    files,
+    error: null,
+    loading: false,
+    pendingIds: new Set<number>(),
+    addFolder,
+    pickAndAdd,
+    removeFile,
+  });
 }
 
 describe("FilesAppsTab", () => {

--- a/src/components/organisms/FilesAppsTab.tsx
+++ b/src/components/organisms/FilesAppsTab.tsx
@@ -3,7 +3,7 @@ import { useSharedKnowledgeFiles } from "@/hooks/useKnowledgeFiles";
 import { entryIcon } from "@/lib/knowledgeEntryIcon";
 
 export default function FilesAppsTab() {
-  const { files, error, addFolder, pickAndAdd, removeFile } = useSharedKnowledgeFiles();
+  const { files, error, loading, pendingIds, addFolder, pickAndAdd, removeFile } = useSharedKnowledgeFiles();
 
   const folders = files.filter((f) => f.kind === "folder");
   // Documents and saved web pages share this list: both are app-owned copies the user manages
@@ -17,6 +17,7 @@ export default function FilesAppsTab() {
         <button
           type="button"
           className="settings-action-btn-sm settings-action-btn-ghost"
+          disabled={loading}
           onClick={() => void addFolder()}
         >
           <TablerIcon name="ti-folder-plus" />
@@ -38,6 +39,7 @@ export default function FilesAppsTab() {
               className="settings-icon-btn"
               // Removing a folder revokes access; it never deletes anything from disk.
               aria-label={`Remove access to ${folder.path}`}
+              disabled={pendingIds.has(folder.id)}
               onClick={() => void removeFile(folder.id)}
             >
               <TablerIcon name="ti-x" />
@@ -51,6 +53,7 @@ export default function FilesAppsTab() {
         <button
           type="button"
           className="settings-action-btn-sm settings-action-btn-ghost"
+          disabled={loading}
           onClick={() => void pickAndAdd()}
         >
           <TablerIcon name="ti-file-plus" />
@@ -76,6 +79,7 @@ export default function FilesAppsTab() {
             <button
               className="settings-icon-btn"
               aria-label={`Remove ${doc.originalName}`}
+              disabled={pendingIds.has(doc.id)}
               onClick={() => void removeFile(doc.id)}
             >
               <TablerIcon name="ti-x" />

--- a/src/components/organisms/KnowledgeModal.test.tsx
+++ b/src/components/organisms/KnowledgeModal.test.tsx
@@ -37,6 +37,8 @@ function setFiles(files: KnowledgebaseFileRecord[]) {
   useSharedKnowledgeFiles.mockReturnValue({
     files,
     error: null,
+    loading: false,
+    pendingIds: new Set<number>(),
     removeFile: vi.fn(),
     updateCategory: vi.fn(),
     syncOne: vi.fn(),

--- a/src/components/organisms/KnowledgeModal.tsx
+++ b/src/components/organisms/KnowledgeModal.tsx
@@ -17,7 +17,7 @@ interface KnowledgeModalProps {
 }
 
 export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
-  const { files, error, removeFile, updateCategory, syncOne, openFile, addFolder, pickAndAdd } =
+  const { files, error, pendingIds, removeFile, updateCategory, syncOne, openFile, addFolder, pickAndAdd } =
     useSharedKnowledgeFiles();
   const [activeTab, setActiveTab] = useState("All");
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -40,16 +40,30 @@ export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
     });
   };
 
+  // `bulkBusy` rather than reading pendingIds: the loops below are sequential, so only one id
+  // is ever in flight and pendingIds would let the toolbar re-arm between rows.
+  const [bulkBusy, setBulkBusy] = useState(false);
+
   const bulkRemove = async () => {
-    for (const id of selected) await removeFile(id);
-    setSelected(new Set());
+    setBulkBusy(true);
+    try {
+      for (const id of selected) await removeFile(id);
+      setSelected(new Set());
+    } finally {
+      setBulkBusy(false);
+    }
   };
 
   // Folder rows are skipped rather than passed through: syncing one is already a no-op in the
   // main process, but sending them would make the button look like it did something.
   const bulkSync = async () => {
-    const syncable = files.filter((f) => selected.has(f.id) && f.kind !== "folder");
-    for (const file of syncable) await syncOne(file.id);
+    setBulkBusy(true);
+    try {
+      const syncable = files.filter((f) => selected.has(f.id) && f.kind !== "folder");
+      for (const file of syncable) await syncOne(file.id);
+    } finally {
+      setBulkBusy(false);
+    }
   };
 
   const reveal = (path: string) => {
@@ -105,10 +119,10 @@ export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
             {selected.size > 0 && (
               <div className="km-bulk-toolbar">
                 <span>{selected.size} selected</span>
-                <button className="widget-icon-btn" aria-label="Bulk re-sync" onClick={bulkSync}>
+                <button className="widget-icon-btn" aria-label="Bulk re-sync" disabled={bulkBusy} onClick={bulkSync}>
                   <TablerIcon name="ti-refresh" />
                 </button>
-                <button className="widget-icon-btn" aria-label="Bulk remove" onClick={bulkRemove}>
+                <button className="widget-icon-btn" aria-label="Bulk remove" disabled={bulkBusy} onClick={bulkRemove}>
                   <TablerIcon name="ti-trash" />
                 </button>
               </div>
@@ -184,6 +198,7 @@ export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
                       <button
                         className="widget-icon-btn"
                         aria-label={`Re-sync ${file.originalName}`}
+                        disabled={pendingIds.has(file.id)}
                         onClick={() => void syncOne(file.id)}
                       >
                         <TablerIcon name="ti-refresh" />
@@ -194,6 +209,7 @@ export default function KnowledgeModal({ open, onClose }: KnowledgeModalProps) {
                       aria-label={
                         isFolder ? `Remove access to ${file.path}` : `Remove ${file.originalName}`
                       }
+                      disabled={pendingIds.has(file.id)}
                       onClick={() => void removeFile(file.id)}
                     >
                       <TablerIcon name="ti-x" />

--- a/src/hooks/useKnowledgeFiles.test.ts
+++ b/src/hooks/useKnowledgeFiles.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useKnowledgeFiles } from "./useKnowledgeFiles";
+
+/** Minimal stand-in for the preload bridge. Only the knowledgebase calls this hook makes. */
+function installBridge(overrides: Record<string, unknown> = {}) {
+  const api = {
+    knowledgebase: {
+      list: vi.fn().mockResolvedValue([]),
+      remove: vi.fn().mockResolvedValue(undefined),
+      sync: vi.fn().mockResolvedValue({ missing: [] }),
+      updateCategory: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    },
+    fs: { openPath: vi.fn().mockResolvedValue(undefined) },
+  };
+  (globalThis as unknown as { window: { agentsAPI: unknown } }).window.agentsAPI = api;
+  return api;
+}
+
+/** A promise you resolve by hand, so an operation can be held mid-flight and the pending state
+ * observed while it is genuinely outstanding. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useKnowledgeFiles pending state", () => {
+  beforeEach(() => {
+    installBridge();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+    vi.restoreAllMocks();
+  });
+
+  it("starts with nothing pending", async () => {
+    const { result } = renderHook(() => useKnowledgeFiles());
+
+    await waitFor(() => expect(result.current.pendingIds.size).toBe(0));
+  });
+
+  // U10 — the row's own buttons had no way to know an operation was already running, so an
+  // impatient second click queued a duplicate remove or re-sync.
+  it("marks a row pending while removeFile is in flight, and clears it after", async () => {
+    const gate = deferred<void>();
+    installBridge({ remove: vi.fn().mockReturnValue(gate.promise) });
+    const { result } = renderHook(() => useKnowledgeFiles());
+
+    let done!: Promise<void>;
+    act(() => {
+      done = result.current.removeFile(7);
+    });
+
+    await waitFor(() => expect(result.current.pendingIds.has(7)).toBe(true));
+
+    await act(async () => {
+      gate.resolve();
+      await done;
+    });
+
+    expect(result.current.pendingIds.has(7)).toBe(false);
+  });
+
+  it("marks a row pending while syncOne is in flight", async () => {
+    const gate = deferred<{ missing: [] }>();
+    installBridge({ sync: vi.fn().mockReturnValue(gate.promise) });
+    const { result } = renderHook(() => useKnowledgeFiles());
+
+    let done!: Promise<void>;
+    act(() => {
+      done = result.current.syncOne(3);
+    });
+
+    await waitFor(() => expect(result.current.pendingIds.has(3)).toBe(true));
+
+    await act(async () => {
+      gate.resolve({ missing: [] });
+      await done;
+    });
+
+    expect(result.current.pendingIds.has(3)).toBe(false);
+  });
+
+  // The `finally` in track() exists for exactly this: a row whose operation threw must not be
+  // left with dead buttons until the component remounts.
+  it("releases the row when the operation fails", async () => {
+    installBridge({ remove: vi.fn().mockRejectedValue(new Error("nope")) });
+    const { result } = renderHook(() => useKnowledgeFiles());
+
+    await act(async () => {
+      await result.current.removeFile(11);
+    });
+
+    expect(result.current.pendingIds.has(11)).toBe(false);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("tracks several rows independently", async () => {
+    const a = deferred<void>();
+    const b = deferred<void>();
+    const remove = vi.fn().mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    installBridge({ remove });
+    const { result } = renderHook(() => useKnowledgeFiles());
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = result.current.removeFile(1);
+      second = result.current.removeFile(2);
+    });
+
+    await waitFor(() => {
+      expect(result.current.pendingIds.has(1)).toBe(true);
+      expect(result.current.pendingIds.has(2)).toBe(true);
+    });
+
+    await act(async () => {
+      a.resolve();
+      await first;
+    });
+
+    // Releasing one must not release the other — a shared boolean would have.
+    expect(result.current.pendingIds.has(1)).toBe(false);
+    expect(result.current.pendingIds.has(2)).toBe(true);
+
+    await act(async () => {
+      b.resolve();
+      await second;
+    });
+
+    expect(result.current.pendingIds.size).toBe(0);
+  });
+});

--- a/src/hooks/useKnowledgeFiles.ts
+++ b/src/hooks/useKnowledgeFiles.ts
@@ -10,6 +10,28 @@ export function useKnowledgeFiles() {
     hasAgentsAPI() ? null : "Native filesystem bridge unavailable (window.agentsAPI is missing)."
   );
 
+  /** Ids of rows with an operation in flight, so a row's own controls can disable rather than
+   * queueing a second remove or re-sync behind the first. `loading` already covers the
+   * whole-list operations (pickAndAdd, addFolder); it says nothing about a single row, which is
+   * where the repeat clicks actually happen — re-syncing a URL is network-bound and gives no
+   * feedback of its own. */
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<number>>(() => new Set());
+
+  /** Marks `id` busy for the duration of `op`. `finally` rather than a trailing clear: an op
+   * that throws must still release the row, or its buttons stay dead until remount. */
+  const track = useCallback(async (id: number, op: () => Promise<void>): Promise<void> => {
+    setPendingIds((prev) => new Set(prev).add(id));
+    try {
+      await op();
+    } finally {
+      setPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }, []);
+
   const refresh = useCallback(async () => {
     if (!hasAgentsAPI()) return;
     const list = await window.agentsAPI.knowledgebase.list();
@@ -107,45 +129,51 @@ export function useKnowledgeFiles() {
     async (id: number) => {
       if (!hasAgentsAPI()) return;
       setError(null);
-      try {
-        await window.agentsAPI.knowledgebase.remove(id);
-        await refresh();
-      } catch (e) {
-        setError(formatHumanizedError(humanizeError(e)));
-      }
+      await track(id, async () => {
+        try {
+          await window.agentsAPI.knowledgebase.remove(id);
+          await refresh();
+        } catch (e) {
+          setError(formatHumanizedError(humanizeError(e)));
+        }
+      });
     },
-    [refresh]
+    [refresh, track]
   );
 
   const updateCategory = useCallback(
     async (id: number, category: string) => {
       if (!hasAgentsAPI()) return;
       setError(null);
-      try {
-        await window.agentsAPI.knowledgebase.updateCategory(id, category);
-        await refresh();
-      } catch (e) {
-        setError(formatHumanizedError(humanizeError(e)));
-      }
+      await track(id, async () => {
+        try {
+          await window.agentsAPI.knowledgebase.updateCategory(id, category);
+          await refresh();
+        } catch (e) {
+          setError(formatHumanizedError(humanizeError(e)));
+        }
+      });
     },
-    [refresh]
+    [refresh, track]
   );
 
   const syncOne = useCallback(
     async (id: number) => {
       if (!hasAgentsAPI()) return;
       setError(null);
-      try {
-        const { missing } = await window.agentsAPI.knowledgebase.sync(id);
-        await refresh();
-        if (missing.length > 0) {
-          setError(`Could not re-sync: ${missing.map((m) => `${m.name} (${m.error})`).join(", ")}`);
+      await track(id, async () => {
+        try {
+          const { missing } = await window.agentsAPI.knowledgebase.sync(id);
+          await refresh();
+          if (missing.length > 0) {
+            setError(`Could not re-sync: ${missing.map((m) => `${m.name} (${m.error})`).join(", ")}`);
+          }
+        } catch (e) {
+          setError(formatHumanizedError(humanizeError(e)));
         }
-      } catch (e) {
-        setError(formatHumanizedError(humanizeError(e)));
-      }
+      });
     },
-    [refresh]
+    [refresh, track]
   );
 
   const openFile = useCallback(async (filePath: string) => {
@@ -161,6 +189,7 @@ export function useKnowledgeFiles() {
   return {
     files,
     loading,
+    pendingIds,
     error,
     addFiles,
     addFolder,


### PR DESCRIPTION
## What changed

`useKnowledgeFiles` now reports which rows have an operation in flight, and both consumers disable the matching controls. Previously **neither `KnowledgeModal` nor `FilesAppsTab` contained a single `disabled` attribute**, across eight buttons that all fire async work.

## Root cause

The hook already returned `loading`, which covers the whole-list operations (`pickAndAdd`, `addFolder`). It said nothing about a single row — and that is where repeat clicks actually happen. Re-syncing a URL is network-bound and gives no feedback of its own, so a second click queued the whole operation again.

Bulk re-sync was the sharp edge: it loops over every selected row, with no indication it had started.

## Design notes

- **`pendingIds`, not a boolean.** A shared flag would disable every row while any one of them worked. A test pins that releasing one row leaves another still pending.
- **The clear is in a `finally`.** An operation that throws must still release the row — otherwise its buttons stay dead until the component remounts, which is worse than the bug being fixed. Covered by a test that rejects the bridge call.
- **The bulk toolbar gates on its own `bulkBusy`**, not on `pendingIds`. The loops are sequential, so only one id is ever in flight and `pendingIds` would let the toolbar re-arm between rows.
- **Both existing test mocks needed updating.** They stub `useSharedKnowledgeFiles` and returned no `pendingIds`, so the components rendered `.has()` against `undefined` and threw. Caught by the full suite, not by the new tests — which only passed in isolation.

## Testing

- Unit/integration: **1098 passed** (baseline 1093 at `601f88c`, +5). Predicted 1093+5 before running; matched.
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData`. Added a URL entry, opened Knowledge, clicked Re-sync and polled at 25ms — the button was **observed disabled while the fetch was in flight** and **enabled again after it completed**. Not inferred from the code.

## Notes

Two things noticed while validating, neither filed as findings:

- Inserting a knowledge row straight through the bridge leaves the Knowledge widget showing "Nothing added yet" until a reload — `useKnowledgeFiles` fetches on mount and nothing broadcasts external writes, unlike the `settings:update` / `connectors:update` / `tasks:update` broadcasts that exist for exactly this. No agent tool currently adds knowledge files, so nothing user-facing hits it today.
- `[aria-label="Expand knowledge base"]` is the Knowledge widget's expand control; the first `.widget-icon-btn` on the page belongs to a different widget and opens an agent info modal. Worth knowing for anyone scripting the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)