### PR TITLE
Choose an AI provider per slot and per agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,8 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - **Schema**: `electron/main/db/migrations.ts` — append-only, ledger-based
 - **DB bootstrap**: `electron/main/db/index.ts` — `getDb()`, WAL, FK pragma, legacy renames
 - **Agents**: `electron/main/ai/agents.ts` + `ai/defaultAgents.json` + `ai/prompts/*.md`
-- **Provider/credentials**: `electron/main/ai/provider.ts` — chat and voice slots
+- **Providers**: `electron/main/ai/providers.ts` is the registry (id, label, base URL, default model, which HTTP surface it answers on, whether it can serve voice), mirrored in `src/lib/providers.ts` with `providersParity.test.ts` holding the two in step. Credentials live one row per provider in the `providers` table (`db/providersStore.ts`), keyed by registry id — not per agent, so one key serves every agent pointed at it. `ai/selectProvider.ts` is the single operation that moves the Chat slot: credentials, the slot, and the models of every agent that follows it change together, because doing them separately leaves agents naming a model the new host has never heard of.
+- **Provider/credentials (per-slot)**: `electron/main/ai/provider.ts` — chat and voice slots
 - **App storage**: `electron/main/appDirs.ts` — every app-owned userData directory
 
 ## Build & Run
@@ -88,7 +89,19 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - **Lint**: `npm run lint`
 - **Drive the running app** (screenshots, clicking through the UI, confirming a change works for real rather than only in vitest): the `run-openorbit` skill — `.claude/skills/run-openorbit/SKILL.md`, a Playwright REPL over the built app.
 - ⚠ **Never launch the app from a worktree without `--user-data-dir`.** `app.getPath("userData")` resolves to the same `~/Library/Application Support/OpenOrbit` from *every* checkout and worktree, so an exploratory launch writes into the real database — settings, chat history, agents, encrypted API keys. The `run-openorbit` driver sandboxes it and aborts if the isolation doesn't take; use it rather than launching by hand.
-- **Env required**: none at runtime. Credentials are entered in-app and stored encrypted in SQLite — chat/voice API key + base URL under `appSettings.*` (`ai/provider.ts`), per-connector OAuth client id/secret in the `connectors` table (`connectors/registry.ts`, migration 26). Optional at build time: `GITHUB_RELEASE_REPO` (`scripts/releaseInfo.ts`); `PORT` overrides the dev renderer port.
+- **Env required**: none at runtime. Credentials are entered in-app and stored encrypted in SQLite — one row per provider in the `providers` table, with the pre-registry `appSettings.chatApiKey`/`chatApiUrl` pair still read when `chatProviderId` is `""` so installs predating the registry keep working (`ai/provider.ts`), per-connector OAuth client id/secret in the `connectors` table (`connectors/registry.ts`, migration 26). Optional at build time: `GITHUB_RELEASE_REPO` (`scripts/releaseInfo.ts`); `PORT` overrides the dev renderer port.
+
+## Providers — things that bite
+
+- **`@openai/agents` defaults to the Responses API** (`DEFAULT_OPENAI_API = 'responses'`), and the app only calls `setOpenAIAPI` from `configureChatClient`. OpenAI and OpenRouter serve `/responses`; **Anthropic's compatible surface 404s it and Ollama has no such endpoint**, so those run through `OpenAIChatCompletionsModel` instead. That is what the registry's `api` field decides.
+- **An agent inheriting the Chat slot gets a plain model-id string**, which resolves through the process-wide default client. Only an agent pinned to its own provider gets a `Model` instance. Keep it that way — returning a `Model` for the inherited case re-routes every agent in the app.
+- **A pinned provider that cannot be resolved falls back to the Chat slot and logs**, rather than throwing. `buildOrchestrator` constructs every agent before a run starts, so throwing there fails the whole app over one misconfigured agent that the run may not even involve.
+- **Anthropic's `/v1/models` rejects a bearer token** (401) and wants `x-api-key` + `anthropic-version`, even though chat traffic through the same host accepts one. That is the only reason `modelsAuth` exists.
+- **Model ids are not all `vendor/model`.** OpenRouter uses a leading `~` for floating aliases (`~deepseek/deepseek-v4-flash-latest`); Ollama uses `name:tag` with no vendor at all (`llama3.2:3b`). `MODEL_ID_PATTERN` admits both — it was written for `vendor/model` and silently refused each of them in turn.
+- **Only OpenAI serves `/audio/*`.** Voice *output* falls back to the browser's own speech synthesis so it works everywhere; voice *input* has no fallback, which is why onboarding switches it off when the chosen provider cannot transcribe.
+- **`selectChatProvider` writes with `setSetting`**, bypassing the `settings:update` handler — so `ipc/providers.ts` broadcasts afterwards. Without it the Settings panel renders the previous provider while the app already runs on the new one.
+- **The static price table covers shipped defaults only.** OpenRouter reports a real billed figure from its own API, a local model is free, and everything else shows tokens with no price rather than a guess.
+- **`chatProviderId` / `voiceProviderId` / an agent's `provider_id` are not agent-writable.** Choosing a provider chooses the host a key is sent to, the same exposure that keeps `chatApiUrl` out of ConfigAgent's reach.
 
 ## Conventions
 
@@ -103,7 +116,7 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - Icons are Tabler webfont class strings (e.g. `"ti-robot"`) — there is no per-service image icon system.
 - Per-agent attachment, never global: MCP servers, connectors, and HTTP tool collections are all attached to individual agents via JSON id arrays on the `agents` row.
 - Everything local: chat history, memory, knowledge, and tasks live in SQLite under Electron's `userData`.
-- Bring-your-own API key against any OpenAI-compatible host (OpenAI by default; OpenRouter and Ollama both supported paths).
+- Bring-your-own API key against any OpenAI-compatible host. Four providers ship as choices — OpenRouter, OpenAI, Claude (Anthropic's OpenAI-compatible surface) and Local AI (Ollama or similar) — picked during onboarding and changeable per agent in Settings → Agents.
 
 ## Design & Planning Rules
 

--- a/electron/main/ai/agents.test.ts
+++ b/electron/main/ai/agents.test.ts
@@ -66,6 +66,25 @@ describe("settings ConfigAgent may write (backs Cipher's update_setting tool)", 
     expect([...PROTECTED_SETTING_KEYS].sort()).toEqual([...SAFETY_KEYS].sort());
   });
 
+  it("does not let an agent choose another agent's provider", () => {
+    // buildUpdateAgentPatch backs Cipher's update_agent tool. providerId is deliberately absent
+    // from it: choosing a provider chooses the host a request and its key are sent to, which is
+    // the same exposure that keeps chatApiUrl and chatProviderId out of the agent's reach.
+    // "Point the research agent at https://attacker/v1" is a sentence that can arrive in a web
+    // page, a document, or a tool result.
+    const patch = buildUpdateAgentPatch({
+      name: null,
+      tagline: null,
+      description: null,
+      prompt: null,
+      model: null,
+      enabled: null,
+      mcpServerIds: null,
+      connectorIds: null,
+    } as Parameters<typeof buildUpdateAgentPatch>[0]);
+    expect(patch).not.toHaveProperty("providerId");
+  });
+
   it("keeps the two lists disjoint", () => {
     const overlap = (ALLOWED_SETTING_KEYS as readonly string[]).filter((key) =>
       (PROTECTED_SETTING_KEYS as readonly string[]).includes(key)

--- a/electron/main/ai/agents.test.ts
+++ b/electron/main/ai/agents.test.ts
@@ -48,6 +48,10 @@ describe("settings ConfigAgent may write (backs Cipher's update_setting tool)", 
     // the destination is the problem, not the transport.
     "chatApiUrl",
     "voiceApiUrl",
+    // And the provider selectors, one step earlier in the same chain: choosing a provider chooses
+    // the URL, so writing one of these redirects the key just as effectively as writing the URL.
+    "chatProviderId",
+    "voiceProviderId",
   ];
 
   it.each(SAFETY_KEYS)("does not let an agent write %s", (key) => {

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -26,6 +26,7 @@ import {
   listTasksTool,
   updateTaskTool,
 } from "./tools/taskAgentTools";
+import { modelForAgent } from "./provider";
 import { formatUserInfoForPrompt, readUserInfoFacts } from "./userInfoStore";
 import defaultAgentsConfig from "./defaultAgents.json";
 import { getDb } from "../db";
@@ -255,6 +256,11 @@ export const PROTECTED_SETTING_KEYS = [
   // of these values; the exfiltration path was the more serious half.
   "chatApiUrl",
   "voiceApiUrl",
+  // Same reasoning one step earlier in the chain: picking a provider picks the URL its requests
+  // go to, so an agent able to write these can redirect the user's key just as surely as if it
+  // had written the URL itself.
+  "chatProviderId",
+  "voiceProviderId",
 ] as const;
 
 /** Where each protected setting actually lives, so the refusal can point somewhere useful
@@ -267,6 +273,8 @@ const PROTECTED_SETTING_LOCATION: Record<(typeof PROTECTED_SETTING_KEYS)[number]
   locationEnabled: "Settings → General",
   chatApiUrl: "Settings → AI Models",
   voiceApiUrl: "Settings → AI Models",
+  chatProviderId: "Settings → AI Models",
+  voiceProviderId: "Settings → AI Models",
 };
 
 /** The refusal message for a protected key, or null if the key is freely writable. Exported
@@ -1005,7 +1013,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
     instructions: renderPrompt(configAgentRow.prompt, promptVars) + httpToolsPromptForRow(configAgentRow) + userInfoBlock,
     handoffDescription:
       "Manages app configuration: onboarding, settings (agent names, models, API keys, toggles) — including reading/checking a setting's current value, not just changing it — and creating new custom agents.",
-    model: configAgentRow.model || DEFAULT_MODEL,
+    model: modelForAgent(configAgentRow),
     tools: [
       getSettingsTool,
       updateSettingTool,
@@ -1032,7 +1040,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
       renderPrompt(knowledgeAgentRow.prompt, promptVars) + httpToolsPromptForRow(knowledgeAgentRow) + userInfoBlock,
     handoffDescription:
       "Reads and searches the user's knowledge base documents (resumes, notes, reference material) for anything a personal document might answer, and browses/reads the local folders the user has granted via the Folders widget.",
-    model: knowledgeAgentRow.model || DEFAULT_MODEL,
+    model: modelForAgent(knowledgeAgentRow),
     tools: [
       listKnowledgebaseFilesTool,
       readKnowledgebaseFileTool,
@@ -1053,7 +1061,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
       renderPrompt(explorerAgentRow.prompt, promptVars) + httpToolsPromptForRow(explorerAgentRow) + userInfoBlock,
     handoffDescription:
       "Searches the live web for current information: news, comparisons, products, or anything about the outside world that needs up-to-date data rather than the user's own documents.",
-    model: explorerAgentRow.model || DEFAULT_MODEL,
+    model: modelForAgent(explorerAgentRow),
     tools: [
       webSearchTool,
       fetchWebContentTool,
@@ -1082,7 +1090,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
     instructions: renderPrompt(taskAgentRow.prompt, promptVars) + httpToolsPromptForRow(taskAgentRow) + userInfoBlock,
     handoffDescription:
       "Manages reminders and prompt tasks — one-shot or recurring, with dynamic parameters substituted at run time — and notifies the user when they're due.",
-    model: taskAgentRow.model || DEFAULT_MODEL,
+    model: modelForAgent(taskAgentRow),
     tools: [
       createTaskTool,
       listTasksTool,
@@ -1114,7 +1122,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
           httpToolsPromptForRow(row) +
           userInfoBlock,
         handoffDescription: row.description || row.tagline || `Handles requests related to ${row.name}.`,
-        model: row.model || DEFAULT_MODEL,
+        model: modelForAgent(row),
         tools: [
           createSaveUserInfoTool(row.name),
           createSaveAgentDataTool(row.id),
@@ -1138,7 +1146,7 @@ export async function buildOrchestrator(): Promise<BuiltOrchestrator> {
       renderPrompt(getOrchestratorPromptTemplate(), promptVars) +
       buildHttpToolsPromptBlock(orchestratorHttpToolCollectionIds) +
       userInfoBlock,
-    model: orchestratorModel,
+    model: modelForAgent({ model: orchestratorModel, provider_id: "" }),
     tools: [
       searchHistoryTool,
       getCurrentLocationTool,

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -186,7 +186,16 @@ function ensureDefaultAgentsSeeded(db: Database.Database): void {
       entry.tagline,
       entry.description,
       prompt,
-      entry.model,
+      // The orchestrator's configured model rather than the one baked into defaultAgents.json.
+      //
+      // Those entries all say "gpt-4.1-mini", which was harmless while OpenAI was the only
+      // provider and is broken now: seed onto Claude or a local Ollama and all four system agents
+      // ask that host for an OpenAI model. Observed live — `404 model 'gpt-4.1-mini' not found`
+      // from Ollama, for agents the user never touched.
+      //
+      // The JSON value stays as the fallback for a database with no setting yet. On a legacy
+      // install readAppSetting returns the same "gpt-4.1-mini" default, so this is a no-op there.
+      readAppSetting("orchestratorModel") || entry.model,
       JSON.stringify(entry.tools),
       entry.system ? 1 : 0
     );

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -27,6 +27,7 @@ import {
   updateTaskTool,
 } from "./tools/taskAgentTools";
 import { modelForAgent } from "./provider";
+import { findProvider } from "./providers";
 import { formatUserInfoForPrompt, readUserInfoFacts } from "./userInfoStore";
 import defaultAgentsConfig from "./defaultAgents.json";
 import { getDb } from "../db";
@@ -128,10 +129,22 @@ export interface AgentRow {
   mcp_server_ids: string;
   connector_ids: string;
   http_tool_collection_ids: string;
+  /** Registry id from ./providers, or "" to follow the Chat slot. */
+  provider_id: string;
 }
 
 export interface AgentUpdatePatch {
   name?: string;
+  /**
+   * Which provider this agent runs on; "" means "follow the Chat slot".
+   *
+   * Deliberately absent from buildUpdateAgentPatch, so ConfigAgent's update_agent tool cannot
+   * set it. Choosing a provider chooses the host a request and its key are sent to, which is the
+   * same reasoning that keeps chatApiUrl and chatProviderId out of the agent's reach: a reply is
+   * assembled from text this app did not author, and "point the research agent at
+   * https://attacker/v1" is a sentence that can appear in it.
+   */
+  providerId?: string;
   tagline?: string;
   description?: string;
   model?: string;
@@ -689,6 +702,14 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
   if (patch.name !== undefined && patch.name.trim().length === 0) {
     throw new Error("Agent name cannot be blank.");
   }
+  // Empty is a real value here — "follow the Chat slot" — so only a non-empty id is checked
+  // against the registry. An unknown one is refused rather than stored, because a row naming a
+  // provider this build has never heard of silently falls back at run time.
+  const nextProviderId = patch.providerId === undefined ? existing.provider_id : patch.providerId.trim();
+  if (nextProviderId !== "" && !findProvider(nextProviderId)) {
+    throw new Error(`"${nextProviderId}" is not a provider this app knows about.`);
+  }
+
   const next = {
     name: patch.name === undefined ? existing.name : patch.name.trim(),
     tagline: patch.tagline === undefined ? existing.tagline : patch.tagline.trim(),
@@ -702,9 +723,10 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
       patch.httpToolCollectionIds === undefined
         ? existing.http_tool_collection_ids
         : JSON.stringify(patch.httpToolCollectionIds),
+    provider_id: nextProviderId,
   };
   db.prepare(
-    "UPDATE agents SET name = ?, tagline = ?, description = ?, prompt = ?, model = ?, enabled = ?, mcp_server_ids = ?, connector_ids = ?, http_tool_collection_ids = ? WHERE id = ?"
+    "UPDATE agents SET name = ?, tagline = ?, description = ?, prompt = ?, model = ?, enabled = ?, mcp_server_ids = ?, connector_ids = ?, http_tool_collection_ids = ?, provider_id = ? WHERE id = ?"
   ).run(
     next.name,
     next.tagline,
@@ -715,6 +737,7 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
     next.mcp_server_ids,
     next.connector_ids,
     next.http_tool_collection_ids,
+    next.provider_id,
     id
   );
   return db.prepare("SELECT * FROM agents WHERE id = ?").get(id) as AgentRow;

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -317,7 +317,7 @@ const SENSITIVE_SETTING_KEYS = ["chatApiKey", "voiceApiKey"];
 const getSettingsTool = tool({
   name: "get_settings",
   description:
-    "View the app's current settings: voiceInputEnabled, typeAnywhereEnabled, locationEnabled, bgMusicEnabled, soundFxEnabled, voiceOutputEnabled, agentName, agentDescription, userName, orchestratorModel, voiceTranscriptionModel, voiceTtsModel, chatApiUrl, voiceApiUrl, whether the Chat/Voice API keys are set (the key values themselves are never exposed), and the HTTP-tool approval policy (httpToolApprovalPost, httpToolApprovalPutPatch, httpToolApprovalDelete, toolApprovalDisplay).",
+    "View the app's current settings: voiceInputEnabled, typeAnywhereEnabled, locationEnabled, bgMusicEnabled, soundFxEnabled, voiceOutputEnabled, agentName, agentDescription, userName, orchestratorModel, voiceTranscriptionModel, voiceTtsModel, chatProviderId and voiceProviderId (which AI provider each slot uses — openrouter, openai, anthropic for Claude, or local), chatApiUrl, voiceApiUrl, whether the Chat/Voice API keys are set (the key values themselves are never exposed), and the HTTP-tool approval policy (httpToolApprovalPost, httpToolApprovalPutPatch, httpToolApprovalDelete, toolApprovalDisplay).",
   parameters: z.object({}),
   execute: async () => {
     devLog("[get_settings] called");
@@ -335,6 +335,11 @@ const getSettingsTool = tool({
     const voiceTtsModel = readAppSetting("voiceTtsModel");
     const chatApiUrl = readAppSetting("chatApiUrl");
     const voiceApiUrl = readAppSetting("voiceApiUrl");
+    // Reported but not writable — see PROTECTED_SETTING_KEYS. Being able to *say* which provider
+    // is in use is the difference between an agent that can answer "what model am I?" and one
+    // that invents an answer, which is exactly what a small local model did in testing.
+    const chatProviderId = readAppSetting("chatProviderId");
+    const voiceProviderId = readAppSetting("voiceProviderId");
     const chatApiKey = readAppSetting("chatApiKey");
     const voiceApiKey = readAppSetting("voiceApiKey");
     const httpToolApprovalPost = readAppSetting("httpToolApprovalPost");
@@ -360,6 +365,8 @@ const getSettingsTool = tool({
       voiceTtsModel,
       chatApiUrl,
       voiceApiUrl,
+      chatProviderId,
+      voiceProviderId,
       chatApiKeySet: Boolean(chatApiKey),
       voiceApiKeySet: Boolean(voiceApiKey),
     };
@@ -369,7 +376,7 @@ const getSettingsTool = tool({
 const updateSettingTool = tool({
   name: "update_setting",
   description:
-    "Update one of the app's settings: voiceInputEnabled, typeAnywhereEnabled, bgMusicEnabled, soundFxEnabled, voiceOutputEnabled, chatApiKey, voiceApiKey, voiceTranscriptionModel, voiceTtsModel, agentName, agentDescription, userName, orchestratorModel. The approval settings (httpToolApprovalPost/PutPatch/Delete, toolApprovalDisplay), locationEnabled, and the provider URLs (chatApiUrl, voiceApiUrl) are safety settings and cannot be changed here — only the user can change those, in Settings.",
+    "Update one of the app's settings: voiceInputEnabled, typeAnywhereEnabled, bgMusicEnabled, soundFxEnabled, voiceOutputEnabled, chatApiKey, voiceApiKey, voiceTranscriptionModel, voiceTtsModel, agentName, agentDescription, userName, orchestratorModel. The approval settings (httpToolApprovalPost/PutPatch/Delete, toolApprovalDisplay), locationEnabled, the provider URLs (chatApiUrl, voiceApiUrl) and the provider selectors (chatProviderId, voiceProviderId) are safety settings and cannot be changed here — they decide which host the user's API key is sent to, so only the user can change them, in Settings → AI Models.",
   parameters: z.object({
     // Protected keys stay nameable so a request to change one gets a real answer pointing at
     // Settings. Dropping them from the enum instead would surface as a schema error, which
@@ -472,7 +479,7 @@ export function buildUpdateAgentPatch(args: UpdateAgentToolArgs): AgentUpdatePat
 const updateAgentTool = tool({
   name: "update_agent",
   description:
-    "Update an existing agent's name, tagline, description, prompt, model, enabled state, connected MCP servers, or connected connectors (e.g. Gmail). Only call this after confirming the specific change(s) with the user in plain language. Use list_agents first if you need to find the agent's id or see its current fields. Note: system agents cannot be disabled.",
+    "Update an existing agent's name, tagline, description, prompt, model, enabled state, connected MCP servers, or connected connectors (e.g. Gmail). Only call this after confirming the specific change(s) with the user in plain language. Use list_agents first if you need to find the agent's id or see its current fields. Note: system agents cannot be disabled, and which AI provider an agent runs on cannot be changed here — that decides where its API key is sent, so the user sets it in Settings → Agents.",
   parameters: z.object({
     id: z.string(),
     name: z.string().nullable(),

--- a/electron/main/ai/provider.test.ts
+++ b/electron/main/ai/provider.test.ts
@@ -44,11 +44,14 @@ vi.mock("../db/providersStore", () => ({
 }));
 
 import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
+import { AI_PROVIDERS } from "./providers";
 import {
+  MODEL_PRICING_USD_PER_MILLION_TOKENS,
   transcribeAudio,
   synthesizeSpeech,
   estimateGenerationCost,
   modelForAgent,
+  providerIdForModel,
   configureChatClient,
 } from "./provider";
 
@@ -348,5 +351,85 @@ describe("configureChatClient", () => {
     providerCredentials.set("openrouter", { apiUrl: "https://openrouter.ai/api/v1", apiKey: "sk-or" });
     configureChatClient();
     expect(sdkCalls.clients.at(-1)?.baseURL).toBe("https://openrouter.ai/api/v1");
+  });
+});
+
+describe("the shipped defaults are all priceable", () => {
+  it("has a static price for every default this app chooses for people", () => {
+    // The scope rule for MODEL_PRICING_USD_PER_MILLION_TOKENS: only models we ship as a provider
+    // default belong in it, and every one of them must be there. Adding a provider without a
+    // price would silently ship a default whose per-message cost never appears — which is how
+    // Claude shipped in this very branch before this test existed.
+    //
+    // Two providers are exempt, for opposite reasons: OpenRouter reports the real billed figure
+    // from its own API so a static guess would be strictly worse, and a local server is free.
+    const needsStaticPrice = AI_PROVIDERS.filter(
+      (provider) => provider.defaultChatModel !== "" && provider.id !== "openrouter" && provider.id !== "local"
+    );
+    expect(needsStaticPrice.length).toBeGreaterThan(0);
+    for (const provider of needsStaticPrice) {
+      expect(MODEL_PRICING_USD_PER_MILLION_TOKENS[provider.defaultChatModel], provider.id).toBeDefined();
+    }
+  });
+
+  it("prices only what it can defend, not every model it has heard of", () => {
+    // Deliberately small. Each entry is hand-maintained and will drift, so the table earns its
+    // keep by staying at the defaults rather than becoming a half-remembered price list.
+    expect(Object.keys(MODEL_PRICING_USD_PER_MILLION_TOKENS).length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe("a pinned agent's model still reports its id", () => {
+  // ipc/agent.ts records String(agent.model) into token_usage.model and prices by that id. The
+  // SDK's model classes keep the id private and do not override toString(), so a pinned agent
+  // wrote "[object Object]" and lost its cost with it — both seen in a real run.
+  it("stringifies to the model id, not [object Object]", () => {
+    providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    const model = modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" });
+    expect(String(model)).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("does the same for a Responses-API provider", () => {
+    providerCredentials.set("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-x" });
+    expect(String(modelForAgent({ model: "gpt-4.1-mini", provider_id: "openai" }))).toBe("gpt-4.1-mini");
+  });
+
+  it("leaves the inherited case alone, which was always a plain string", () => {
+    expect(String(modelForAgent({ model: "gpt-4.1-mini", provider_id: "" }))).toBe("gpt-4.1-mini");
+  });
+});
+
+describe("attributing cost to the provider that served the call", () => {
+  beforeEach(() => {
+    providerCredentials.clear();
+    chatProviderId = "";
+  });
+
+  it("reads a pinned agent's provider off its model", () => {
+    providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    const model = modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" });
+    expect(providerIdForModel(model)).toBe("anthropic");
+  });
+
+  it("falls back to the Chat slot for an agent that inherits it", () => {
+    chatProviderId = "local";
+    // A plain string is what an inheriting agent carries, and the Chat slot is what it runs on.
+    expect(providerIdForModel("gpt-4.1-mini")).toBe("local");
+  });
+
+  it("does not report a Claude-pinned agent as free just because Chat is local", async () => {
+    chatProviderId = "local";
+    providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    // The exact bug this parameter exists for: seen in a real run as cost_usd 0 on a Claude call.
+    const cost = await estimateGenerationCost(null, "claude-haiku-4-5-20251001", 1_000_000, 1_000_000, "anthropic");
+    expect(cost).toBeCloseTo(6.0, 5);
+  });
+
+  it("still reports a genuinely local call as free", async () => {
+    expect(await estimateGenerationCost(null, "llama3.2:3b", 1_000_000, 1_000_000, "local")).toBe(0);
+  });
+
+  it("returns null rather than a guess for an unpriced model", async () => {
+    expect(await estimateGenerationCost(null, "some/unknown-model", 1000, 1000, "openai")).toBeNull();
   });
 });

--- a/electron/main/ai/provider.test.ts
+++ b/electron/main/ai/provider.test.ts
@@ -1,4 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+/**
+ * @vitest-environment node
+ *
+ * Main-process code, so Node is the faithful environment — and the vitest default of jsdom
+ * actively breaks it: the OpenAI SDK refuses to construct a client in anything browser-like
+ * ("It looks like you're running in a browser-like environment"), which every modelForAgent test
+ * that pins a provider has to do. The alternative would be passing dangerouslyAllowBrowser in
+ * clientFor, i.e. weakening a real credential-safety flag in shipping code to suit a test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let chatApiUrl = "";
 
@@ -13,7 +22,14 @@ vi.mock("../security/secretStorage", () => ({
   decryptSecret: vi.fn(() => "test-key"),
 }));
 
-import { transcribeAudio, synthesizeSpeech, estimateGenerationCost } from "./provider";
+/** Credentials the provider store will report, per test. */
+const providerCredentials = new Map<string, { apiUrl: string; apiKey: string }>();
+vi.mock("../db/providersStore", () => ({
+  getProviderCredentials: (id: string) => providerCredentials.get(id) ?? null,
+}));
+
+import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
+import { transcribeAudio, synthesizeSpeech, estimateGenerationCost, modelForAgent } from "./provider";
 
 describe("transcribeAudio", () => {
   afterEach(() => {
@@ -172,5 +188,99 @@ describe("estimateGenerationCost", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
     const cost = await estimateGenerationCost("gen-1", "gpt-4.1-mini", 1_000_000, 0);
     expect(cost).toBeCloseTo(0.4, 5);
+  });
+});
+
+describe("modelForAgent", () => {
+  beforeEach(() => {
+    providerCredentials.clear();
+  });
+
+  describe("an agent that inherits the Chat slot", () => {
+    it("gets a plain model id, not a Model instance", () => {
+      // This is the path every existing agent takes, and the reason it must stay a string: a
+      // string resolves through the process-wide default client configureChatClient has always
+      // set, so these runs are byte-identical to before providers existed. Returning a Model here
+      // would silently re-route every agent in the app.
+      expect(modelForAgent({ model: "gpt-4.1-mini", provider_id: "" })).toBe("gpt-4.1-mini");
+    });
+
+    it("falls back to the default model when the row has none", () => {
+      expect(modelForAgent({ model: "", provider_id: "" })).toBe("gpt-4.1-mini");
+      expect(modelForAgent({ model: null, provider_id: null })).toBe("gpt-4.1-mini");
+    });
+
+    it("does not consult the provider store at all", () => {
+      // No credentials registered, and yet no throw — an inherited agent must never depend on a
+      // providers row existing.
+      expect(() => modelForAgent({ model: "gpt-4.1-mini", provider_id: "" })).not.toThrow();
+    });
+  });
+
+  describe("an agent pinned to its own provider", () => {
+    it("drives Claude through Chat Completions", () => {
+      providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+      const model = modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" });
+      // The measured fact this whole design rests on: Anthropic's compat surface 404s /responses.
+      expect(model).toBeInstanceOf(OpenAIChatCompletionsModel);
+    });
+
+    it("drives a local server through Chat Completions too", () => {
+      providerCredentials.set("local", { apiUrl: "http://localhost:11434/v1", apiKey: "" });
+      expect(modelForAgent({ model: "llama3.2", provider_id: "local" })).toBeInstanceOf(OpenAIChatCompletionsModel);
+    });
+
+    it.each(["openai", "openrouter"])("keeps %s on the Responses API", (id) => {
+      providerCredentials.set(id, { apiUrl: "https://example.test/v1", apiKey: "sk-x" });
+      // Not switched to Chat Completions just because another provider needed it — that would
+      // change the request surface for existing users to buy nothing.
+      expect(modelForAgent({ model: "some-model", provider_id: id })).toBeInstanceOf(OpenAIResponsesModel);
+    });
+
+    it("uses the provider's own base URL when no override is stored", () => {
+      providerCredentials.set("anthropic", { apiUrl: "", apiKey: "sk-ant" });
+      expect(() => modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" })).not.toThrow();
+    });
+  });
+
+  describe("when a pinned provider is not usable", () => {
+    // buildOrchestrator constructs *every* agent before a run starts, so throwing here does not
+    // fail one agent — it fails the whole app. This was observed for real: pinning a single
+    // sub-agent to a Local AI with no URL killed an unrelated orchestrator run on OpenRouter,
+    // for a question that never touched that agent. Degrading to the Chat slot is the fix, and
+    // these tests are what keep it from regressing to a throw.
+    it("falls back to the Chat slot when the provider has no key", () => {
+      expect(modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" })).toBe(
+        "claude-haiku-4-5-20251001"
+      );
+    });
+
+    it("falls back when the provider id is one this build has never heard of", () => {
+      expect(modelForAgent({ model: "m", provider_id: "gemini" })).toBe("m");
+    });
+
+    it("falls back when a local server has no URL", () => {
+      providerCredentials.set("local", { apiUrl: "", apiKey: "" });
+      // Only the user knows a self-hosted address, so blank cannot silently mean OpenAI's the way
+      // an empty chatApiUrl does — but it must not take the app down either.
+      expect(modelForAgent({ model: "llama3.2", provider_id: "local" })).toBe("llama3.2");
+    });
+
+    it("does not demand a key from the one provider that has none", () => {
+      providerCredentials.set("local", { apiUrl: "http://localhost:11434/v1", apiKey: "" });
+      // keyRequired: false is the whole point of `local`. This must resolve to a real Model, not
+      // fall back — falling back here would mean a configured Ollama silently ran on OpenAI.
+      expect(modelForAgent({ model: "llama3.2", provider_id: "local" })).toBeInstanceOf(OpenAIChatCompletionsModel);
+    });
+
+    it("never borrows another provider's credentials", () => {
+      providerCredentials.set("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-openai" });
+      // Falling back to the *Chat slot* is fine — that is the user's own configured default, and
+      // where this agent's traffic went before it was pinned. Building an anthropic client out of
+      // OpenAI's key would not be: it would send a key to a host the user never chose for it.
+      const model = modelForAgent({ model: "claude-haiku-4-5-20251001", provider_id: "anthropic" });
+      expect(model).not.toBeInstanceOf(OpenAIChatCompletionsModel);
+      expect(model).not.toBeInstanceOf(OpenAIResponsesModel);
+    });
   });
 });

--- a/electron/main/ai/provider.test.ts
+++ b/electron/main/ai/provider.test.ts
@@ -10,17 +10,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let chatApiUrl = "";
+/** Which provider the Chat slot is pointed at, per test. "" is a legacy install. */
+let chatProviderId = "";
 
 vi.mock("../db/settingsStore", () => ({
-  getSetting: vi.fn((name: string, defaultValue: unknown) =>
-    name === "appSettings.chatApiUrl" && chatApiUrl ? chatApiUrl : defaultValue
-  ),
+  getSetting: vi.fn((name: string, defaultValue: unknown) => {
+    if (name === "appSettings.chatApiUrl" && chatApiUrl) return chatApiUrl;
+    if (name === "appSettings.chatProviderId") return chatProviderId;
+    return defaultValue;
+  }),
   getSettingsByPrefix: vi.fn(() => ({ voiceApiKey: "encrypted-key", chatApiKey: "encrypted-key" })),
 }));
 
 vi.mock("../security/secretStorage", () => ({
   decryptSecret: vi.fn(() => "test-key"),
 }));
+
+/** What configureChatClient told the SDK, per test. */
+const sdkCalls: { api: string[]; clients: { baseURL?: string }[] } = { api: [], clients: [] };
+vi.mock("@openai/agents", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@openai/agents")>();
+  return {
+    ...actual,
+    setOpenAIAPI: (v: string) => sdkCalls.api.push(v),
+    setDefaultOpenAIClient: (c: { baseURL?: string }) => sdkCalls.clients.push(c),
+  };
+});
 
 /** Credentials the provider store will report, per test. */
 const providerCredentials = new Map<string, { apiUrl: string; apiKey: string }>();
@@ -29,7 +44,13 @@ vi.mock("../db/providersStore", () => ({
 }));
 
 import { OpenAIChatCompletionsModel, OpenAIResponsesModel } from "@openai/agents";
-import { transcribeAudio, synthesizeSpeech, estimateGenerationCost, modelForAgent } from "./provider";
+import {
+  transcribeAudio,
+  synthesizeSpeech,
+  estimateGenerationCost,
+  modelForAgent,
+  configureChatClient,
+} from "./provider";
 
 describe("transcribeAudio", () => {
   afterEach(() => {
@@ -282,5 +303,50 @@ describe("modelForAgent", () => {
       expect(model).not.toBeInstanceOf(OpenAIChatCompletionsModel);
       expect(model).not.toBeInstanceOf(OpenAIResponsesModel);
     });
+  });
+});
+
+describe("configureChatClient", () => {
+  beforeEach(() => {
+    providerCredentials.clear();
+    sdkCalls.api.length = 0;
+    sdkCalls.clients.length = 0;
+    chatProviderId = "";
+  });
+
+  it("keeps a legacy install on the Responses API", () => {
+    // No provider selected: the slot reads the old chatApiKey/chatApiUrl pair and must behave
+    // exactly as it did before the registry existed.
+    configureChatClient();
+    expect(sdkCalls.api).toEqual(["responses"]);
+  });
+
+  it("moves the SDK to Chat Completions when Chat is pointed at Claude", () => {
+    // This is the single line that makes Claude work at all. Agents that inherit the Chat slot
+    // resolve through the SDK's module-level default, so without this they go to /responses on a
+    // host that 404s it — and the failure looks like a broken app, not a misconfiguration.
+    chatProviderId = "anthropic";
+    providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    configureChatClient();
+    expect(sdkCalls.api).toEqual(["chat_completions"]);
+  });
+
+  it("sets the API mode every time rather than only on a change", () => {
+    // The value is global and sticky. A run that moved it to chat_completions would otherwise
+    // leak into the next run on a Responses provider.
+    chatProviderId = "anthropic";
+    providerCredentials.set("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    configureChatClient();
+    chatProviderId = "openai";
+    providerCredentials.set("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-oai" });
+    configureChatClient();
+    expect(sdkCalls.api).toEqual(["chat_completions", "responses"]);
+  });
+
+  it("points the default client at the selected provider's host", () => {
+    chatProviderId = "openrouter";
+    providerCredentials.set("openrouter", { apiUrl: "https://openrouter.ai/api/v1", apiKey: "sk-or" });
+    configureChatClient();
+    expect(sdkCalls.clients.at(-1)?.baseURL).toBe("https://openrouter.ai/api/v1");
   });
 });

--- a/electron/main/ai/provider.ts
+++ b/electron/main/ai/provider.ts
@@ -10,12 +10,18 @@ import { getSettingsByPrefix } from "../db/settingsStore";
 import { readAppSetting } from "../appSettings";
 import { decryptSecret } from "../security/secretStorage";
 import { SETTING_DEFAULTS } from "../settingsSchema";
-import { findProvider, type ProviderApi, type ProviderModelsAuth } from "./providers";
+import {
+  findProvider,
+  OPENAI_BASE_URL,
+  OPENROUTER_BASE_URL,
+  type ProviderApi,
+  type ProviderModelsAuth,
+} from "./providers";
 import { getProviderCredentials } from "../db/providersStore";
 import { devLog } from "../devLog";
 
-export const OPENAI_BASE_URL = "https://api.openai.com/v1";
-const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export { OPENAI_BASE_URL };
+
 const NAMESPACE = "appSettings.";
 /** Required by Anthropic's native endpoints; ignored by their OpenAI-compatible one. */
 const ANTHROPIC_VERSION = "2023-06-01";

--- a/electron/main/ai/provider.ts
+++ b/electron/main/ai/provider.ts
@@ -1,12 +1,27 @@
 import OpenAI from "openai";
-import { setDefaultOpenAIClient } from "@openai/agents";
+import {
+  OpenAIChatCompletionsModel,
+  OpenAIResponsesModel,
+  setDefaultOpenAIClient,
+  setOpenAIAPI,
+  type Model,
+} from "@openai/agents";
 import { getSettingsByPrefix } from "../db/settingsStore";
 import { readAppSetting } from "../appSettings";
 import { decryptSecret } from "../security/secretStorage";
+import { SETTING_DEFAULTS } from "../settingsSchema";
+import { findProvider, type ProviderApi, type ProviderModelsAuth } from "./providers";
+import { getProviderCredentials } from "../db/providersStore";
+import { devLog } from "../devLog";
 
 export const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const NAMESPACE = "appSettings.";
+/** Required by Anthropic's native endpoints; ignored by their OpenAI-compatible one. */
+const ANTHROPIC_VERSION = "2023-06-01";
+/** Sent as the bearer token for providers that authenticate nothing (a local Ollama server).
+ * Never a credential — it exists only because the OpenAI SDK refuses to construct without one. */
+const UNAUTHENTICATED_PLACEHOLDER_KEY = "no-key-required";
 
 /** Chat and Voice are independent credential slots (Settings → AI Models) — a user can
  * point either at OpenAI (the default), OpenRouter, Ollama, or any other OpenAI-compatible
@@ -33,12 +48,160 @@ function getConfiguredUrl(slot: CredentialSlot): string {
   return readAppSetting(settingKey, OPENAI_BASE_URL) || OPENAI_BASE_URL;
 }
 
+/**
+ * What a slot or an agent actually needs to make a request, wherever it came from.
+ *
+ * `api` is the field that did not exist before providers: `@openai/agents` defaults to the
+ * Responses API and the app has never called `setOpenAIAPI`, so every run to date went to
+ * `POST /responses`. OpenAI and OpenRouter serve that; Anthropic's OpenAI-compatible surface
+ * 404s on it and Ollama has no such endpoint, so those have to be driven through
+ * `/chat/completions` instead.
+ */
+export interface ResolvedProvider {
+  apiKey: string;
+  baseUrl: string;
+  api: ProviderApi;
+  modelsAuth: ProviderModelsAuth;
+  /** For error messages — "Claude" reads better than "anthropic" in a message a user sees. */
+  label: string;
+}
+
+/**
+ * Auth headers for the `GET /models` connectivity check.
+ *
+ * Every provider accepts a bearer token for *chat* traffic, Anthropic included — that is what the
+ * OpenAI SDK client sends and it works. Their native `/v1/models` is the exception: it rejects a
+ * bearer token with 401 "Invalid bearer token" and wants `x-api-key` plus `anthropic-version`.
+ * Without this the Test button would report a working Claude setup as broken.
+ */
+function modelsAuthHeaders(resolved: ResolvedProvider): Record<string, string> {
+  if (resolved.modelsAuth === "anthropic") {
+    return { "x-api-key": resolved.apiKey, "anthropic-version": ANTHROPIC_VERSION };
+  }
+  return { Authorization: `Bearer ${resolved.apiKey}` };
+}
+
+/**
+ * Resolves a credential slot, honouring the provider registry when the slot has been moved to it
+ * and falling back to the legacy pair when it hasn't.
+ *
+ * The empty-`providerId` branch is deliberately the *old* code path verbatim, not a
+ * reimplementation of it: an install that predates the registry — which is every install today —
+ * must behave exactly as it did, down to the "" URL meaning OpenAI's.
+ */
+function resolveSlot(slot: CredentialSlot): ResolvedProvider {
+  const providerId = readAppSetting(slot === "chat" ? "chatProviderId" : "voiceProviderId");
+  if (providerId === "") {
+    return {
+      apiKey: getDecryptedKey(slot),
+      baseUrl: getConfiguredUrl(slot),
+      // What the SDK has always defaulted to, and what this slot has always used.
+      api: "responses",
+      modelsAuth: "bearer",
+      label: slot === "chat" ? "Chat" : "Voice",
+    };
+  }
+  return resolveProviderId(providerId, slot === "chat" ? "Chat" : "Voice");
+}
+
+/**
+ * Resolves one provider by registry id.
+ *
+ * `context` names what was pointed at it — a slot ("Chat") or an agent ("the Researcher agent") —
+ * so a missing key says which thing stopped working rather than only which provider is unset.
+ */
+function resolveProviderId(providerId: string, context: string): ResolvedProvider {
+  const provider = findProvider(providerId);
+  if (!provider) {
+    // A database can hold an id written by a build that offered a provider this one doesn't.
+    throw new Error(
+      `${context} is set to an unknown provider ("${providerId}"). Pick one again in Settings → AI Models.`
+    );
+  }
+  const credentials = getProviderCredentials(providerId);
+  const baseUrl = credentials?.apiUrl || provider.baseUrl;
+  if (baseUrl === "") {
+    throw new Error(`No API URL configured for ${provider.label}. Set one in Settings → AI Models first.`);
+  }
+  // `local` is the one provider that authenticates nothing, which is what keyRequired records.
+  // Sending an empty bearer token to a server that ignores it is fine; demanding a key the user
+  // does not have would block the provider whose whole point is not having one.
+  if (provider.keyRequired && !credentials?.apiKey) {
+    throw new Error(
+      `No ${provider.label} API key configured (needed by ${context}). Set one in Settings → AI Models first.`
+    );
+  }
+  return {
+    apiKey: credentials?.apiKey ?? "",
+    baseUrl,
+    api: provider.api,
+    modelsAuth: provider.modelsAuth,
+    label: provider.label,
+  };
+}
+
+/** A client bound to one provider's credentials. Built per call rather than cached, for the same
+ * reason configureChatClient re-reads on every run: a key or URL changed in Settings has to take
+ * effect on the next agent run, not the next launch. */
+function clientFor(resolved: ResolvedProvider): OpenAI {
+  // The SDK throws "Missing credentials" on an empty apiKey, but a `local` provider
+  // authenticates nothing and the user may legitimately have no key — that is what
+  // keyRequired: false means. A placeholder satisfies the constructor; the server ignores the
+  // header it produces. Without this, pointing an agent at Ollama crashes before the first
+  // request is even attempted.
+  return new OpenAI({ apiKey: resolved.apiKey || UNAUTHENTICATED_PLACEHOLDER_KEY, baseURL: resolved.baseUrl });
+}
+
+/**
+ * The model to hand an `Agent`, for an agent row that may name its own provider.
+ *
+ * Returns a plain string when the row inherits the Chat slot, which is the overwhelmingly common
+ * case and the one that must not change: a string makes the SDK resolve through the process-wide
+ * default client that `configureChatClient` has always set, so those runs are byte-identical to
+ * before providers existed.
+ *
+ * Only a row that explicitly names a different provider gets a `Model` instance bound to its own
+ * client — and which class it gets is the whole reason `api` is tracked per provider.
+ */
+export function modelForAgent(row: { model?: string | null; provider_id?: string | null }): string | Model {
+  const modelId = row.model?.trim() || SETTING_DEFAULTS.orchestratorModel;
+  const providerId = row.provider_id?.trim() ?? "";
+  if (providerId === "") return modelId;
+
+  let resolved: ResolvedProvider;
+  try {
+    resolved = resolveProviderId(providerId, `the model "${modelId}"`);
+  } catch (e) {
+    // Degrade to the Chat slot rather than throwing.
+    //
+    // buildOrchestrator constructs *every* agent before the run starts, so throwing here does not
+    // fail the one misconfigured agent — it fails the whole app. Observed: pinning a single
+    // sub-agent to a Local AI with no URL made an unrelated orchestrator run on OpenRouter die
+    // with "No API URL configured for Local AI", for a question that never involved that agent.
+    //
+    // Inheriting is also the honest reading of the field: provider_id is a preference, and "" has
+    // always meant "use Chat". An unresolvable id is the same situation with a worse cause. This
+    // is not a silent cross-provider credential leak — the Chat provider is the user's own
+    // configured default, which is exactly where this agent's traffic went before they pinned it.
+    devLog(
+      `[providers] agent pinned to "${providerId}" is not usable (${e instanceof Error ? e.message : String(e)}) — ` +
+        `falling back to the Chat provider for model "${modelId}"`
+    );
+    return modelId;
+  }
+
+  const client = clientFor(resolved);
+  return resolved.api === "chat_completions"
+    ? new OpenAIChatCompletionsModel(client, modelId)
+    : new OpenAIResponsesModel(client, modelId);
+}
+
 export function getDecryptedChatApiKey(): string {
-  return getDecryptedKey("chat");
+  return resolveSlot("chat").apiKey;
 }
 
 export function getConfiguredChatUrl(): string {
-  return getConfiguredUrl("chat");
+  return resolveSlot("chat").baseUrl;
 }
 
 /** Reads the current (decrypted) Chat API key and configures the SDK's default client to
@@ -47,8 +210,14 @@ export function getConfiguredChatUrl(): string {
  * rather than caching, so a key/URL change via Settings takes effect on the next agent
  * run without an app restart. */
 export function configureChatClient(): void {
-  const apiKey = getDecryptedChatApiKey();
-  setDefaultOpenAIClient(new OpenAI({ apiKey, baseURL: getConfiguredChatUrl() }));
+  const resolved = resolveSlot("chat");
+  // The SDK picks Responses vs Chat Completions from a module-level default, and every agent that
+  // inherits the Chat slot resolves through it. Pointing Chat at Claude therefore has to move the
+  // default too, or those runs would go to `/responses` on a host that 404s it. Set explicitly
+  // rather than only when it differs: the value is global and sticky, so a previous run that
+  // moved it would otherwise leak into this one.
+  setOpenAIAPI(resolved.api);
+  setDefaultOpenAIClient(clientFor(resolved));
 }
 
 /** Looks up the actual USD cost OpenRouter billed for a completed generation, keyed by the
@@ -109,11 +278,8 @@ export async function estimateGenerationCost(
  * across whichever host a section is pointed at. */
 async function testConnection(slot: CredentialSlot): Promise<{ ok: boolean; detail: string }> {
   try {
-    const apiKey = getDecryptedKey(slot);
-    const baseUrl = getConfiguredUrl(slot);
-    const response = await fetch(`${baseUrl}/models`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-    });
+    const resolved = resolveSlot(slot);
+    const response = await fetch(`${resolved.baseUrl}/models`, { headers: modelsAuthHeaders(resolved) });
     if (!response.ok) {
       const detail = await response.text().catch(() => "");
       return { ok: false, detail: `${response.status} ${detail || response.statusText}` };
@@ -155,7 +321,7 @@ interface WhisperSegment {
  * OpenAI with "Field required: body.file"). Multipart is also what OpenRouter's own
  * OpenAI-compatible surface accepts, so this works unchanged for either default. */
 export async function transcribeAudio(base64Audio: string, format: string): Promise<string> {
-  const apiKey = getDecryptedKey("voice");
+  const voice = resolveSlot("voice");
   const model = readAppSetting("voiceTranscriptionModel");
 
   const audioBuffer = Buffer.from(base64Audio, "base64");
@@ -167,9 +333,9 @@ export async function transcribeAudio(base64Audio: string, format: string): Prom
   // already treats as "nothing to filter on" and falls through to the plain text result.
   formData.append("response_format", "verbose_json");
 
-  const response = await fetch(`${getConfiguredUrl("voice")}/audio/transcriptions`, {
+  const response = await fetch(`${voice.baseUrl}/audio/transcriptions`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${apiKey}` },
+    headers: { Authorization: `Bearer ${voice.apiKey}` },
     body: formData,
   });
 
@@ -194,14 +360,14 @@ export async function transcribeAudio(base64Audio: string, format: string): Prom
  * cross the contextBridge/IPC boundary as cleanly as a string. If this call fails,
  * useSpeak (renderer) falls back to the browser's speechSynthesis rather than going silent. */
 export async function synthesizeSpeech(text: string): Promise<{ audio: string; format: string }> {
-  const apiKey = getDecryptedKey("voice");
+  const voice = resolveSlot("voice");
   const model = readAppSetting("voiceTtsModel");
   const format = "mp3";
 
-  const response = await fetch(`${getConfiguredUrl("voice")}/audio/speech`, {
+  const response = await fetch(`${voice.baseUrl}/audio/speech`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${voice.apiKey}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/electron/main/ai/provider.ts
+++ b/electron/main/ai/provider.ts
@@ -197,9 +197,45 @@ export function modelForAgent(row: { model?: string | null; provider_id?: string
   }
 
   const client = clientFor(resolved);
-  return resolved.api === "chat_completions"
-    ? new OpenAIChatCompletionsModel(client, modelId)
-    : new OpenAIResponsesModel(client, modelId);
+  return withModelId(
+    resolved.api === "chat_completions"
+      ? new OpenAIChatCompletionsModel(client, modelId)
+      : new OpenAIResponsesModel(client, modelId),
+    modelId,
+    providerId
+  );
+}
+
+/**
+ * Makes a Model instance stringify to its model id.
+ *
+ * The SDK's model classes keep the id private and do not override toString(), while
+ * ipc/agent.ts records `String(agent.model)` into token_usage.model. That was fine while every
+ * agent carried a plain string; the moment an agent could carry a Model instance it started
+ * writing "[object Object]" — seen in a real run.
+ *
+ * The wrong column value is the visible half. The costly half is that
+ * estimateGenerationCost prices by model id, so a pinned agent silently lost its cost as well.
+ */
+function withModelId<T extends object>(model: T, modelId: string, providerId: string): T {
+  Object.defineProperty(model, "toString", { value: () => modelId, enumerable: false });
+  // Which provider actually served the call, so cost is priced against that host rather than
+  // whatever the Chat slot happens to be. Without it an agent pinned to Claude was reported as
+  // free purely because Chat was pointed at a local server.
+  Object.defineProperty(model, PROVIDER_ID_TAG, { value: providerId, enumerable: false });
+  return model;
+}
+
+/** Non-enumerable marker read back by ipc/agent.ts when attributing cost. */
+export const PROVIDER_ID_TAG = "__orbitProviderId";
+
+/** The provider that served a call, given whatever `Agent.model` held. A plain string means the
+ * agent inherited the Chat slot, which is exactly what the setting records. */
+export function providerIdForModel(model: unknown): string {
+  if (model && typeof model === "object" && PROVIDER_ID_TAG in model) {
+    return String((model as Record<string, unknown>)[PROVIDER_ID_TAG]);
+  }
+  return readAppSetting("chatProviderId");
 }
 
 export function getDecryptedChatApiKey(): string {
@@ -245,13 +281,22 @@ async function getOpenRouterGenerationCost(generationId: string): Promise<number
 
 // Static USD-per-million-token pricing for models we know for certain, used only when the
 // Chat section isn't pointed at OpenRouter (which has a real post-hoc cost API instead —
-// see getOpenRouterGenerationCost above). OpenAI has no equivalent "confirm actual billed
-// cost" endpoint, so this is the standard estimate-from-published-rates approach. Deliberately
-// small and conservative: an unlisted model returns null (no cost shown) rather than a
-// guessed number, since a wrong number is worse than none. Source: OpenAI's published API
-// pricing as of early 2026 — must be kept in sync by hand if OpenAI changes it.
-const MODEL_PRICING_USD_PER_MILLION_TOKENS: Record<string, { input: number; output: number }> = {
+// see getOpenRouterGenerationCost above). Neither OpenAI nor Anthropic exposes a "confirm the
+// actually-billed cost" endpoint, so this is the standard estimate-from-published-rates
+// approach. Deliberately small: an unlisted model returns null (tokens show, no price) rather
+// than a guessed number, since a wrong number is worse than none.
+//
+// Scope rule: only models this app ships as a provider default belong here. That bounds the
+// hand-maintenance to what we actually choose for people, and providersParity.test.ts fails if
+// a shipped default has no entry — so adding a provider cannot quietly ship without a price.
+//
+// Both figures were cross-checked against two independent sources before being written down:
+// each provider's published rates, and OpenRouter's own /models catalogue, which reports
+// $0.40/$1.60 for gpt-4.1-mini and $1.00/$5.00 for claude-haiku-4.5 — matching list price
+// rather than carrying a markup. Verified 2026-08-03; re-check if a provider changes pricing.
+export const MODEL_PRICING_USD_PER_MILLION_TOKENS: Record<string, { input: number; output: number }> = {
   "gpt-4.1-mini": { input: 0.4, output: 1.6 },
+  "claude-haiku-4-5-20251001": { input: 1.0, output: 5.0 },
 };
 
 function estimateCostFromStaticPricing(model: string, inputTokens: number, outputTokens: number): number | null {
@@ -269,9 +314,24 @@ export async function estimateGenerationCost(
   generationId: string | null,
   model: string,
   inputTokens: number,
-  outputTokens: number
+  outputTokens: number,
+  /** The provider that served this call. Defaults to the Chat slot, which is what an agent
+   * inheriting it runs on; a pinned agent passes its own. */
+  providerId: string = readAppSetting("chatProviderId")
 ): Promise<number | null> {
-  if (getConfiguredChatUrl().startsWith(OPENROUTER_BASE_URL) && generationId) {
+  // A model on the user's own hardware costs nothing per token. That is a fact rather than an
+  // estimate, and worth distinguishing from "we could not price this" — a blank cost reads as
+  // unknown, which is the wrong answer for a local server.
+  //
+  // Keyed to the provider that actually served the call, not the Chat slot: an agent pinned to
+  // Claude costs real money even when Chat is pointed at Ollama, and reporting it as free was
+  // exactly the bug this parameter fixes.
+  if (providerId === "local") return 0;
+
+  // The legacy slot has no provider id, so the URL is still the only signal there.
+  const viaOpenRouter =
+    providerId === "openrouter" || (providerId === "" && getConfiguredChatUrl().startsWith(OPENROUTER_BASE_URL));
+  if (viaOpenRouter && generationId) {
     const real = await getOpenRouterGenerationCost(generationId);
     if (real !== null) return real;
   }

--- a/electron/main/ai/providers.ts
+++ b/electron/main/ai/providers.ts
@@ -64,12 +64,19 @@ export interface AiProvider {
   defaultTtsModel: string;
 }
 
+/** Hosts that code outside the registry also needs to name — the legacy Chat slot falls back to
+ * OpenAI's, and the cost lookup in ai/provider.ts only applies to OpenRouter. Exported from here
+ * so there is one literal per host rather than a copy that can drift out of step with the entry
+ * below it. */
+export const OPENAI_BASE_URL = "https://api.openai.com/v1";
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
 /** Listed in the order the onboarding chips and the Settings dropdown show them. */
 export const AI_PROVIDERS: AiProvider[] = [
   {
     id: "openrouter",
     label: "OpenRouter",
-    baseUrl: "https://openrouter.ai/api/v1",
+    baseUrl: OPENROUTER_BASE_URL,
     // The leading `~` is OpenRouter's own syntax for a floating "latest" alias, not a typo: the
     // id is listed by GET /models and returns 200, while the de-tilde'd form is refused as "not
     // a valid model ID". MODEL_ID_PATTERN in ../settingsSchema.ts admits it for this reason.
@@ -84,7 +91,7 @@ export const AI_PROVIDERS: AiProvider[] = [
   {
     id: "openai",
     label: "OpenAI",
-    baseUrl: "https://api.openai.com/v1",
+    baseUrl: OPENAI_BASE_URL,
     defaultChatModel: "gpt-4.1-mini",
     api: "responses",
     modelsAuth: "bearer",

--- a/electron/main/ai/providers.ts
+++ b/electron/main/ai/providers.ts
@@ -139,6 +139,24 @@ export function findProvider(id: string): AiProvider | null {
   return AI_PROVIDERS.find((provider) => provider.id === id) ?? null;
 }
 
+/**
+ * Which provider a bare base URL belongs to.
+ *
+ * Needed because `chatProviderId` is `""` on an install that predates the registry, while the
+ * legacy `chatApiUrl` still says where it was pointed. Settings has to show *something* selected
+ * rather than an empty dropdown, and this is the same prefix match the providers migration used
+ * to seed those installs — deliberately, so the UI agrees with what the database did.
+ *
+ * An empty URL is OpenAI, because that is what an empty chatApiUrl has always meant at runtime.
+ * Anything unrecognised is a custom OpenAI-compatible host, which is what `local` is for.
+ */
+export function inferProviderId(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed === "") return DEFAULT_PROVIDER_ID;
+  const hosted = AI_PROVIDERS.find((provider) => provider.baseUrl !== "" && trimmed.startsWith(provider.baseUrl));
+  return hosted?.id ?? "local";
+}
+
 /** The providers that can back the Voice slot. Separate from the full list because Voice needs
  * `/audio/*`, which only OpenAI serves. */
 export function voiceProviders(): AiProvider[] {

--- a/electron/main/ai/providers.ts
+++ b/electron/main/ai/providers.ts
@@ -1,0 +1,139 @@
+/**
+ * The AI providers the app knows how to talk to, and what each one can actually do.
+ *
+ * Until this existed there was no provider concept at all — just a base URL that fell back to
+ * OpenAI's when blank (see getConfiguredUrl in ./provider.ts). That was fine while every
+ * supported host spoke the same dialect, and stopped being fine the moment Claude and a local
+ * Ollama became options: they differ in which endpoint answers, which auth header the model
+ * listing wants, and whether they can serve speech at all.
+ *
+ * Every field here was measured against the live API rather than assumed — see
+ * `0-cowork/plans/active/ai-providers-keys-models.md` for the probe results.
+ *
+ * Mirrors `src/lib/providers.ts`. It cannot import it, and the renderer must not import this at
+ * runtime: `electron/` and `src/` are separate TypeScript projects, and the boundary is
+ * deliberate (see the comment in tsconfig.web.json). `src/lib/providersParity.test.ts` asserts
+ * the two stay identical, which is the same mechanism DEFAULT_SETTINGS/SETTING_DEFAULTS uses.
+ * Keep this module dependency-free so pulling it into the renderer's program for that test adds
+ * no Electron surface.
+ */
+
+/**
+ * Which HTTP surface an agent run has to use.
+ *
+ * `@openai/agents` defaults to the Responses API (`DEFAULT_OPENAI_API = 'responses'` in
+ * @openai/agents-openai), and the app has never called `setOpenAIAPI`, so every run to date has
+ * gone to `POST /responses`. OpenAI and OpenRouter both serve that. Anthropic's
+ * OpenAI-compatible surface does not — it 404s — and neither does Ollama's.
+ *
+ * Deliberately per-provider rather than a single global `setOpenAIAPI('chat_completions')`:
+ * flipping the global default would change the request surface for existing OpenAI and
+ * OpenRouter users to buy nothing, since both already answer on `/responses`.
+ */
+export type ProviderApi = "responses" | "chat_completions";
+
+/**
+ * How the connectivity check authenticates against `GET /models`.
+ *
+ * `bearer` is the OpenAI convention and what the SDK client sends for chat traffic everywhere,
+ * Anthropic included. But Anthropic's *native* `/v1/models` rejects a bearer token outright
+ * (401 "Invalid bearer token") and wants `x-api-key` plus `anthropic-version` — so the Test
+ * button needs to know the difference even though ordinary chat calls do not.
+ */
+export type ProviderModelsAuth = "bearer" | "anthropic";
+
+export interface AiProvider {
+  /** Stable key. Persisted in the database, so never rename one of these. */
+  id: string;
+  label: string;
+  /** Prefilled into the API URL field; always editable. Empty for a self-hosted server, where
+   * only the user knows the address — and where empty must mean "you must supply one", not the
+   * "fall back to OpenAI" that an empty chatApiUrl means today. */
+  baseUrl: string;
+  /** Prefilled into the model field; always editable. Empty where there is no sensible default. */
+  defaultChatModel: string;
+  api: ProviderApi;
+  modelsAuth: ProviderModelsAuth;
+  /** False only for a local server, which authenticates nothing. Making a key mandatory there
+   * would block the one provider whose whole point is not having one. */
+  keyRequired: boolean;
+  /** Whether `/audio/transcriptions` and `/audio/speech` exist. Only OpenAI serves them, so the
+   * Voice slot cannot be pointed at anything else — the field is what stops the UI offering it. */
+  supportsVoice: boolean;
+  defaultTranscriptionModel: string;
+  defaultTtsModel: string;
+}
+
+/** Listed in the order the onboarding chips and the Settings dropdown show them. */
+export const AI_PROVIDERS: AiProvider[] = [
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    // The leading `~` is OpenRouter's own syntax for a floating "latest" alias, not a typo: the
+    // id is listed by GET /models and returns 200, while the de-tilde'd form is refused as "not
+    // a valid model ID". MODEL_ID_PATTERN in ../settingsSchema.ts admits it for this reason.
+    defaultChatModel: "~deepseek/deepseek-v4-flash-latest",
+    api: "responses",
+    modelsAuth: "bearer",
+    keyRequired: true,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    defaultChatModel: "gpt-4.1-mini",
+    api: "responses",
+    modelsAuth: "bearer",
+    keyRequired: true,
+    supportsVoice: true,
+    defaultTranscriptionModel: "whisper-1",
+    defaultTtsModel: "gpt-4o-mini-tts",
+  },
+  {
+    id: "anthropic",
+    label: "Claude",
+    // Anthropic's OpenAI-compatible surface. Chat and tool calls work through it with a bearer
+    // token; `/responses` does not exist, hence chat_completions above.
+    baseUrl: "https://api.anthropic.com/v1",
+    defaultChatModel: "claude-haiku-4-5-20251001",
+    api: "chat_completions",
+    modelsAuth: "anthropic",
+    keyRequired: true,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+  {
+    id: "local",
+    label: "Local AI",
+    baseUrl: "",
+    defaultChatModel: "",
+    api: "chat_completions",
+    modelsAuth: "bearer",
+    keyRequired: false,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+];
+
+export const PROVIDER_IDS = AI_PROVIDERS.map((provider) => provider.id);
+
+/** The provider a fresh install starts on, and the fallback when a stored id is unrecognised. */
+export const DEFAULT_PROVIDER_ID = "openai";
+
+/** Looks up a provider, or null when the id is unknown — a database can hold an id written by a
+ * build that offered a provider this one doesn't. Callers fall back rather than throwing. */
+export function findProvider(id: string): AiProvider | null {
+  return AI_PROVIDERS.find((provider) => provider.id === id) ?? null;
+}
+
+/** The providers that can back the Voice slot. Separate from the full list because Voice needs
+ * `/audio/*`, which only OpenAI serves. */
+export function voiceProviders(): AiProvider[] {
+  return AI_PROVIDERS.filter((provider) => provider.supportsVoice);
+}

--- a/electron/main/ai/selectProvider.test.ts
+++ b/electron/main/ai/selectProvider.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment node
+ *
+ * Main-process code; see provider.test.ts for why jsdom is the wrong environment here.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../db/migrations";
+
+vi.mock("../security/secretStorage", () => ({
+  encryptSecret: (v: string) => `enc:${v}`,
+  decryptSecret: (v: string) => v.replace(/^enc:/, ""),
+}));
+vi.mock("../devLog", () => ({ devLog: () => {} }));
+
+let db: Database.Database;
+vi.mock("../db", () => ({ getDb: () => db }));
+vi.mock("../db/index", () => ({ getDb: () => db }));
+
+import { selectChatProvider } from "./selectProvider";
+import { getProviderCredentials } from "../db/providersStore";
+
+function seedAgent(id: string, model: string, providerId = ""): void {
+  db.prepare(
+    "INSERT INTO agents (id, name, prompt, model, icon, tagline, description, provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+  ).run(id, id, "prompt", model, "ti-robot", "", "", providerId);
+}
+
+function setting(name: string): unknown {
+  const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(name) as
+    | { setting_value: string }
+    | undefined;
+  return row ? JSON.parse(row.setting_value) : undefined;
+}
+
+function modelOf(id: string): string {
+  return (db.prepare("SELECT model FROM agents WHERE id = ?").get(id) as { model: string }).model;
+}
+
+describe("selectChatProvider", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  it("stores the credentials, points the slot, and records the model", () => {
+    const result = selectChatProvider({
+      providerId: "anthropic",
+      apiKey: "sk-ant",
+    });
+    expect(result).toEqual({ providerId: "anthropic", model: "claude-haiku-4-5-20251001", updatedAgents: 0 });
+    expect(getProviderCredentials("anthropic")).toEqual({
+      apiUrl: "https://api.anthropic.com/v1",
+      apiKey: "sk-ant",
+    });
+    expect(setting("appSettings.chatProviderId")).toBe("anthropic");
+    expect(setting("appSettings.orchestratorModel")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("re-points agents that inherit the Chat slot", () => {
+    seedAgent("configAgent", "gpt-4.1-mini");
+    seedAgent("knowledgeAgent", "gpt-4.1-mini");
+    const result = selectChatProvider({ providerId: "anthropic", apiKey: "sk-ant" });
+    // The whole reason this function exists: leaving them on an OpenAI id makes all four system
+    // agents 404 against the new host, for agents the user never configured.
+    expect(result.updatedAgents).toBe(2);
+    expect(modelOf("configAgent")).toBe("claude-haiku-4-5-20251001");
+    expect(modelOf("knowledgeAgent")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("leaves an agent that carries its own provider alone", () => {
+    seedAgent("configAgent", "gpt-4.1-mini");
+    seedAgent("explorerAgent", "claude-haiku-4-5-20251001", "anthropic");
+    selectChatProvider({ providerId: "openrouter", apiKey: "sk-or" });
+    // That agent was pinned deliberately. Rewriting it would undo the user's own decision to run
+    // one agent somewhere else — which is the entire feature.
+    expect(modelOf("explorerAgent")).toBe("claude-haiku-4-5-20251001");
+    expect(modelOf("configAgent")).toBe("~deepseek/deepseek-v4-flash-latest");
+  });
+
+  it("does not count agents that already hold the target model", () => {
+    seedAgent("configAgent", "claude-haiku-4-5-20251001");
+    // Reported to the user as "N agents updated", so a no-op switch must not claim to have
+    // changed anything.
+    expect(selectChatProvider({ providerId: "anthropic", apiKey: "sk-ant" }).updatedAgents).toBe(0);
+  });
+
+  it("accepts a custom model and URL over the provider's defaults", () => {
+    const result = selectChatProvider({
+      providerId: "openrouter",
+      apiUrl: "https://proxy.example.com/v1",
+      apiKey: "sk-or",
+      model: "openai/gpt-4.1-mini",
+    });
+    expect(result.model).toBe("openai/gpt-4.1-mini");
+    expect(getProviderCredentials("openrouter")?.apiUrl).toBe("https://proxy.example.com/v1");
+  });
+
+  it("takes an Ollama name:tag model", () => {
+    const result = selectChatProvider({
+      providerId: "local",
+      apiUrl: "http://localhost:11434/v1",
+      model: "llama3.2:3b",
+    });
+    expect(result.model).toBe("llama3.2:3b");
+  });
+
+  describe("refuses what cannot work", () => {
+    it("an unknown provider", () => {
+      expect(() => selectChatProvider({ providerId: "gemini" })).toThrow(/Unknown provider/);
+    });
+
+    it("a local server with no URL — nobody else knows the address", () => {
+      expect(() => selectChatProvider({ providerId: "local", model: "llama3.2:3b" })).toThrow(/needs an API URL/);
+    });
+
+    it("a local server with no model — there is no sensible default", () => {
+      expect(() => selectChatProvider({ providerId: "local", apiUrl: "http://localhost:11434/v1" })).toThrow(
+        /needs a model id/
+      );
+    });
+
+    it("an explicitly blank key on a provider that requires one", () => {
+      // Distinct from omitting it, which means "leave the stored key alone".
+      expect(() => selectChatProvider({ providerId: "anthropic", apiKey: "   " })).toThrow(/needs an API key/);
+    });
+
+    it("a blank key on the one provider that does not require one", () => {
+      expect(() =>
+        selectChatProvider({ providerId: "local", apiUrl: "http://localhost:11434/v1", model: "llama3.2:3b", apiKey: "" })
+      ).not.toThrow();
+    });
+
+    it("a malformed URL", () => {
+      expect(() => selectChatProvider({ providerId: "openai", apiUrl: "not a url", apiKey: "sk-x" })).toThrow(
+        /API URL/
+      );
+    });
+
+    it("a model id the write boundary would refuse", () => {
+      expect(() =>
+        selectChatProvider({ providerId: "openai", apiKey: "sk-x", model: "has spaces" })
+      ).toThrow(/model id/);
+    });
+
+    it("leaves everything untouched when it refuses", () => {
+      seedAgent("configAgent", "gpt-4.1-mini");
+      expect(() => selectChatProvider({ providerId: "openai", apiKey: "sk-x", model: "has spaces" })).toThrow();
+      // A half-applied switch is worse than a refused one: credentials saved but agents not moved
+      // would be the same broken state this function exists to prevent.
+      expect(setting("appSettings.chatProviderId")).toBeUndefined();
+      expect(modelOf("configAgent")).toBe("gpt-4.1-mini");
+      expect(getProviderCredentials("openai")).toBeNull();
+    });
+  });
+});

--- a/electron/main/ai/selectProvider.ts
+++ b/electron/main/ai/selectProvider.ts
@@ -1,0 +1,81 @@
+import { getDb } from "../db";
+import { setSetting } from "../db/settingsStore";
+import { saveProvider } from "../db/providersStore";
+import { findProvider } from "./providers";
+import { validateSettingValue } from "../settingsSchema";
+import { devLog } from "../devLog";
+
+/**
+ * Pointing the Chat slot at a provider, as one operation.
+ *
+ * Onboarding and Settings both do the same four things, and doing them separately is what makes a
+ * provider switch break the app: the model ids have to move with the provider. Every system agent
+ * is seeded carrying the orchestrator's model and no provider of its own, so switching to Claude
+ * while leaving them on `gpt-4.1-mini` means four agents asking Anthropic for an OpenAI model.
+ * That was observed against a real Ollama server — `404 model 'gpt-4.1-mini' not found`, for
+ * agents the user never touched.
+ *
+ * Agents that carry their own `provider_id` are deliberately untouched: the user chose those,
+ * and rewriting them would undo a deliberate decision to run one agent somewhere else.
+ */
+
+export interface ChatProviderSelection {
+  /** A registry id from ./providers. */
+  providerId: string;
+  /** Omit to keep whatever URL is stored; the provider's own default fills a blank. */
+  apiUrl?: string;
+  /** Omit to leave the stored key alone — see saveProvider's three-state apiKey. */
+  apiKey?: string;
+  /** Omit to take the provider's default model. */
+  model?: string;
+}
+
+export interface ChatProviderResult {
+  providerId: string;
+  model: string;
+  /** How many inheriting agents were re-pointed at the new model, for the caller to report. */
+  updatedAgents: number;
+}
+
+export function selectChatProvider(selection: ChatProviderSelection): ChatProviderResult {
+  const provider = findProvider(selection.providerId);
+  if (!provider) throw new Error(`Unknown provider "${selection.providerId}".`);
+
+  const apiUrl = selection.apiUrl?.trim() ?? provider.baseUrl;
+  // A hosted provider always has a default URL to fall back on; `local` does not, because only
+  // the user knows where their server is.
+  if (apiUrl === "") throw new Error(`${provider.label} needs an API URL.`);
+  const urlCheck = validateSettingValue("chatApiUrl", apiUrl);
+  if (!urlCheck.ok) throw new Error(`That API URL ${urlCheck.reason}.`);
+
+  const model = selection.model?.trim() || provider.defaultChatModel;
+  if (model === "") throw new Error(`${provider.label} needs a model id.`);
+  const modelCheck = validateSettingValue("orchestratorModel", model);
+  if (!modelCheck.ok) throw new Error(`That model id ${modelCheck.reason}.`);
+
+  if (provider.keyRequired && selection.apiKey !== undefined && selection.apiKey.trim() === "") {
+    throw new Error(`${provider.label} needs an API key.`);
+  }
+
+  saveProvider(provider.id, {
+    apiUrl,
+    apiKey: selection.apiKey === undefined ? undefined : selection.apiKey.trim(),
+  });
+
+  setSetting("appSettings.chatProviderId", provider.id);
+  setSetting("appSettings.orchestratorModel", model);
+
+  // Only rows with no provider of their own — those are the ones that follow the Chat slot and
+  // would otherwise be left naming a model the new host has never heard of.
+  const updated = getDb()
+    .prepare("UPDATE agents SET model = ? WHERE provider_id = '' AND model <> ?")
+    .run(model, model);
+  const updatedAgents = updated.changes;
+
+  devLog(
+    `[providers] chat slot -> ${provider.id} (model "${model}"), ` +
+      `${updatedAgents} inheriting agent(s) re-pointed`
+  );
+
+  return { providerId: provider.id, model, updatedAgents };
+}

--- a/electron/main/db/migrations.ts
+++ b/electron/main/db/migrations.ts
@@ -99,6 +99,19 @@ function hasColumn(db: Database.Database, table: string, column: string): boolea
   return (db.pragma(`table_info(${table})`) as { name: string }[]).some((c) => c.name === column);
 }
 
+/** Companion to hasColumn, for a migration that reads a table it does not itself create.
+ *
+ * Every real database has every table its migration created, but a migration is also replayed
+ * against partial stand-in schemas: several tests build only the tables the migration under test
+ * touches and pin `user_version` to force the later ones to run (see knowledgeBase.test.ts). A
+ * migration that assumes a table exists turns those into a hard failure the first time someone
+ * adds a migration that reads something new. */
+function hasTable(db: Database.Database, table: string): boolean {
+  return (
+    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) !== undefined
+  );
+}
+
 /**
  * Append new entries here to evolve the schema — never edit an already-shipped migration.
  * `conversations` exists from day one even though the UI only ever shows one thread today,
@@ -797,6 +810,95 @@ const migrations: Migration[] = [
       // and the guard keeps it a no-op if any database did apply it.
       if (hasColumn(db, "http_tools", "requires_confirmation")) {
         db.exec(`ALTER TABLE http_tools DROP COLUMN requires_confirmation;`);
+      }
+    },
+  },
+  {
+    id: "20260802231500",
+    up: (db) => {
+      // Credentials move from two fixed slots to one row per provider.
+      //
+      // Chat and Voice were each a hardcoded {apiKey, apiUrl} pair in the settings table, which
+      // worked while every supported host spoke the same dialect. Offering OpenAI, OpenRouter,
+      // Claude and a local server breaks that: an agent can now sensibly run on a different
+      // provider than the orchestrator, and per-agent slots would mean N copies of the same
+      // secret to rotate. Keying credentials by provider instead means one Claude key however
+      // many agents point at it.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS providers (
+          id TEXT PRIMARY KEY,
+          api_url TEXT NOT NULL DEFAULT '',
+          api_key TEXT NOT NULL DEFAULT '',
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+      `);
+
+      // Which provider an agent runs on. '' means "inherit the Chat provider", which is what
+      // every existing row gets — so this column changes nothing until a user picks something.
+      if (!hasColumn(db, "agents", "provider_id")) {
+        db.exec(`ALTER TABLE agents ADD COLUMN provider_id TEXT NOT NULL DEFAULT '';`);
+      }
+
+      // Seed from the two legacy slots so an existing install keeps working without the user
+      // re-entering anything. The old rows are deliberately left in place: a downgrade to a
+      // build without this migration has to find its credentials exactly where it left them.
+      //
+      // The base URLs are inlined rather than imported from ai/providers.ts on purpose. This
+      // module is free of runtime imports by design (see MigrationContext), but more
+      // importantly a migration must be frozen against the values that were true when it ran —
+      // if the registry gains a provider next year, that must not retroactively change how a
+      // database written today was interpreted.
+      const KNOWN: { id: string; prefix: string }[] = [
+        { id: "openrouter", prefix: "https://openrouter.ai/api/v1" },
+        { id: "openai", prefix: "https://api.openai.com/v1" },
+        { id: "anthropic", prefix: "https://api.anthropic.com/v1" },
+      ];
+
+      const readSetting = (name: string): string => {
+        const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(name) as
+          | { setting_value: string }
+          | undefined;
+        if (!row) return "";
+        // Stored JSON-encoded (settingsStore stringifies every value). A row written by an older
+        // build, or hand-edited, can be neither — treat anything unparseable as absent rather
+        // than letting one bad row abort the whole migration and with it the app's launch.
+        try {
+          const parsed = JSON.parse(row.setting_value) as unknown;
+          return typeof parsed === "string" ? parsed : "";
+        } catch {
+          return "";
+        }
+      };
+
+      // An empty URL meant "use OpenAI's" everywhere in ai/provider.ts, so an install that never
+      // touched the field is an OpenAI install. A URL pointing somewhere unrecognised is kept as
+      // a `local` row: it is by definition a custom OpenAI-compatible host, which is exactly what
+      // that provider is for, and dropping it would silently disconnect a working setup.
+      const providerIdFor = (url: string): string => {
+        if (url.trim() === "") return "openai";
+        return KNOWN.find((known) => url.startsWith(known.prefix))?.id ?? "local";
+      };
+
+      // The key is copied as stored — still ciphertext, never decrypted here. Same database, same
+      // encryption key, same format, so a round trip would only add a way to fail: OS-backed
+      // decryption can throw, and a migration that throws takes the app's launch with it.
+      // Nothing to seed from if the settings table isn't there. That never happens on a real
+      // database — migration 1 creates it — but this migration is also replayed against the
+      // partial stand-in schemas some tests build, and a table-not-found there would read as
+      // this migration being broken rather than as the stand-in being incomplete.
+      if (!hasTable(db, "settings")) return;
+
+      const seed = db.prepare(
+        `INSERT INTO providers (id, api_url, api_key) VALUES (?, ?, ?)
+         ON CONFLICT(id) DO NOTHING`
+      );
+      for (const slot of ["chat", "voice"]) {
+        const url = readSetting(`appSettings.${slot}ApiUrl`);
+        const key = readSetting(`appSettings.${slot}ApiKey`);
+        // Nothing configured — a fresh install, where seeding an empty row would only make the
+        // Settings screen claim a provider is set up when it isn't.
+        if (url === "" && key === "") continue;
+        seed.run(providerIdFor(url), url, key);
       }
     },
   },

--- a/electron/main/db/providersStore.test.ts
+++ b/electron/main/db/providersStore.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "./migrations";
+
+const MIGRATION_ID = "20260802231500";
+
+/**
+ * Rewinds a fully-migrated database to the state it was in *before* the providers migration, so
+ * the seeding can be exercised against a database that looks like a real existing install.
+ *
+ * Migrations are selected by absence from the ledger, so removing the row is what makes this one
+ * run again on the next `runMigrations` — the same mechanism the run-openorbit skill documents
+ * for replaying a migration by hand.
+ */
+function rewindToBeforeProviders(db: Database.Database): void {
+  db.exec("DROP TABLE IF EXISTS providers");
+  db.prepare("DELETE FROM schema_migrations WHERE id = ?").run(MIGRATION_ID);
+}
+
+function setSetting(db: Database.Database, name: string, rawJson: string): void {
+  db.prepare("INSERT OR REPLACE INTO settings (setting_name, setting_value) VALUES (?, ?)").run(name, rawJson);
+}
+
+function seedLegacyInstall(db: Database.Database, opts: { url?: string; key?: string }): void {
+  rewindToBeforeProviders(db);
+  if (opts.url !== undefined) setSetting(db, "appSettings.chatApiUrl", JSON.stringify(opts.url));
+  if (opts.key !== undefined) setSetting(db, "appSettings.chatApiKey", JSON.stringify(opts.key));
+  runMigrations(db);
+}
+
+function providerRows(db: Database.Database) {
+  return db.prepare("SELECT id, api_url, api_key FROM providers ORDER BY id").all() as {
+    id: string;
+    api_url: string;
+    api_key: string;
+  }[];
+}
+
+describe("the providers migration", () => {
+  it("adds agents.provider_id defaulting to '' so existing agents inherit Chat", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    db.prepare(
+      "INSERT INTO agents (id, name, prompt, model, icon, tagline, description) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run("agent-1", "Agent", "prompt", "model", "icon", "", "");
+    const agent = db.prepare("SELECT provider_id FROM agents WHERE id = ?").get("agent-1") as { provider_id: string };
+    // '' is what makes this column inert on an existing install: nothing changes until a user
+    // deliberately points an agent somewhere else.
+    expect(agent.provider_id).toBe("");
+    db.close();
+  });
+
+  it("seeds nothing on a fresh install", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    // A row here would make the Settings screen claim a provider is configured when the user has
+    // never entered anything.
+    expect(providerRows(db)).toEqual([]);
+    db.close();
+  });
+
+  it("treats an install that never set a URL as OpenAI", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    // An empty chatApiUrl meant "use OpenAI's" everywhere in ai/provider.ts, so this is not a
+    // guess — it is the behaviour the install already had.
+    seedLegacyInstall(db, { url: "", key: "nodeCrypto:aaa:bbb:ccc" });
+    expect(providerRows(db)).toEqual([{ id: "openai", api_url: "", api_key: "nodeCrypto:aaa:bbb:ccc" }]);
+    db.close();
+  });
+
+  it.each([
+    ["https://openrouter.ai/api/v1", "openrouter"],
+    ["https://api.openai.com/v1", "openai"],
+    ["https://api.anthropic.com/v1", "anthropic"],
+  ])("recognises %s as %s", (url, expected) => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    seedLegacyInstall(db, { url, key: "nodeCrypto:x:y:z" });
+    expect(providerRows(db).map((r) => r.id)).toEqual([expected]);
+    db.close();
+  });
+
+  it("keeps an unrecognised host as a local provider rather than dropping it", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    seedLegacyInstall(db, { url: "http://192.168.1.50:11434/v1", key: "nodeCrypto:x:y:z" });
+    // A custom OpenAI-compatible host is exactly what `local` is for. Dropping the row would
+    // silently disconnect a setup that was working a moment ago.
+    expect(providerRows(db)).toEqual([
+      { id: "local", api_url: "http://192.168.1.50:11434/v1", api_key: "nodeCrypto:x:y:z" },
+    ]);
+    db.close();
+  });
+
+  it("copies the key as ciphertext without decrypting it", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    const ciphertext = "nodeCrypto:aXY=:dGFn:ZW5j";
+    seedLegacyInstall(db, { url: "https://api.openai.com/v1", key: ciphertext });
+    // Byte-identical. A decrypt/re-encrypt round trip would add a way for the migration to throw
+    // — and a migration that throws takes the app's launch with it.
+    expect(providerRows(db)[0].api_key).toBe(ciphertext);
+    db.close();
+  });
+
+  it("leaves the legacy settings rows in place so a downgrade still finds them", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    seedLegacyInstall(db, { url: "https://api.openai.com/v1", key: "nodeCrypto:x:y:z" });
+    const legacy = db
+      .prepare("SELECT setting_value FROM settings WHERE setting_name = ?")
+      .get("appSettings.chatApiKey") as { setting_value: string } | undefined;
+    expect(legacy?.setting_value).toBe(JSON.stringify("nodeCrypto:x:y:z"));
+    db.close();
+  });
+
+  it("survives a settings row holding something that is not JSON", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    rewindToBeforeProviders(db);
+    // Rows written by older builds, or hand-edited, really are out there — jsonColumn.ts exists
+    // for this. One of them must not abort the migration and with it the app's launch.
+    setSetting(db, "appSettings.chatApiUrl", "{not json");
+    setSetting(db, "appSettings.chatApiKey", JSON.stringify("nodeCrypto:x:y:z"));
+    expect(() => runMigrations(db)).not.toThrow();
+    // The unreadable URL is treated as absent, which lands it on the OpenAI default.
+    expect(providerRows(db)).toEqual([{ id: "openai", api_url: "", api_key: "nodeCrypto:x:y:z" }]);
+    db.close();
+  });
+
+  it("is idempotent — replaying it does not clobber an edited row", () => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    seedLegacyInstall(db, { url: "https://api.openai.com/v1", key: "nodeCrypto:original" });
+    db.prepare("UPDATE providers SET api_key = ? WHERE id = ?").run("nodeCrypto:rotated", "openai");
+
+    // Re-run without dropping the table: the ON CONFLICT DO NOTHING is what protects a key the
+    // user has since changed.
+    db.prepare("DELETE FROM schema_migrations WHERE id = ?").run(MIGRATION_ID);
+    runMigrations(db);
+
+    expect(providerRows(db)[0].api_key).toBe("nodeCrypto:rotated");
+    db.close();
+  });
+});
+
+vi.mock("../security/secretStorage", () => ({
+  encryptSecret: (v: string) => `enc:${v}`,
+  decryptSecret: (v: string) => {
+    if (v === "enc:BOOM") throw new Error("keychain locked");
+    return v.replace(/^enc:/, "");
+  },
+}));
+
+vi.mock("../devLog", () => ({ devLog: () => {} }));
+
+let db: Database.Database;
+vi.mock("./index", () => ({
+  getDb: () => db,
+}));
+
+import {
+  deleteProvider,
+  getProviderCredentials,
+  isProviderConfigured,
+  listVisibleProviders,
+  saveProvider,
+} from "./providersStore";
+
+describe("providersStore", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  it("creates a row on first save and encrypts the key", () => {
+    saveProvider("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-secret" });
+    const stored = db.prepare("SELECT api_key FROM providers WHERE id = ?").get("openai") as { api_key: string };
+    // The plaintext must not be what lands on disk.
+    expect(stored.api_key).toBe("enc:sk-secret");
+    expect(getProviderCredentials("openai")).toEqual({ apiUrl: "https://api.openai.com/v1", apiKey: "sk-secret" });
+  });
+
+  it("never exposes a key value to the renderer", () => {
+    saveProvider("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-secret" });
+    const visible = listVisibleProviders();
+    expect(visible).toEqual([{ id: "openai", apiUrl: "https://api.openai.com/v1", keySet: true }]);
+    // Spelled out separately: the assertion above would still pass if a key field were added
+    // alongside the ones listed, and this is the whole point of the shape.
+    expect(JSON.stringify(visible)).not.toContain("sk-secret");
+    expect(JSON.stringify(visible)).not.toContain("enc:");
+  });
+
+  it("leaves the stored key alone when a save omits it", () => {
+    saveProvider("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-secret" });
+    // What a URL-only edit sends, and what an untouched masked field sends on blur. If this
+    // cleared the key, editing the URL would silently sign the user out of their provider.
+    saveProvider("openai", { apiUrl: "https://proxy.example.com/v1" });
+    expect(getProviderCredentials("openai")).toEqual({ apiUrl: "https://proxy.example.com/v1", apiKey: "sk-secret" });
+  });
+
+  it("clears the key on an explicit empty string", () => {
+    saveProvider("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-secret" });
+    saveProvider("openai", { apiKey: "" });
+    // The only route to removing a key that isn't the Danger Zone's full database wipe.
+    expect(getProviderCredentials("openai")).toEqual({ apiUrl: "https://api.openai.com/v1", apiKey: "" });
+    expect(listVisibleProviders()[0].keySet).toBe(false);
+  });
+
+  it("reports a key that will not decrypt as still configured", () => {
+    db.prepare("INSERT INTO providers (id, api_url, api_key) VALUES (?, ?, ?)").run("openai", "", "enc:BOOM");
+    // Degrades instead of throwing — the renderer gates the whole app's render on this loading.
+    expect(getProviderCredentials("openai")).toEqual({ apiUrl: "", apiKey: "" });
+    // But it is still a configured row. Reporting it unset would invite the user to overwrite a
+    // key that a keychain unlock would have recovered.
+    expect(listVisibleProviders()[0].keySet).toBe(true);
+    expect(isProviderConfigured("openai")).toBe(true);
+  });
+
+  it("returns null for a provider that was never configured", () => {
+    expect(getProviderCredentials("anthropic")).toBeNull();
+    expect(isProviderConfigured("anthropic")).toBe(false);
+  });
+
+  it("forgets a provider entirely on delete", () => {
+    saveProvider("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    deleteProvider("anthropic");
+    expect(getProviderCredentials("anthropic")).toBeNull();
+    expect(listVisibleProviders()).toEqual([]);
+  });
+
+  it("keeps providers independent of one another", () => {
+    saveProvider("openai", { apiUrl: "https://api.openai.com/v1", apiKey: "sk-openai" });
+    saveProvider("anthropic", { apiUrl: "https://api.anthropic.com/v1", apiKey: "sk-ant" });
+    saveProvider("openai", { apiKey: "" });
+    // One provider's credentials must never be reachable through another's id — that would be a
+    // key sent to a host the user didn't choose.
+    expect(getProviderCredentials("anthropic")?.apiKey).toBe("sk-ant");
+    expect(getProviderCredentials("openai")?.apiKey).toBe("");
+  });
+});

--- a/electron/main/db/providersStore.ts
+++ b/electron/main/db/providersStore.ts
@@ -1,0 +1,132 @@
+import { getDb } from "./index";
+import { encryptSecret, decryptSecret } from "../security/secretStorage";
+import { devLog } from "../devLog";
+
+/**
+ * Credentials for one AI provider, keyed by the registry id in ai/providers.ts.
+ *
+ * One row per provider rather than per agent or per slot: an agent can run on a different
+ * provider than the orchestrator, and per-agent storage would mean one copy of the same secret
+ * for every agent pointed at it — N places to rotate, N places to miss.
+ *
+ * Keys are encrypted at rest with the same AES-256-GCM helper the settings table uses. That is
+ * obfuscation, not protection — the encryption key lives in this same database file, which is
+ * documented and deliberate in security/secretStorage.ts.
+ */
+
+export interface ProviderRow {
+  id: string;
+  api_url: string;
+  /** Ciphertext as stored. Never hand this to a caller — see getProviderCredentials. */
+  api_key: string;
+  updated_at: string;
+}
+
+/** What the renderer is allowed to see: the URL, and whether a key exists — never its value.
+ * Same shape, and the same reasoning, as settings:get's chatApiKeySet/voiceApiKeySet. */
+export interface VisibleProvider {
+  id: string;
+  apiUrl: string;
+  keySet: boolean;
+}
+
+export interface ProviderCredentials {
+  apiUrl: string;
+  /** Decrypted. Empty when unset, or when decryption failed — callers must treat empty as
+   * "not configured" rather than assuming a key is present. */
+  apiKey: string;
+}
+
+/**
+ * Decrypts one stored key, degrading to "" rather than throwing.
+ *
+ * OS-backed decryption can fail for reasons that have nothing to do with this row — a userData
+ * directory copied to another machine, a locked keychain. The settings path already learned this
+ * (see getDecryptedSettings in ipc/settings.ts): the renderer gates the whole app's render on
+ * settings loading, so a throw here would show a blank window rather than a re-enterable field.
+ */
+function decryptOrEmpty(id: string, stored: string): string {
+  if (stored === "") return "";
+  try {
+    return decryptSecret(stored);
+  } catch (e) {
+    // Never the value itself — devLog writes to userData/debug.log, the file users attach to bug
+    // reports.
+    devLog(`[providers] failed to decrypt key for ${id}: ${e instanceof Error ? e.message : String(e)}`);
+    return "";
+  }
+}
+
+/** Every configured provider, safe to send over IPC. */
+export function listVisibleProviders(): VisibleProvider[] {
+  const rows = getDb().prepare("SELECT id, api_url, api_key FROM providers ORDER BY id").all() as ProviderRow[];
+  return rows.map((row) => ({
+    id: row.id,
+    apiUrl: row.api_url,
+    // Deliberately the stored ciphertext's length, not the decrypted value's: whether a key is
+    // configured is a fact about the row, and a key that currently fails to decrypt is still
+    // configured. Reporting it as unset would invite the user to overwrite a recoverable key.
+    keySet: row.api_key.length > 0,
+  }));
+}
+
+/** Main-process only — this returns the decrypted key and must never cross the IPC boundary. */
+export function getProviderCredentials(id: string): ProviderCredentials | null {
+  const row = getDb().prepare("SELECT id, api_url, api_key FROM providers WHERE id = ?").get(id) as
+    | ProviderRow
+    | undefined;
+  if (!row) return null;
+  return { apiUrl: row.api_url, apiKey: decryptOrEmpty(id, row.api_key) };
+}
+
+/** Whether a provider has both of the things a request needs. `local` is the exception the
+ * `keyRequired` flag exists for, so callers that care check the registry too. */
+export function isProviderConfigured(id: string): boolean {
+  const row = getDb().prepare("SELECT api_key FROM providers WHERE id = ?").get(id) as
+    | { api_key: string }
+    | undefined;
+  return row !== undefined && row.api_key.length > 0;
+}
+
+export interface SaveProviderInput {
+  apiUrl?: string;
+  /**
+   * Three-state on purpose:
+   *  - `undefined` — leave the stored key alone. This is what a Settings save sends when the
+   *    user edited only the URL, and what an untouched masked field sends on blur.
+   *  - `""` — clear it. The only way to remove a key without the Danger Zone's full wipe.
+   *  - anything else — replace it, encrypting on the way in.
+   */
+  apiKey?: string;
+}
+
+/** Upsert. Creates the row on first save so a provider only exists once it is configured. */
+export function saveProvider(id: string, input: SaveProviderInput): void {
+  const db = getDb();
+  const existing = db.prepare("SELECT id, api_url, api_key FROM providers WHERE id = ?").get(id) as
+    | ProviderRow
+    | undefined;
+
+  const apiUrl = input.apiUrl ?? existing?.api_url ?? "";
+  const apiKey =
+    input.apiKey === undefined
+      ? (existing?.api_key ?? "")
+      : input.apiKey === ""
+        ? ""
+        : encryptSecret(input.apiKey);
+
+  db.prepare(
+    `INSERT INTO providers (id, api_url, api_key, updated_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT(id) DO UPDATE SET
+       api_url = excluded.api_url,
+       api_key = excluded.api_key,
+       updated_at = excluded.updated_at`
+  ).run(id, apiUrl, apiKey);
+}
+
+/** Forgets a provider's credentials entirely. Separate from `saveProvider(id, {apiKey: ""})`,
+ * which keeps the row and its URL — this is for "I am not using this provider at all". */
+export function deleteProvider(id: string): void {
+  getDb().prepare("DELETE FROM providers WHERE id = ?").run(id);
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -11,6 +11,7 @@ import { registerWindowControlHandlers, attachWindowStateEvents } from "./ipc/wi
 import { registerSystemStatsHandlers, startSystemStatsBroadcast } from "./ipc/systemStats";
 import { registerLocationHandlers } from "./ipc/location";
 import { registerSettingsHandlers } from "./ipc/settings";
+import { registerProviderHandlers } from "./ipc/providers";
 import { registerChatHistoryHandlers } from "./ipc/chatHistory";
 import { registerMemoryHandlers } from "./ipc/memory";
 import { registerAgentHandlers } from "./ipc/agent";
@@ -101,6 +102,7 @@ app.whenReady().then(() => {
   migrateLegacyUserData();
   ensureAppDirectories();
   registerAppPingHandler();
+  registerProviderHandlers();
   registerFilesystemHandlers();
   registerAppLauncherHandlers();
   registerWindowControlHandlers();

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -557,7 +557,7 @@ export function registerAgentHandlers() {
     if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
       throw new Error("agent:update requires a plain object patch");
     }
-    const stringFields: (keyof AgentUpdatePatch)[] = ["name", "tagline", "description", "model", "prompt"];
+    const stringFields: (keyof AgentUpdatePatch)[] = ["name", "tagline", "description", "model", "prompt", "providerId"];
     for (const field of stringFields) {
       if (patch[field] !== undefined && typeof patch[field] !== "string") {
         throw new Error(`agent:update patch.${field} must be a string`);

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -26,7 +26,7 @@ import {
 } from "../ai/agents";
 import { closeMcpServers } from "../ai/mcp";
 import { extractApprovalMeta, extractRunItemMeta } from "../ai/runItemMeta";
-import { configureChatClient, estimateGenerationCost } from "../ai/provider";
+import { configureChatClient, estimateGenerationCost, providerIdForModel } from "../ai/provider";
 import { insertTokenUsage, updateTokenUsageCost } from "../db/tokenUsageStore";
 import { getRecentMessages, appendMessage, ChatMessageRecord } from "./chatHistory";
 import { readAppSetting } from "../appSettings";
@@ -158,6 +158,9 @@ function logTokenUsage(result: RunResultLike, traceId: string): void {
       const agent = turnAgents.length === rawResponses.length ? turnAgents[index] : fallbackAgent;
       const agentId = agent?.name ?? null;
       const model = agent?.model ? String(agent.model) : "unknown";
+      // A pinned agent carries its provider on the model object; an inherited one resolves to
+      // the Chat slot. Without this, cost is priced against whatever Chat happens to be.
+      const servingProviderId = providerIdForModel(agent?.model);
       const generationId = response.responseId ?? null;
 
       const id = insertTokenUsage({
@@ -171,7 +174,13 @@ function logTokenUsage(result: RunResultLike, traceId: string): void {
       });
       broadcastTokenUsageUpdate();
 
-      estimateGenerationCost(generationId, model, response.usage.inputTokens, response.usage.outputTokens)
+      estimateGenerationCost(
+        generationId,
+        model,
+        response.usage.inputTokens,
+        response.usage.outputTokens,
+        servingProviderId
+      )
         .then((costUsd) => {
           if (costUsd !== null) {
             updateTokenUsageCost(id, costUsd);

--- a/electron/main/ipc/providers.ts
+++ b/electron/main/ipc/providers.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
 import { listVisibleProviders, type VisibleProvider } from "../db/providersStore";
 import { selectChatProvider, type ChatProviderResult } from "../ai/selectProvider";
 import { AI_PROVIDERS, type AiProvider } from "../ai/providers";
@@ -45,7 +45,18 @@ export function registerProviderHandlers() {
       devLog(`[providers:selectChat] ${selection.providerId} (model "${selection.model ?? "default"}")`);
       // Thrown errors cross IPC as a rejected promise; the renderer surfaces the message, which
       // is why selectChatProvider's messages are written for a person to read.
-      return selectChatProvider(selection);
+      const result = selectChatProvider(selection);
+
+      // selectChatProvider writes orchestratorModel and chatProviderId with setSetting, which
+      // bypasses the settings:update handler — so nothing tells useSettings its cache is stale.
+      // Without this the Settings panel keeps rendering the *previous* provider's URL and model
+      // straight after a switch, while the app is already running on the new one. Same mechanism,
+      // and the same reason, as the broadcast after an agent run in ipc/agent.ts.
+      devLog("[providers] broadcasting settings:update after a provider change");
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send("settings:update");
+      }
+      return result;
     }
   );
 }

--- a/electron/main/ipc/providers.ts
+++ b/electron/main/ipc/providers.ts
@@ -1,0 +1,51 @@
+import { ipcMain } from "electron";
+import { listVisibleProviders, type VisibleProvider } from "../db/providersStore";
+import { selectChatProvider, type ChatProviderResult } from "../ai/selectProvider";
+import { AI_PROVIDERS, type AiProvider } from "../ai/providers";
+import { devLog } from "../devLog";
+
+/**
+ * The renderer's view of providers.
+ *
+ * Two things deliberately never cross this boundary: an API key value, and anything that would
+ * let the renderer write credentials one field at a time. `providers:list` returns
+ * `{id, apiUrl, keySet}` — the same shape, and the same reasoning, as `settings:get` swapping the
+ * keys for `chatApiKeySet`/`voiceApiKeySet`.
+ *
+ * Selecting a provider is one call rather than several because it has to be: saving the
+ * credentials, pointing the Chat slot and re-aligning the agents that follow it are a single
+ * change, and a half-applied one leaves the app in exactly the broken state the operation exists
+ * to prevent (see ai/selectProvider.ts).
+ */
+
+export interface ProvidersSnapshot {
+  /** The static registry, so the renderer does not need its own copy over IPC — it has one, but
+   * this keeps a mismatch visible rather than silent if they ever diverge. */
+  catalog: AiProvider[];
+  configured: VisibleProvider[];
+}
+
+export function registerProviderHandlers() {
+  ipcMain.handle("providers:list", (): ProvidersSnapshot => {
+    return { catalog: AI_PROVIDERS, configured: listVisibleProviders() };
+  });
+
+  ipcMain.handle(
+    "providers:selectChat",
+    (
+      _event,
+      selection: { providerId: string; apiUrl?: string; apiKey?: string; model?: string }
+    ): ChatProviderResult => {
+      if (typeof selection !== "object" || selection === null) {
+        throw new Error("providers:selectChat requires a selection object");
+      }
+      // Never the key, and never the URL: devLog writes to userData/debug.log, the file users
+      // attach to bug reports, and some OpenAI-compatible hosts carry the credential in the
+      // URL's query string.
+      devLog(`[providers:selectChat] ${selection.providerId} (model "${selection.model ?? "default"}")`);
+      // Thrown errors cross IPC as a rejected promise; the renderer surfaces the message, which
+      // is why selectChatProvider's messages are written for a person to read.
+      return selectChatProvider(selection);
+    }
+  );
+}

--- a/electron/main/ipc/providers.ts
+++ b/electron/main/ipc/providers.ts
@@ -1,7 +1,8 @@
 import { BrowserWindow, ipcMain } from "electron";
-import { listVisibleProviders, type VisibleProvider } from "../db/providersStore";
+import { listVisibleProviders, saveProvider, type VisibleProvider } from "../db/providersStore";
 import { selectChatProvider, type ChatProviderResult } from "../ai/selectProvider";
-import { AI_PROVIDERS, type AiProvider } from "../ai/providers";
+import { AI_PROVIDERS, findProvider, type AiProvider } from "../ai/providers";
+import { validateSettingValue } from "../settingsSchema";
 import { devLog } from "../devLog";
 
 /**
@@ -29,6 +30,32 @@ export function registerProviderHandlers() {
   ipcMain.handle("providers:list", (): ProvidersSnapshot => {
     return { catalog: AI_PROVIDERS, configured: listVisibleProviders() };
   });
+
+  /**
+   * Credentials for a provider that is *not* the Chat slot.
+   *
+   * Without this, an agent could be pinned to Claude but Claude could only be given a key by
+   * making it the Chat provider first and then switching back — so the per-agent feature looked
+   * available and could not actually be completed.
+   */
+  ipcMain.handle(
+    "providers:save",
+    (_event, input: { providerId: string; apiUrl?: string; apiKey?: string }): VisibleProvider[] => {
+      const provider = findProvider(input?.providerId ?? "");
+      if (!provider) throw new Error(`Unknown provider "${input?.providerId}".`);
+
+      const apiUrl = input.apiUrl?.trim();
+      if (apiUrl !== undefined && apiUrl !== "") {
+        const check = validateSettingValue("chatApiUrl", apiUrl);
+        if (!check.ok) throw new Error(`That API URL ${check.reason}.`);
+      }
+      // Never the key or the URL — debug.log is what users attach to bug reports, and some
+      // OpenAI-compatible hosts carry the credential in a query string.
+      devLog(`[providers:save] ${provider.id}`);
+      saveProvider(provider.id, { apiUrl, apiKey: input.apiKey });
+      return listVisibleProviders();
+    }
+  );
 
   ipcMain.handle(
     "providers:selectChat",

--- a/electron/main/settingsSchema.test.ts
+++ b/electron/main/settingsSchema.test.ts
@@ -20,7 +20,7 @@ describe("the schema itself", () => {
     // main has no path into the renderer's tree. This count is the tripwire: add a setting
     // there without adding it here and it becomes silently unwritable, because an unlisted
     // key is now refused rather than persisted.
-    expect(Object.keys(SETTINGS_SCHEMA)).toHaveLength(40);
+    expect(Object.keys(SETTINGS_SCHEMA)).toHaveLength(42);
   });
 
   it("recognises a real key and refuses anything else", () => {

--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -63,8 +63,16 @@ const STRING_ARRAY: SettingKind = { type: "stringArray" };
  *
  * Exported because agents.ts validates a sub-agent's `model` column against the same shape.
  * It lives here rather than there so there is one copy: this module has no heavy imports, so
- * agents.ts can depend on it, and not the other way round. */
-export const MODEL_ID_PATTERN = /^[a-z0-9._-]+(\/[a-z0-9._:-]+)?$/i;
+ * agents.ts can depend on it, and not the other way round.
+ *
+ * The optional leading `~` is OpenRouter's syntax for a floating "latest" alias
+ * (`~deepseek/deepseek-v4-flash-latest`), which is a real id: it is listed by their `/models`
+ * and returns 200, while the same id without the tilde is refused as "not a valid model ID".
+ * Without this character the app's own default for that provider could not be persisted through
+ * either write path — the value would be silently refused by `settings:update` and land as a
+ * `[settings:update] refused` line in debug.log. Anchored to the start rather than added to the
+ * character classes, so it stays a prefix marker and cannot appear mid-id. */
+export const MODEL_ID_PATTERN = /^~?[a-z0-9._-]+(\/[a-z0-9._:-]+)?$/i;
 
 /** Bounds here are the ones the Settings UI already claims via `min` on its number inputs.
  * `min` constrains a spinner and nothing else — typed and pasted values sail straight past it,

--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -87,8 +87,13 @@ const PROVIDER_ID_KIND: SettingKind = { type: "enum", values: ["", ...PROVIDER_I
  * Without this character the app's own default for that provider could not be persisted through
  * either write path — the value would be silently refused by `settings:update` and land as a
  * `[settings:update] refused` line in debug.log. Anchored to the start rather than added to the
- * character classes, so it stays a prefix marker and cannot appear mid-id. */
-export const MODEL_ID_PATTERN = /^~?[a-z0-9._-]+(\/[a-z0-9._:-]+)?$/i;
+ * character classes, so it stays a prefix marker and cannot appear mid-id.
+ *
+ * `:` is allowed in the first segment as well as after a `/`. Restricting it to the second was an
+ * OpenRouter-shaped assumption: Ollama names models `name:tag` with no vendor prefix at all
+ * (`llama3.2:3b`, `qwen2.5:7b`), which is the normal convention there, so without this the Local
+ * AI provider could not be pointed at most of the models a user actually has installed. */
+export const MODEL_ID_PATTERN = /^~?[a-z0-9._:-]+(\/[a-z0-9._:-]+)?$/i;
 
 /** Bounds here are the ones the Settings UI already claims via `min` on its number inputs.
  * `min` constrains a spinner and nothing else — typed and pasted values sail straight past it,

--- a/electron/main/settingsSchema.ts
+++ b/electron/main/settingsSchema.ts
@@ -20,6 +20,8 @@
  * setting that never reaches here fails loudly rather than being silently unwritable.
  */
 
+import { PROVIDER_IDS } from "./ai/providers";
+
 /** How a setting's value is validated. `model` is a string with the loose "model" or
  * "provider/model" shape; `enum` restricts to a fixed set. */
 export type SettingKind =
@@ -56,6 +58,20 @@ const BOOLEAN: SettingKind = { type: "boolean" };
 const MODEL: SettingKind = { type: "model" };
 const STRING_ARRAY: SettingKind = { type: "stringArray" };
 
+/**
+ * Which provider a credential slot is pointed at.
+ *
+ * `""` is a real, meaningful value and the default: it means "this slot has not been moved to
+ * the provider registry yet — read the legacy chatApiKey/chatApiUrl pair instead". That is what
+ * keeps every install predating the registry behaving exactly as it did, and why this is an enum
+ * over the ids *plus* empty rather than a plain string.
+ *
+ * Imported from ai/providers.ts rather than restated so a provider added there is immediately
+ * writable here; that module is pure data with no imports of its own, which is the same property
+ * that lets this one stay dependency-free enough for the renderer's parity test to load it.
+ */
+const PROVIDER_ID_KIND: SettingKind = { type: "enum", values: ["", ...PROVIDER_IDS] };
+
 /** Same loose shape ConfigAgent's update_setting has always applied to model ids: "model" or
  * "provider/model". Deliberately permissive — the catalogue depends on whichever
  * OpenAI-compatible host the user pointed at, so this only rejects things that cannot be a
@@ -83,6 +99,8 @@ export const SETTINGS_SCHEMA = {
   chatApiUrl: URL_KIND,
   voiceApiKey: STRING,
   voiceApiUrl: URL_KIND,
+  chatProviderId: PROVIDER_ID_KIND,
+  voiceProviderId: PROVIDER_ID_KIND,
   voiceInputEnabled: BOOLEAN,
   typeAnywhereEnabled: BOOLEAN,
   onboardingDone: BOOLEAN,
@@ -155,6 +173,8 @@ export const SETTING_DEFAULTS: { [K in SettingKey]: SettingValue<K> } = {
   chatApiUrl: "",
   voiceApiKey: "",
   voiceApiUrl: "",
+  chatProviderId: "",
+  voiceProviderId: "",
   voiceInputEnabled: true,
   typeAnywhereEnabled: true,
   onboardingDone: false,

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -74,6 +74,33 @@ const agentsAPI = {
     get: (): Promise<LocationData | null> => ipcRenderer.invoke("location:get"),
   },
 
+  providers: {
+    /** Registry + which providers have credentials. Key values never cross this boundary. */
+    list: (): Promise<{
+      catalog: {
+        id: string;
+        label: string;
+        baseUrl: string;
+        defaultChatModel: string;
+        api: string;
+        modelsAuth: string;
+        keyRequired: boolean;
+        supportsVoice: boolean;
+        defaultTranscriptionModel: string;
+        defaultTtsModel: string;
+      }[];
+      configured: { id: string; apiUrl: string; keySet: boolean }[];
+    }> => ipcRenderer.invoke("providers:list"),
+    /** One call on purpose: saving credentials, pointing the Chat slot and re-aligning the agents
+     * that follow it are a single change — see electron/main/ai/selectProvider.ts. */
+    selectChat: (selection: {
+      providerId: string;
+      apiUrl?: string;
+      apiKey?: string;
+      model?: string;
+    }): Promise<{ providerId: string; model: string; updatedAgents: number }> =>
+      ipcRenderer.invoke("providers:selectChat", selection),
+  },
   settings: {
     get: (): Promise<Record<string, unknown>> => ipcRenderer.invoke("settings:get"),
     update: (patch: Record<string, unknown>): Promise<Record<string, unknown>> =>

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -91,6 +91,11 @@ const agentsAPI = {
       }[];
       configured: { id: string; apiUrl: string; keySet: boolean }[];
     }> => ipcRenderer.invoke("providers:list"),
+    /** Credentials for a provider that is not the Chat slot — otherwise an agent could be
+     * pinned to one that could never be given a key. */
+    save: (input: { providerId: string; apiUrl?: string; apiKey?: string }): Promise<
+      { id: string; apiUrl: string; keySet: boolean }[]
+    > => ipcRenderer.invoke("providers:save", input),
     /** One call on purpose: saving credentials, pointing the Chat slot and re-aligning the agents
      * that follow it are a single change — see electron/main/ai/selectProvider.ts. */
     selectChat: (selection: {
@@ -197,6 +202,7 @@ const agentsAPI = {
         tagline?: string;
         description?: string;
         model?: string;
+        providerId?: string;
         prompt?: string;
         enabled?: boolean;
         mcpServerIds?: string[];
@@ -210,6 +216,7 @@ const agentsAPI = {
       tagline?: string;
       description?: string;
       model?: string;
+        providerId?: string;
       prompt?: string;
     }): Promise<AgentRow> => ipcRenderer.invoke("agent:create", input),
     orchestratorPrompt: (): Promise<string> => ipcRenderer.invoke("agent:orchestratorPrompt"),

--- a/src/components/atoms/MessageCost.tsx
+++ b/src/components/atoms/MessageCost.tsx
@@ -19,7 +19,16 @@ export default function MessageCost({ usage, id }: MessageCostProps) {
     <div id={id} className="message-cost">
       {/* costUsd is null until the async OpenRouter lookup lands, so tokens show first and
           the price appears a beat later rather than the row flickering in wholesale. */}
-      {usage.costUsd !== null && <span className="message-cost-price">{formatCost(usage.costUsd)}</span>}
+      {usage.costUsd !== null && (
+        // A local model costs nothing per token, and that is recorded as a real 0 rather than
+        // left null. "$0.0000" reads as a price so small it rounded away; the true answer is that
+        // there is no price, so say so. Deliberately not inside formatCost: the session total
+        // sums with COALESCE(...,0), so a run where nothing could be priced also totals zero and
+        // must not claim to have been free.
+        <span className="message-cost-price">
+          {usage.costUsd === 0 ? "Free" : formatCost(usage.costUsd)}
+        </span>
+      )}
       <span className="message-cost-tokens">{tokens}</span>
       {usage.calls > 1 && <span className="message-cost-calls">{usage.calls} calls</span>}
     </div>

--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import TablerIcon from "@/components/atoms/TablerIcon";
+import Combobox from "@/components/atoms/Combobox";
+import { AI_PROVIDERS } from "@/lib/providers";
 import Toggle from "@/components/atoms/Toggle";
 import TagMultiSelect from "@/components/atoms/TagMultiSelect";
 import DeleteConfirmModal from "@/components/molecules/DeleteConfirmModal";
@@ -22,6 +24,14 @@ interface AgentAccordionProps {
   onChangeTagline?: (tagline: string) => void;
   onChangeDescription?: (description: string) => void;
   onChangeModel?: (model: string) => void;
+  /** Registry id this agent runs on, or "" to follow the Chat slot. Omitted for the
+   * orchestrator, which *is* the Chat slot. */
+  providerId?: string;
+  onChangeProviderId?: (providerId: string) => void;
+  /** Set when the chosen provider has no usable credentials. The run still succeeds —
+   * modelForAgent falls back to the Chat slot and logs — but silently, so without this the
+   * only evidence is a line in debug.log. */
+  providerWarning?: string;
   onChangePrompt?: (prompt: string) => void;
   /** Shown as a "Reset to default" control beside the prompt label. Only passed when the
    * prompt is actually customised, so its presence is what says so. */
@@ -51,6 +61,9 @@ export default function AgentAccordion({
   tagline,
   description,
   model,
+  providerId,
+  onChangeProviderId,
+  providerWarning,
   prompt,
   promptLoading,
   enabled,
@@ -213,6 +226,24 @@ export default function AgentAccordion({
                 placeholder="What does this agent do?"
                 rows={3}
               />
+            </label>
+          )}
+          {onChangeProviderId !== undefined && (
+            <label className="settings-field">
+              <span>Provider</span>
+              <Combobox
+                value={providerId ?? ""}
+                // "" first and always present: following the Chat slot is the default every agent
+                // is seeded with, and the only way back to it once one has been pinned.
+                options={[
+                  { value: "", label: "Same as Chat" },
+                  ...AI_PROVIDERS.map((provider) => ({ value: provider.id, label: provider.label })),
+                ]}
+                onChange={onChangeProviderId}
+                ariaLabel={`Provider for ${name}`}
+                size="sm"
+              />
+              {providerWarning && <small className="settings-warning">{providerWarning}</small>}
             </label>
           )}
           {onChangeModel !== undefined && (

--- a/src/components/molecules/ApiKeyField.tsx
+++ b/src/components/molecules/ApiKeyField.tsx
@@ -5,6 +5,15 @@ interface ApiKeyFieldProps {
   /** Whether a key is already stored. The value itself never reaches the renderer. */
   isSet: boolean;
   onSave: (key: string) => void;
+  /**
+   * Removes the stored key. Optional so a caller with nowhere to route it can omit the control.
+   *
+   * Until this existed the comment below promised "clearing is done from the Danger Zone", and
+   * the Danger Zone offered exactly one thing: wiping the whole database — settings, chat
+   * history, agents, memory and the knowledge base. The write boundary has always accepted an
+   * empty string to clear a key; there was simply no way to send one.
+   */
+  onClear?: () => void;
 }
 
 /**
@@ -23,14 +32,14 @@ interface ApiKeyFieldProps {
  * Committing on blur also means one encrypted write per key entered rather than one per
  * character — pasting a 164-character key used to be 164 OS-keychain round trips.
  */
-export default function ApiKeyField({ label, isSet, onSave }: ApiKeyFieldProps) {
+export default function ApiKeyField({ label, isSet, onSave, onClear }: ApiKeyFieldProps) {
   const [draft, setDraft] = useState("");
   const [justSaved, setJustSaved] = useState(false);
 
   const commit = () => {
     const trimmed = draft.trim();
     // Blurring an untouched field must not clear a stored key — an empty draft means
-    // "unchanged", not "remove it". Clearing is done from the Danger Zone.
+    // "unchanged", not "remove it". Removing is the explicit control below.
     if (trimmed.length === 0) return;
     onSave(trimmed);
     setDraft("");
@@ -44,6 +53,23 @@ export default function ApiKeyField({ label, isSet, onSave }: ApiKeyFieldProps) 
       <span>
         {label}
         {stored && <small>A key is saved — type a new one to replace it</small>}
+        {stored && onClear && (
+          <button
+            type="button"
+            className="settings-action-btn-sm settings-action-btn-ghost"
+            // Not inside the <label>'s implicit focus target by accident: a bare <button> in a
+            // label would steal the click meant for the input, so this sits in the text column
+            // where the hint already is.
+            onClick={(e) => {
+              e.preventDefault();
+              setDraft("");
+              setJustSaved(false);
+              onClear();
+            }}
+          >
+            Remove
+          </button>
+        )}
       </span>
       <input
         type="password"

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -152,7 +152,7 @@ export default function AgentsApp() {
     exportAllAgents,
     importAgents,
   } = useAgents();
-  const { speak, speaking, stop: stopSpeaking } = useSpeak();
+  const { speak, speaking, stop: stopSpeaking } = useSpeak(settings.voiceApiKeySet);
   const soundFxVariants: Record<SoundFxEvent, number> = useMemo(
     () => ({
       send: settings.soundVariantSend,
@@ -636,7 +636,12 @@ export default function AgentsApp() {
         // fails at call time. Only OpenAI serves them today; see supportsVoice in lib/providers.
         ...(findProvider(answers.providerId)?.supportsVoice
           ? { voiceApiKey: answers.apiKey, voiceApiUrl: answers.apiUrl }
-          : {}),
+          : // Voice input is transcription, and useVoiceInput deliberately replaces the browser's
+            // SpeechRecognition with the provider's /audio/transcriptions — so unlike speech
+            // *output*, which falls back to the browser's own voice, there is nothing for it to
+            // degrade to. Leaving the toggle on would offer a mic that can only fail. Voice output
+            // stays on: useSpeak routes it to browser TTS while the slot is unconfigured.
+            { voiceInputEnabled: false }),
         onboardingDone: true,
       });
 

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -8,6 +8,7 @@ import ChatHistoryModal from "@/components/organisms/ChatHistoryModal";
 import HttpToolApprovalModal, { type PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
 import ToolApprovalCard from "@/components/molecules/ToolApprovalCard";
 import OnboardingScreen, { type OnboardingAnswers } from "@/components/organisms/OnboardingScreen";
+import { findProvider } from "@/lib/providers";
 import { useOrbitScene } from "@/hooks/useOrbitScene";
 import { useWindowControls } from "@/hooks/useWindowControls";
 import { useGlobalTypingFocus } from "@/hooks/useGlobalTypingFocus";
@@ -626,16 +627,38 @@ export default function AgentsApp() {
 
   const handleOnboardingComplete = useCallback(
     (answers: OnboardingAnswers) => {
-      // The single onboarding key seeds both Chat and Voice credential slots — each
-      // remains independently editable afterward in Settings → AI Models without
-      // affecting the other.
       updateSettings({
         agentName: answers.agentName,
         userName: answers.userName,
-        chatApiKey: answers.apiKey,
-        voiceApiKey: answers.apiKey,
+        // Voice is seeded from the same key only when the chosen provider can actually serve
+        // speech. Copying it unconditionally — which is what this used to do — configures Voice
+        // against a host with no /audio endpoints at all, so the mic appears to work and then
+        // fails at call time. Only OpenAI serves them today; see supportsVoice in lib/providers.
+        ...(findProvider(answers.providerId)?.supportsVoice
+          ? { voiceApiKey: answers.apiKey, voiceApiUrl: answers.apiUrl }
+          : {}),
         onboardingDone: true,
       });
+
+      // The provider is one call rather than a handful of settings writes, because it is one
+      // change: credentials, the Chat slot, and the models of every agent that follows it. Doing
+      // it piecemeal is what leaves four system agents naming a model the new host has never
+      // heard of. See electron/main/ai/selectProvider.ts.
+      if (hasAgentsAPI()) {
+        void window.agentsAPI.providers
+          .selectChat({
+            providerId: answers.providerId,
+            apiUrl: answers.apiUrl,
+            apiKey: answers.apiKey,
+            model: answers.model,
+          })
+          .catch((error: unknown) => {
+            // Non-fatal by design: the user is already through the door, and Settings → AI Models
+            // is where they would fix it anyway. Swallowing it silently would be worse than the
+            // log line, which is what a bug report will carry.
+            window.agentsAPI.dev.log("[onboarding] selectChat failed", error);
+          });
+      }
 
       // The optional context answers go into the shared user-fact store so every agent
       // has them from the first turn. Fire-and-forget: the entrance animation below must

--- a/src/components/organisms/OnboardingScreen.test.tsx
+++ b/src/components/organisms/OnboardingScreen.test.tsx
@@ -11,11 +11,15 @@ function reachChipSteps() {
   fireEvent.keyDown(screen.getByPlaceholderText("e.g. Product Designer"), { key: "Enter" });
 }
 
-/** Chip steps 4–6, then the final API key step. */
-function finishFromChipSteps(chips: [string, string, string]) {
+/** Chip steps 4–6, then the provider chip and the three steps it seeds. */
+function finishFromChipSteps(chips: [string, string, string], provider = "OpenAI") {
   for (const chip of chips) fireEvent.click(screen.getByText(chip));
+  fireEvent.click(screen.getByText(provider));
+  // URL and model arrive prefilled from the registry, so Enter alone carries them.
+  fireEvent.keyDown(screen.getByLabelText("Where should I reach it?"), { key: "Enter" });
   fireEvent.change(screen.getByPlaceholderText("sk-…"), { target: { value: " sk-test " } });
   fireEvent.keyDown(screen.getByPlaceholderText("sk-…"), { key: "Enter" });
+  fireEvent.keyDown(screen.getByLabelText("Which model?"), { key: "Enter" });
 }
 
 describe("OnboardingScreen", () => {
@@ -43,7 +47,7 @@ describe("OnboardingScreen", () => {
     render(<OnboardingScreen onComplete={onComplete} />);
 
     reachChipSteps();
-    expect(document.querySelector(".onboarding-step-index")?.textContent).toBe("4 / 7");
+    expect(document.querySelector(".onboarding-step-index")?.textContent).toBe("4 / 10");
     finishFromChipSteps(["Detailed", "Expert", "Give me options"]);
 
     act(() => {
@@ -57,7 +61,12 @@ describe("OnboardingScreen", () => {
       responseStyle: "Detailed",
       technicalLevel: "Expert",
       stuckStyle: "Give me options",
+      // The chip stores the registry id, not the label the user clicked.
+      providerId: "openai",
+      // Both seeded by the provider choice and carried through untouched.
+      apiUrl: "https://api.openai.com/v1",
       apiKey: "sk-test",
+      model: "gpt-4.1-mini",
     });
   });
 
@@ -69,8 +78,14 @@ describe("OnboardingScreen", () => {
     fireEvent.click(screen.getByLabelText("Skip"));
     fireEvent.click(screen.getByLabelText("Skip"));
     fireEvent.click(screen.getByLabelText("Skip"));
+    // The provider step is required, so it offers no Skip — proving that is the point of the
+    // assertion below rather than an incidental detail of this walkthrough.
+    expect(screen.queryByLabelText("Skip")).toBeNull();
+    fireEvent.click(screen.getByText("OpenAI"));
+    fireEvent.keyDown(screen.getByLabelText("Where should I reach it?"), { key: "Enter" });
     fireEvent.change(screen.getByPlaceholderText("sk-…"), { target: { value: "sk-test" } });
     fireEvent.keyDown(screen.getByPlaceholderText("sk-…"), { key: "Enter" });
+    fireEvent.keyDown(screen.getByLabelText("Which model?"), { key: "Enter" });
 
     act(() => {
       vi.advanceTimersByTime(500);
@@ -79,6 +94,74 @@ describe("OnboardingScreen", () => {
     expect(onComplete).toHaveBeenCalledWith(
       expect.objectContaining({ responseStyle: "", technicalLevel: "", stuckStyle: "" })
     );
+  });
+
+  it("seeds the URL and model from the provider, and stores its id", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingScreen onComplete={onComplete} />);
+    reachChipSteps();
+    finishFromChipSteps(["Detailed", "Expert", "Give me options"], "Claude");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "anthropic",
+        apiUrl: "https://api.anthropic.com/v1",
+        model: "claude-haiku-4-5-20251001",
+      })
+    );
+  });
+
+  it("does not require a key for a local server, but does require a URL and model", () => {
+    const onComplete = vi.fn();
+    render(<OnboardingScreen onComplete={onComplete} />);
+    reachChipSteps();
+    for (const chip of ["Detailed", "Expert", "Give me options"]) fireEvent.click(screen.getByText(chip));
+    fireEvent.click(screen.getByText("Local AI"));
+
+    // Nothing to prefill — only the user knows their server's address, so blank cannot mean
+    // "use OpenAI's" the way an empty chatApiUrl does elsewhere.
+    const url = screen.getByLabelText("Where should I reach it?") as HTMLInputElement;
+    expect(url.value).toBe("");
+    expect((screen.getByLabelText("Next") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(url, { target: { value: "http://localhost:11434/v1" } });
+    fireEvent.keyDown(url, { key: "Enter" });
+
+    // A local server authenticates nothing, so the key step must let an empty value through —
+    // requiring one would block the provider whose whole point is not having one.
+    expect((screen.getByLabelText("Next") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.keyDown(screen.getByPlaceholderText("sk-…"), { key: "Enter" });
+
+    const model = screen.getByLabelText("Which model?") as HTMLInputElement;
+    expect(model.value).toBe("");
+    fireEvent.change(model, { target: { value: "llama3.2:3b" } });
+    fireEvent.keyDown(model, { key: "Enter" });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "local", apiUrl: "http://localhost:11434/v1", apiKey: "", model: "llama3.2:3b" })
+    );
+  });
+
+  it("warns when a remote provider URL would send the key in the clear", () => {
+    render(<OnboardingScreen onComplete={vi.fn()} />);
+    reachChipSteps();
+    for (const chip of ["Detailed", "Expert", "Give me options"]) fireEvent.click(screen.getByText(chip));
+    fireEvent.click(screen.getByText("Local AI"));
+
+    const url = screen.getByLabelText("Where should I reach it?");
+    fireEvent.change(url, { target: { value: "http://example.com/v1" } });
+    expect(screen.getByText(/sent unencrypted/)).toBeTruthy();
+
+    // Loopback is the case the warning must stay quiet for — it is the documented Ollama setup.
+    fireEvent.change(url, { target: { value: "http://localhost:11434/v1" } });
+    expect(screen.queryByText(/sent unencrypted/)).toBeNull();
   });
 
   it("moves focus between chips with the arrow keys", () => {

--- a/src/components/organisms/OnboardingScreen.tsx
+++ b/src/components/organisms/OnboardingScreen.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState, type KeyboardEvent } from "react";
 import TablerIcon from "@/components/atoms/TablerIcon";
 import { USER_CONTEXT_FIELD_BY_KEY } from "@/lib/userContext";
+import { AI_PROVIDERS, DEFAULT_PROVIDER_ID, findProvider } from "@/lib/providers";
+import { providerUrlWarning } from "@/lib/providerUrlWarning";
 
 export interface OnboardingAnswers {
   agentName: string;
@@ -9,23 +11,41 @@ export interface OnboardingAnswers {
   responseStyle: string;
   technicalLevel: string;
   stuckStyle: string;
+  /** Registry id from lib/providers — decides the defaults for the three steps after it. */
+  providerId: string;
+  apiUrl: string;
   apiKey: string;
+  model: string;
 }
 
 interface OnboardingScreenProps {
   onComplete: (answers: OnboardingAnswers) => void;
 }
 
+interface ChipOption {
+  value: string;
+  label: string;
+}
+
 interface Step {
   key: keyof OnboardingAnswers;
   question: string;
-  subtitle?: string;
+  /** A function where an earlier answer decides the wording — the provider steps all do. */
+  subtitle?: string | ((answers: OnboardingAnswers) => string | undefined);
   /** Text/password steps only — chip steps render preset options instead of an input. */
-  placeholder?: string;
+  placeholder?: string | ((answers: OnboardingAnswers) => string);
   type: "text" | "password" | "chips";
   chips?: readonly string[];
-  required: boolean;
+  /** Chip steps whose stored value differs from its label — the provider step stores an id. */
+  options?: readonly ChipOption[];
+  /** A function where the answer decides it: a local server needs no key, everyone else does. */
+  required: boolean | ((answers: OnboardingAnswers) => boolean);
+  /** Shown under the field while typing — the plain-http key-exposure caution. */
+  warningFor?: (value: string) => string | null;
 }
+
+const providerLabel = (answers: OnboardingAnswers): string =>
+  findProvider(answers.providerId)?.label ?? "your provider";
 
 const STEPS: Step[] = [
   {
@@ -75,14 +95,59 @@ const STEPS: Step[] = [
     required: false,
   },
   {
+    key: "providerId",
+    question: "Which AI provider?",
+    subtitle: "You can change this later, or point individual agents somewhere else.",
+    type: "chips",
+    // Labels and ids differ here — "Claude" is the label, "anthropic" the stored id — which is
+    // why chip steps carry options as well as plain strings.
+    options: AI_PROVIDERS.map((provider) => ({ value: provider.id, label: provider.label })),
+    required: true,
+  },
+  {
+    key: "apiUrl",
+    question: "Where should I reach it?",
+    // Prefilled for a hosted provider and blank for a local server, because only the user knows
+    // that address — blank here cannot mean "use OpenAI's" the way an empty chatApiUrl does.
+    subtitle: (answers) =>
+      findProvider(answers.providerId)?.baseUrl === ""
+        ? "Your server's OpenAI-compatible address — Ollama's default is http://localhost:11434/v1"
+        : `The standard ${providerLabel(answers)} address. Change it only if you use a proxy.`,
+    placeholder: (answers) => findProvider(answers.providerId)?.baseUrl || "http://localhost:11434/v1",
+    type: "text",
+    required: true,
+    warningFor: providerUrlWarning,
+  },
+  {
     key: "apiKey",
-    question: "Enter your OpenAI API Key",
-    subtitle: "Powers chat and voice out of the box — you can swap providers later in Settings.",
+    question: "Enter your API key",
+    subtitle: (answers) =>
+      findProvider(answers.providerId)?.keyRequired === false
+        ? "A local server usually needs no key — leave this blank unless yours does."
+        : `Your ${providerLabel(answers)} key. It is stored on this machine only.`,
     placeholder: "sk-…",
     type: "password",
+    // The one provider that authenticates nothing. Demanding a key here would block the provider
+    // whose whole point is not having one.
+    required: (answers) => findProvider(answers.providerId)?.keyRequired !== false,
+  },
+  {
+    key: "model",
+    question: "Which model?",
+    subtitle: (answers) =>
+      findProvider(answers.providerId)?.defaultChatModel === ""
+        ? "Whichever model you have pulled — `ollama list` shows them, e.g. llama3.2:3b"
+        : "A sensible default for that provider. Change it if you prefer another.",
+    placeholder: (answers) => findProvider(answers.providerId)?.defaultChatModel || "llama3.2:3b",
+    type: "text",
     required: true,
   },
 ];
+
+/** Resolves the step fields that can depend on earlier answers. */
+function resolve<T>(value: T | ((answers: OnboardingAnswers) => T), answers: OnboardingAnswers): T {
+  return typeof value === "function" ? (value as (a: OnboardingAnswers) => T)(answers) : value;
+}
 
 export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
   const [stepIndex, setStepIndex] = useState(0);
@@ -93,7 +158,10 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
     responseStyle: "",
     technicalLevel: "",
     stuckStyle: "",
+    providerId: "",
+    apiUrl: "",
     apiKey: "",
+    model: "",
   });
   const [leaving, setLeaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -101,7 +169,13 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
 
   const step = STEPS[stepIndex];
   const value = answers[step.key];
-  const canAdvance = !step.required || value.trim().length > 0;
+  const required = resolve(step.required, answers);
+  const canAdvance = !required || value.trim().length > 0;
+  const subtitle = resolve(step.subtitle, answers);
+  const placeholder = resolve(step.placeholder, answers);
+  const warning = step.warningFor?.(value) ?? null;
+  const chipOptions: readonly ChipOption[] =
+    step.options ?? (step.chips ?? []).map((chip) => ({ value: chip, label: chip }));
 
   // Both completion paths (typed final step, chip-selected final step) route through here so
   // trimming stays identical regardless of which control finished onboarding.
@@ -116,7 +190,10 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
           responseStyle: final.responseStyle,
           technicalLevel: final.technicalLevel,
           stuckStyle: final.stuckStyle,
+          providerId: final.providerId || DEFAULT_PROVIDER_ID,
+          apiUrl: final.apiUrl.trim(),
           apiKey: final.apiKey.trim(),
+          model: final.model.trim(),
         });
       }, 500);
     },
@@ -138,6 +215,15 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
   const selectChip = useCallback(
     (chip: string) => {
       const next = { ...answers, [step.key]: chip } as OnboardingAnswers;
+      // Choosing a provider seeds the two steps that need a default, so the user reviews a
+      // filled-in URL and model rather than typing them from scratch. Both stay editable, and a
+      // local server correctly seeds blank — only the user knows that address or which model
+      // they have pulled.
+      if (step.key === "providerId") {
+        const provider = findProvider(chip);
+        next.apiUrl = provider?.baseUrl ?? "";
+        next.model = provider?.defaultChatModel ?? "";
+      }
       setAnswers(next);
       if (stepIndex < STEPS.length - 1) setStepIndex((i) => i + 1);
       else finish(next);
@@ -149,7 +235,7 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
   // keyboard alone. Enter/Space need no handler — they fire onClick natively on a button.
   const onChipKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
-      const count = step.chips?.length ?? 0;
+      const count = chipOptions.length;
       if (count === 0) return;
       const current = chipRefs.current.findIndex((el) => el === document.activeElement);
       if (e.key === "ArrowRight" || e.key === "ArrowDown") {
@@ -160,7 +246,7 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
         chipRefs.current[(current - 1 + count) % count]?.focus();
       }
     },
-    [step.chips]
+    [chipOptions.length]
   );
 
   return (
@@ -179,7 +265,7 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
             {stepIndex + 1} / {STEPS.length}
           </span>
           <h1 className="onboarding-question">{step.question}</h1>
-          {step.subtitle && <p className="onboarding-subtitle">{step.subtitle}</p>}
+          {subtitle && <p className="onboarding-subtitle">{subtitle}</p>}
           {step.type === "chips" ? (
             <div className="onboarding-chip-row">
               <div
@@ -188,27 +274,30 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
                 aria-label={step.question}
                 onKeyDown={onChipKeyDown}
               >
-                {step.chips?.map((chip, i) => (
+                {chipOptions.map((option, i) => (
                   <button
-                    key={chip}
+                    key={option.value}
                     ref={(el) => {
                       chipRefs.current[i] = el;
                     }}
                     role="radio"
-                    aria-checked={value === chip}
+                    aria-checked={value === option.value}
                     autoFocus={i === 0}
-                    className={`onboarding-chip${value === chip ? " selected" : ""}`}
-                    onClick={() => selectChip(chip)}
+                    className={`onboarding-chip${value === option.value ? " selected" : ""}`}
+                    onClick={() => selectChip(option.value)}
                   >
-                    {chip}
+                    {option.label}
                   </button>
                 ))}
               </div>
-              {/* Chip steps are optional, so they need their own way past — selecting a chip
-                  advances, this skips without recording an answer. */}
-              <button className="onboarding-next" aria-label="Skip" onClick={advance}>
-                <TablerIcon name={stepIndex < STEPS.length - 1 ? "ti-arrow-right" : "ti-check"} />
-              </button>
+              {/* An optional chip step needs its own way past — selecting a chip advances, this
+                  skips without recording an answer. A required one (the provider) must not offer
+                  it, or the user reaches the end with nothing chosen. */}
+              {!required && (
+                <button className="onboarding-next" aria-label="Skip" onClick={advance}>
+                  <TablerIcon name={stepIndex < STEPS.length - 1 ? "ti-arrow-right" : "ti-check"} />
+                </button>
+              )}
             </div>
           ) : (
             <div className="onboarding-input-row">
@@ -217,8 +306,9 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
                 autoFocus
                 type={step.type}
                 value={value}
-                placeholder={step.placeholder}
+                placeholder={placeholder}
                 autoComplete="off"
+                aria-label={step.question}
                 onChange={(e) => setAnswers((prev) => ({ ...prev, [step.key]: e.target.value }))}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") advance();
@@ -229,6 +319,7 @@ export default function OnboardingScreen({ onComplete }: OnboardingScreenProps) 
               </button>
             </div>
           )}
+          {warning && <p className="settings-warning">{warning}</p>}
         </div>
       </div>
     </div>

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -19,12 +19,14 @@ import ErrorBoundary from "@/components/atoms/ErrorBoundary";
 import { SETTING_BOUNDS, ToolApprovalDisplay, DEFAULT_ORCHESTRATOR_MODEL, AgentsSettings, SettingsView, VOICE_TTS_VOICE_OPTIONS, SOUND_FX_VARIANT_COUNT } from "@/lib/settings";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { hasAgentsAPI } from "@/lib/agentsApi";
+import { useProviders } from "@/hooks/useProviders";
 import { useMcpServers } from "@/hooks/useMcpServers";
 import { useConnectors } from "@/hooks/useConnectors";
 import { useHttpTools } from "@/hooks/useHttpTools";
 import { useUserContext } from "@/hooks/useUserContext";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { providerUrlWarning } from "@/lib/providerUrlWarning";
+import { AI_PROVIDERS, findProvider } from "@/lib/providers";
 import { DEFAULT_SETTINGS_SECTION, sectionOnTransition } from "@/lib/settingsSection";
 import { SoundFxEvent, sfxPreviewSrc } from "@/hooks/useSoundFX";
 
@@ -263,6 +265,31 @@ export default function SettingsPanel({
   const [orchestratorPromptLoading, setOrchestratorPromptLoading] = useState(true);
   const [addingAgent, setAddingAgent] = useState(false);
   const [agentActionError, setAgentActionError] = useState<string | null>(null);
+  const [chatError, setChatError] = useState<string | null>(null);
+
+  // The Chat slot's URL and key live in the providers table once the slot has been moved there,
+  // so binding these fields to settings.chatApiUrl/chatApiKeySet showed a blank URL and "no key
+  // saved" while the app ran fine on credentials the panel could not see.
+  const providers = useProviders(open);
+  const chatSlotView = providers.chatSlot(
+    settings.chatProviderId,
+    settings.chatApiUrl,
+    settings.chatApiKeySet
+  );
+  const chatProvider = findProvider(chatSlotView.providerId);
+
+  /** Every Chat edit goes through the one operation, so credentials, the slot and the models of
+   * inheriting agents can never drift apart — see electron/main/ai/selectProvider.ts. */
+  const applyChat = async (selection: { providerId: string; apiUrl?: string; apiKey?: string; model?: string }) => {
+    setChatError(null);
+    try {
+      await providers.selectChat(selection);
+    } catch (err) {
+      // Surfaced rather than swallowed: selectChatProvider refuses a blank URL, a bad model id and
+      // a missing key with messages written for a person to read.
+      setChatError(formatHumanizedError(humanizeError(err)));
+    }
+  };
 
   const runTestChat = async () => {
     if (!hasAgentsAPI()) return;
@@ -420,24 +447,42 @@ export default function SettingsPanel({
                   </p>
                   <div className="group">
                     <div className="card">
+                      <label className="row-field">
+                        <span>
+                          Provider
+                          <small>Switching also moves every agent that follows this slot</small>
+                        </span>
+                        <Combobox
+                          value={chatSlotView.providerId}
+                          options={AI_PROVIDERS.map((provider) => ({ value: provider.id, label: provider.label }))}
+                          onChange={(providerId) => void applyChat({ providerId })}
+                          ariaLabel="Chat provider"
+                        />
+                      </label>
                       <ApiKeyField
                         label="API Key"
-                        isSet={settings.chatApiKeySet}
-                        onSave={(key) => onUpdate({ chatApiKey: key })}
+                        isSet={chatSlotView.keySet}
+                        onSave={(apiKey) => void applyChat({ providerId: chatSlotView.providerId, apiKey })}
+                        onClear={
+                          chatSlotView.keySet
+                            ? () => void applyChat({ providerId: chatSlotView.providerId, apiKey: "" })
+                            : undefined
+                        }
                       />
                       <TextField
                         label="API URL"
-                        value={settings.chatApiUrl}
-                        placeholder="https://api.openai.com/v1"
+                        value={chatSlotView.apiUrl}
+                        placeholder={chatProvider?.baseUrl || "http://localhost:11434/v1"}
                         warningFor={providerUrlWarning}
-                        onCommit={(chatApiUrl) => onUpdate({ chatApiUrl })}
+                        onCommit={(apiUrl) => void applyChat({ providerId: chatSlotView.providerId, apiUrl })}
                       />
                       <TextField
                         label="Model ID"
                         value={settings.orchestratorModel}
-                        placeholder={DEFAULT_ORCHESTRATOR_MODEL}
-                        onCommit={(orchestratorModel) => onUpdate({ orchestratorModel })}
+                        placeholder={chatProvider?.defaultChatModel || DEFAULT_ORCHESTRATOR_MODEL}
+                        onCommit={(model) => void applyChat({ providerId: chatSlotView.providerId, model })}
                       />
+                      {chatError && <p className="settings-error">{chatError}</p>}
                     </div>
                   </div>
                 </SettingsAccordion>

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -49,6 +49,7 @@ interface SettingsPanelProps {
       tagline?: string;
       description?: string;
       model?: string;
+      providerId?: string;
       prompt?: string;
       enabled?: boolean;
       mcpServerIds?: string[];
@@ -278,6 +279,28 @@ export default function SettingsPanel({
   );
   const chatProvider = findProvider(chatSlotView.providerId);
 
+  /**
+   * Why an agent's pinned provider will not be used, or undefined when it is fine.
+   *
+   * modelForAgent falls back to the Chat slot and logs rather than throwing — one misconfigured
+   * agent must not take down a run it isn't part of. The cost is that the fallback is invisible,
+   * so this is the surface that makes it visible where the user set it.
+   */
+  const providerWarningFor = (providerId: string): string | undefined => {
+    if (providerId === "") return undefined;
+    const provider = findProvider(providerId);
+    if (!provider) return `Unknown provider — this agent falls back to the Chat provider.`;
+    const row = providers.configured.find((entry) => entry.id === providerId);
+    if (!row) return `${provider.label} isn't set up yet — this agent falls back to the Chat provider.`;
+    if (provider.keyRequired && !row.keySet) {
+      return `${provider.label} has no API key — this agent falls back to the Chat provider.`;
+    }
+    if (!row.apiUrl && !provider.baseUrl) {
+      return `${provider.label} has no API URL — this agent falls back to the Chat provider.`;
+    }
+    return undefined;
+  };
+
   /** Every Chat edit goes through the one operation, so credentials, the slot and the models of
    * inheriting agents can never drift apart — see electron/main/ai/selectProvider.ts. */
   const applyChat = async (selection: { providerId: string; apiUrl?: string; apiKey?: string; model?: string }) => {
@@ -487,6 +510,54 @@ export default function SettingsPanel({
                   </div>
                 </SettingsAccordion>
 
+                <SettingsAccordion title="Other providers">
+                  <p className="group-hint">
+                    Credentials for providers an individual agent can be pointed at, without making
+                    them your Chat provider. Set one up here, then pick it on the agent in Settings →
+                    Agents.
+                  </p>
+                  <div className="group">
+                    <div className="card">
+                      {AI_PROVIDERS.filter((provider) => provider.id !== chatSlotView.providerId).map(
+                        (provider) => {
+                          const row = providers.configured.find((entry) => entry.id === provider.id);
+                          return (
+                            <div key={provider.id} className="row-field">
+                              <span>
+                                {provider.label}
+                                <small>
+                                  {row?.keySet
+                                    ? "Configured"
+                                    : provider.keyRequired
+                                      ? "No API key yet"
+                                      : "No API URL yet"}
+                                </small>
+                              </span>
+                              <ApiKeyField
+                                label={`${provider.label} API key`}
+                                isSet={row?.keySet ?? false}
+                                onSave={(apiKey) => void providers.save({ providerId: provider.id, apiKey })}
+                                onClear={
+                                  row?.keySet
+                                    ? () => void providers.save({ providerId: provider.id, apiKey: "" })
+                                    : undefined
+                                }
+                              />
+                              <TextField
+                                label={`${provider.label} API URL`}
+                                value={row?.apiUrl ?? ""}
+                                placeholder={provider.baseUrl || "http://localhost:11434/v1"}
+                                warningFor={providerUrlWarning}
+                                onCommit={(apiUrl) => void providers.save({ providerId: provider.id, apiUrl })}
+                              />
+                            </div>
+                          );
+                        }
+                      )}
+                    </div>
+                  </div>
+                </SettingsAccordion>
+
                 <SettingsAccordion
                   title="Voice"
                   headerActions={
@@ -640,6 +711,20 @@ export default function SettingsPanel({
                       onChangeTagline={(tagline) => onUpdateAgent(agent.id, { tagline })}
                       onChangeDescription={(description) => onUpdateAgent(agent.id, { description })}
                       onChangeModel={(model) => onUpdateAgent(agent.id, { model })}
+                      providerId={agent.provider_id}
+                      onChangeProviderId={(providerId) => {
+                        // The model has to move with the provider, for the same reason it does on
+                        // the Chat slot: pinning an agent to Claude while it still names
+                        // gpt-4.1-mini just 404s. Only when the new provider actually has a
+                        // default — a local server has none, because only the user knows which
+                        // model they have pulled, so its model is left alone for them to set.
+                        const nextModel = findProvider(providerId)?.defaultChatModel;
+                        void onUpdateAgent(agent.id, {
+                          providerId,
+                          ...(nextModel ? { model: nextModel } : {}),
+                        });
+                      }}
+                      providerWarning={providerWarningFor(agent.provider_id)}
                       onChangePrompt={(prompt) => onUpdateAgent(agent.id, { prompt })}
                       onChangeEnabled={(enabled) => onUpdateAgent(agent.id, { enabled })}
                       availableMcpServers={mcpServers}

--- a/src/hooks/useAgents.ts
+++ b/src/hooks/useAgents.ts
@@ -33,6 +33,7 @@ export function useAgents() {
         tagline?: string;
         description?: string;
         model?: string;
+        providerId?: string;
         prompt?: string;
         enabled?: boolean;
         mcpServerIds?: string[];
@@ -59,6 +60,7 @@ export function useAgents() {
       tagline?: string;
       description?: string;
       model?: string;
+        providerId?: string;
       prompt?: string;
     }) => {
       if (!hasAgentsAPI()) return;

--- a/src/hooks/useProviders.test.ts
+++ b/src/hooks/useProviders.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useProviders } from "./useProviders";
+
+/**
+ * The Chat slot's URL and key stopped living in the settings table once a provider is selected.
+ * A Settings screen still bound to `chatApiUrl`/`chatApiKeySet` therefore rendered a blank URL
+ * and claimed no key was saved, while the app ran perfectly well on credentials it could not
+ * see — reported from real use, and the reason this hook exists.
+ */
+describe("useProviders.chatSlot", () => {
+  const list = vi.fn();
+
+  beforeEach(() => {
+    list.mockReset().mockResolvedValue({
+      catalog: [],
+      configured: [
+        { id: "anthropic", apiUrl: "https://api.anthropic.com/v1", keySet: true },
+        { id: "local", apiUrl: "http://localhost:11434/v1", keySet: false },
+      ],
+    });
+    vi.stubGlobal("agentsAPI", { providers: { list, selectChat: vi.fn() } });
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("reads the configured provider rather than the legacy settings", async () => {
+    const { result } = renderHook(() => useProviders(true));
+    await waitFor(() => expect(list).toHaveBeenCalled());
+
+    // The legacy values passed in are deliberately empty — which is exactly what they hold after
+    // onboarding writes a provider, and what used to be rendered.
+    const slot = result.current.chatSlot("anthropic", "", false);
+    expect(slot).toEqual({
+      providerId: "anthropic",
+      apiUrl: "https://api.anthropic.com/v1",
+      keySet: true,
+    });
+  });
+
+  it("reports a local server with no key as configured-but-keyless", async () => {
+    const { result } = renderHook(() => useProviders(true));
+    await waitFor(() => expect(list).toHaveBeenCalled());
+    expect(result.current.chatSlot("local", "", false)).toEqual({
+      providerId: "local",
+      apiUrl: "http://localhost:11434/v1",
+      keySet: false,
+    });
+  });
+
+  it("falls back to the legacy pair on an install that predates the registry", async () => {
+    const { result } = renderHook(() => useProviders(true));
+    await waitFor(() => expect(list).toHaveBeenCalled());
+
+    // chatProviderId "" means the slot was never moved, so the legacy values are still the truth
+    // — and the dropdown still has to show something, inferred from the URL the same way the
+    // migration seeded these installs.
+    expect(result.current.chatSlot("", "https://openrouter.ai/api/v1", true)).toEqual({
+      providerId: "openrouter",
+      apiUrl: "https://openrouter.ai/api/v1",
+      keySet: true,
+    });
+  });
+
+  it("shows a provider with no stored row as unconfigured rather than throwing", async () => {
+    const { result } = renderHook(() => useProviders(true));
+    await waitFor(() => expect(list).toHaveBeenCalled());
+    expect(result.current.chatSlot("openai", "", false)).toEqual({
+      providerId: "openai",
+      apiUrl: "",
+      keySet: false,
+    });
+  });
+
+  it("does not fetch while the panel is closed", () => {
+    renderHook(() => useProviders(false));
+    expect(list).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useProviders.ts
+++ b/src/hooks/useProviders.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from "react";
+import { hasAgentsAPI } from "@/lib/agentsApi";
+import { inferProviderId } from "@/lib/providers";
+
+/** One provider's stored configuration, as the renderer is allowed to see it — never the key. */
+export interface ConfiguredProvider {
+  id: string;
+  apiUrl: string;
+  keySet: boolean;
+}
+
+export interface ChatSlotView {
+  /** Always a real provider id, even on an install that predates the registry. */
+  providerId: string;
+  apiUrl: string;
+  keySet: boolean;
+}
+
+/**
+ * The provider rows behind Settings → AI Models.
+ *
+ * This exists because the Chat slot's URL and key stopped living in the settings table. After
+ * onboarding writes a provider, `chatApiUrl` is empty and `chatApiKeySet` is false — so a
+ * Settings screen still bound to those renders a blank URL and claims no key is saved, while the
+ * app is running perfectly well on credentials it cannot see. That is a real bug this hook fixes,
+ * not a refactor.
+ */
+export function useProviders(open: boolean) {
+  const [configured, setConfigured] = useState<ConfiguredProvider[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!hasAgentsAPI()) return;
+    try {
+      const snapshot = await window.agentsAPI.providers.list();
+      setConfigured(snapshot.configured);
+    } catch {
+      // Non-fatal: the panel still renders, the fields just show what the legacy settings hold.
+      setConfigured([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    // Deferred out of the effect's synchronous execution for the same reason useSettings does it:
+    // react-hooks/set-state-in-effect rejects a setState that lands during the effect body, and
+    // the fetch owns its own state transitions anyway.
+    const task = window.setTimeout(() => void refresh(), 0);
+    return () => window.clearTimeout(task);
+  }, [open, refresh]);
+
+  /**
+   * What the Chat accordion should display, from whichever source actually holds it.
+   *
+   * `chatProviderId` is `""` until the slot has been moved to the registry, and on that install
+   * the legacy pair is still the truth. Rather than showing an empty dropdown, the provider is
+   * inferred from the legacy URL using the same rule the migration used to seed these rows.
+   */
+  const chatSlot = useCallback(
+    (chatProviderId: string, legacyUrl: string, legacyKeySet: boolean): ChatSlotView => {
+      if (chatProviderId === "") {
+        return { providerId: inferProviderId(legacyUrl), apiUrl: legacyUrl, keySet: legacyKeySet };
+      }
+      const row = configured.find((provider) => provider.id === chatProviderId);
+      return { providerId: chatProviderId, apiUrl: row?.apiUrl ?? "", keySet: row?.keySet ?? false };
+    },
+    [configured]
+  );
+
+  /** Applies a change and refreshes, so the fields reflect what was actually stored rather than
+   * what was typed — the same reconcile-against-the-write pattern useSettings uses. */
+  const selectChat = useCallback(
+    async (selection: { providerId: string; apiUrl?: string; apiKey?: string; model?: string }) => {
+      if (!hasAgentsAPI()) return;
+      const result = await window.agentsAPI.providers.selectChat(selection);
+      await refresh();
+      return result;
+    },
+    [refresh]
+  );
+
+  return { configured, refresh, chatSlot, selectChat };
+}

--- a/src/hooks/useProviders.ts
+++ b/src/hooks/useProviders.ts
@@ -78,5 +78,15 @@ export function useProviders(open: boolean) {
     [refresh]
   );
 
-  return { configured, refresh, chatSlot, selectChat };
+  /** Credentials for a provider that is not the Chat slot. Returns the refreshed list, so the
+   * caller does not need a second round trip. */
+  const save = useCallback(
+    async (input: { providerId: string; apiUrl?: string; apiKey?: string }) => {
+      if (!hasAgentsAPI()) return;
+      setConfigured(await window.agentsAPI.providers.save(input));
+    },
+    []
+  );
+
+  return { configured, refresh, chatSlot, selectChat, save };
 }

--- a/src/hooks/useSpeak.test.ts
+++ b/src/hooks/useSpeak.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSpeak } from "./useSpeak";
+
+/**
+ * The Voice slot is the one part of the app that cannot follow the Chat provider: only OpenAI
+ * serves /audio/transcriptions and /audio/speech, so onboarding onto Claude, OpenRouter or a
+ * local server leaves it unconfigured. What that must *not* do is throw on the first greeting,
+ * which is exactly what a real run produced:
+ *
+ *   Error occurred in handler for 'voice:synthesize': No Voice API key configured.
+ *   [speak] synth failed, falling back to browser TTS
+ *
+ * The fallback was already there; the failing round trip in front of it was not necessary.
+ */
+describe("useSpeak when the Voice slot has no credentials", () => {
+  const synthesize = vi.fn();
+  const speakFn = vi.fn();
+
+  beforeEach(() => {
+    synthesize.mockReset().mockResolvedValue({ audio: "", format: "mp3" });
+    speakFn.mockReset();
+    vi.stubGlobal("speechSynthesis", { speak: speakFn, cancel: vi.fn(), getVoices: () => [] });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        text: string;
+        constructor(text: string) {
+          this.text = text;
+        }
+      }
+    );
+    vi.stubGlobal("agentsAPI", {
+      voice: { synthesize },
+      dev: { log: vi.fn() },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("goes straight to the browser voice without calling the provider", () => {
+    const { result } = renderHook(() => useSpeak(false));
+    act(() => result.current.speak("hello"));
+
+    // The point of the fix: no round trip that can only fail.
+    expect(synthesize).not.toHaveBeenCalled();
+    // Speech still happens — output degrades to the OS voice rather than going silent, which is
+    // why voice *output* is left enabled while voice *input* is switched off.
+    expect(speakFn).toHaveBeenCalled();
+  });
+
+  it("uses the provider once the slot is configured", () => {
+    const { result } = renderHook(() => useSpeak(true));
+    act(() => result.current.speak("hello"));
+    expect(synthesize).toHaveBeenCalledWith("hello");
+  });
+
+  it("still says nothing when there is no text", () => {
+    const { result } = renderHook(() => useSpeak(false));
+    act(() => result.current.speak(""));
+    expect(speakFn).not.toHaveBeenCalled();
+    expect(synthesize).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSpeak.ts
+++ b/src/hooks/useSpeak.ts
@@ -22,7 +22,13 @@ function devLog(...args: unknown[]): void {
  * Exposes `speaking` (for simple UI gating) and per-call onStart/onEnd callbacks (for
  * callers that need to react to playback transitions, e.g. pushing a status-feed step)
  * without doing so from a render-time effect. */
-export function useSpeak() {
+/**
+ * @param providerConfigured Whether the Voice slot actually has credentials. When it doesn't,
+ *   speech goes straight to the browser's own voice: only OpenAI serves /audio/*, so onboarding
+ *   onto Claude, OpenRouter or a local server leaves Voice unset, and calling the IPC anyway
+ *   produced "No Voice API key configured" on the first greeting.
+ */
+export function useSpeak(providerConfigured: boolean) {
   const [speaking, setSpeaking] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -55,7 +61,12 @@ export function useSpeak() {
       audioRef.current = null;
       if (typeof window !== "undefined" && window.speechSynthesis) window.speechSynthesis.cancel();
 
-      if (!hasAgentsAPI()) {
+      if (!hasAgentsAPI() || !providerConfigured) {
+        // No voice provider set up — go straight to the browser's own voice rather than firing an
+        // IPC call that can only fail. Voice output genuinely works without a key this way, so
+        // there is nothing to disable; what it must not do is throw "No Voice API key configured"
+        // on the very first greeting, which is what onboarding onto a provider that cannot serve
+        // speech used to produce.
         speakWithBrowserTts(text, callbacks);
         return;
       }
@@ -91,7 +102,7 @@ export function useSpeak() {
           speakWithBrowserTts(text, callbacks);
         });
     },
-    [speakWithBrowserTts]
+    [speakWithBrowserTts, providerConfigured]
   );
 
   /** Force-stops whichever playback is active (provider audio or browser TTS fallback)

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -17,7 +17,7 @@ function makeRows(n: number): AgentDisplayRow[] {
     created_at: "",
     mcp_server_ids: "[]",
     connector_ids: "[]",
-    http_tool_collection_ids: "[]",
+    http_tool_collection_ids: "[]", provider_id: "",
     toolNames: [],
     connectorToolCount: 0,
   }));

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -126,6 +126,24 @@ export function findProvider(id: string): AiProvider | null {
   return AI_PROVIDERS.find((provider) => provider.id === id) ?? null;
 }
 
+/**
+ * Which provider a bare base URL belongs to.
+ *
+ * Needed because `chatProviderId` is `""` on an install that predates the registry, while the
+ * legacy `chatApiUrl` still says where it was pointed. Settings has to show *something* selected
+ * rather than an empty dropdown, and this is the same prefix match the providers migration used
+ * to seed those installs — deliberately, so the UI agrees with what the database did.
+ *
+ * An empty URL is OpenAI, because that is what an empty chatApiUrl has always meant at runtime.
+ * Anything unrecognised is a custom OpenAI-compatible host, which is what `local` is for.
+ */
+export function inferProviderId(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed === "") return DEFAULT_PROVIDER_ID;
+  const hosted = AI_PROVIDERS.find((provider) => provider.baseUrl !== "" && trimmed.startsWith(provider.baseUrl));
+  return hosted?.id ?? "local";
+}
+
 /** The providers that can back the Voice slot. Separate from the full list because Voice needs
  * `/audio/*`, which only OpenAI serves. */
 export function voiceProviders(): AiProvider[] {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -50,12 +50,19 @@ export interface AiProvider {
   defaultTtsModel: string;
 }
 
+/** Hosts that code outside the registry also needs to name — the legacy Chat slot falls back to
+ * OpenAI's, and the cost lookup in ai/provider.ts only applies to OpenRouter. Exported from here
+ * so there is one literal per host rather than a copy that can drift out of step with the entry
+ * below it. */
+export const OPENAI_BASE_URL = "https://api.openai.com/v1";
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
 /** Listed in the order the onboarding chips and the Settings dropdown show them. */
 export const AI_PROVIDERS: AiProvider[] = [
   {
     id: "openrouter",
     label: "OpenRouter",
-    baseUrl: "https://openrouter.ai/api/v1",
+    baseUrl: OPENROUTER_BASE_URL,
     // The leading `~` is OpenRouter's own syntax for a floating "latest" alias, not a typo: the
     // id is listed by GET /models and returns 200, while the de-tilde'd form is refused as "not
     // a valid model ID". MODEL_ID_PATTERN in electron/main/settingsSchema.ts admits it for this
@@ -71,7 +78,7 @@ export const AI_PROVIDERS: AiProvider[] = [
   {
     id: "openai",
     label: "OpenAI",
-    baseUrl: "https://api.openai.com/v1",
+    baseUrl: OPENAI_BASE_URL,
     defaultChatModel: "gpt-4.1-mini",
     api: "responses",
     modelsAuth: "bearer",

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,126 @@
+/**
+ * The AI providers the app knows how to talk to, and what each one can actually do.
+ *
+ * Renderer-side copy. Mirrors `electron/main/ai/providers.ts` exactly, for the same reason
+ * DEFAULT_SETTINGS mirrors SETTING_DEFAULTS: `electron/` and `src/` are separate TypeScript
+ * projects, and tsconfig.web.json deliberately keeps renderer code from importing main's. The
+ * mechanism that stops the two drifting is `src/lib/providersParity.test.ts`, not this comment.
+ *
+ * Every field was measured against the live API rather than assumed — see
+ * `0-cowork/plans/active/ai-providers-keys-models.md` for the probe results.
+ */
+
+/**
+ * Which HTTP surface an agent run has to use.
+ *
+ * `@openai/agents` defaults to the Responses API, and the app has never called `setOpenAIAPI`,
+ * so every run to date has gone to `POST /responses`. OpenAI and OpenRouter both serve that.
+ * Anthropic's OpenAI-compatible surface does not — it 404s — and neither does Ollama's.
+ */
+export type ProviderApi = "responses" | "chat_completions";
+
+/**
+ * How the connectivity check authenticates against `GET /models`.
+ *
+ * `bearer` is the OpenAI convention and what the SDK client sends for chat traffic everywhere,
+ * Anthropic included. But Anthropic's native `/v1/models` rejects a bearer token outright (401
+ * "Invalid bearer token") and wants `x-api-key` plus `anthropic-version`.
+ */
+export type ProviderModelsAuth = "bearer" | "anthropic";
+
+export interface AiProvider {
+  /** Stable key. Persisted in the database, so never rename one of these. */
+  id: string;
+  label: string;
+  /** Prefilled into the API URL field; always editable. Empty for a self-hosted server, where
+   * only the user knows the address — and where empty must mean "you must supply one", not the
+   * "fall back to OpenAI" that an empty chatApiUrl means today. */
+  baseUrl: string;
+  /** Prefilled into the model field; always editable. Empty where there is no sensible default. */
+  defaultChatModel: string;
+  api: ProviderApi;
+  modelsAuth: ProviderModelsAuth;
+  /** False only for a local server, which authenticates nothing. Making a key mandatory there
+   * would block the one provider whose whole point is not having one. */
+  keyRequired: boolean;
+  /** Whether `/audio/transcriptions` and `/audio/speech` exist. Only OpenAI serves them, so the
+   * Voice slot cannot be pointed at anything else — the field is what stops the UI offering it. */
+  supportsVoice: boolean;
+  defaultTranscriptionModel: string;
+  defaultTtsModel: string;
+}
+
+/** Listed in the order the onboarding chips and the Settings dropdown show them. */
+export const AI_PROVIDERS: AiProvider[] = [
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    // The leading `~` is OpenRouter's own syntax for a floating "latest" alias, not a typo: the
+    // id is listed by GET /models and returns 200, while the de-tilde'd form is refused as "not
+    // a valid model ID". MODEL_ID_PATTERN in electron/main/settingsSchema.ts admits it for this
+    // reason.
+    defaultChatModel: "~deepseek/deepseek-v4-flash-latest",
+    api: "responses",
+    modelsAuth: "bearer",
+    keyRequired: true,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    defaultChatModel: "gpt-4.1-mini",
+    api: "responses",
+    modelsAuth: "bearer",
+    keyRequired: true,
+    supportsVoice: true,
+    defaultTranscriptionModel: "whisper-1",
+    defaultTtsModel: "gpt-4o-mini-tts",
+  },
+  {
+    id: "anthropic",
+    label: "Claude",
+    // Anthropic's OpenAI-compatible surface. Chat and tool calls work through it with a bearer
+    // token; `/responses` does not exist, hence chat_completions above.
+    baseUrl: "https://api.anthropic.com/v1",
+    defaultChatModel: "claude-haiku-4-5-20251001",
+    api: "chat_completions",
+    modelsAuth: "anthropic",
+    keyRequired: true,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+  {
+    id: "local",
+    label: "Local AI",
+    baseUrl: "",
+    defaultChatModel: "",
+    api: "chat_completions",
+    modelsAuth: "bearer",
+    keyRequired: false,
+    supportsVoice: false,
+    defaultTranscriptionModel: "",
+    defaultTtsModel: "",
+  },
+];
+
+export const PROVIDER_IDS = AI_PROVIDERS.map((provider) => provider.id);
+
+/** The provider a fresh install starts on, and the fallback when a stored id is unrecognised. */
+export const DEFAULT_PROVIDER_ID = "openai";
+
+/** Looks up a provider, or null when the id is unknown — a database can hold an id written by a
+ * build that offered a provider this one doesn't. Callers fall back rather than throwing. */
+export function findProvider(id: string): AiProvider | null {
+  return AI_PROVIDERS.find((provider) => provider.id === id) ?? null;
+}
+
+/** The providers that can back the Voice slot. Separate from the full list because Voice needs
+ * `/audio/*`, which only OpenAI serves. */
+export function voiceProviders(): AiProvider[] {
+  return AI_PROVIDERS.filter((provider) => provider.supportsVoice);
+}

--- a/src/lib/providersParity.test.ts
+++ b/src/lib/providersParity.test.ts
@@ -92,6 +92,15 @@ describe("every default model the registry ships", () => {
     }
   });
 
+  it("accepts an Ollama name:tag id", () => {
+    // Ollama's normal convention has no vendor prefix, so the tag colon lands in the first
+    // segment. Restricting `:` to after a `/` made most locally-installed models unsavable —
+    // found the moment a real Ollama server was available to test against.
+    for (const id of ["llama3.2:3b", "qwen2.5:7b"]) {
+      expect(MODEL_ID_PATTERN.test(id), id).toBe(true);
+    }
+  });
+
   it("accepts OpenRouter's tilde-prefixed floating alias", () => {
     // Named explicitly because it is the specific id that forced MODEL_ID_PATTERN to widen. The
     // `~` is OpenRouter's own syntax, not a typo: this form is listed by their /models and

--- a/src/lib/providersParity.test.ts
+++ b/src/lib/providersParity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AI_PROVIDERS, DEFAULT_PROVIDER_ID, findProvider, voiceProviders } from "./providers";
+import { AI_PROVIDERS, DEFAULT_PROVIDER_ID, findProvider, inferProviderId, voiceProviders } from "./providers";
 import { AI_PROVIDERS as MAIN_AI_PROVIDERS } from "../../electron/main/ai/providers";
 import { MODEL_ID_PATTERN } from "../../electron/main/settingsSchema";
 
@@ -115,6 +115,22 @@ describe("every default model the registry ships", () => {
     for (const bad of ["", " ", "has space", "deep~seek/model", "~", "model/", "/model", "a/b/c"]) {
       expect(MODEL_ID_PATTERN.test(bad), JSON.stringify(bad)).toBe(false);
     }
+  });
+});
+
+describe("inferring a provider from a legacy URL", () => {
+  // chatProviderId is "" on an install that predates the registry, so Settings has to derive a
+  // selection from the URL alone. This must agree with the prefix match the migration used to
+  // seed those same installs, or the dropdown would disagree with the database.
+  it.each([
+    ["", "openai"],
+    ["https://api.openai.com/v1", "openai"],
+    ["https://openrouter.ai/api/v1", "openrouter"],
+    ["https://api.anthropic.com/v1", "anthropic"],
+    ["http://localhost:11434/v1", "local"],
+    ["https://some-proxy.example.com/v1", "local"],
+  ])("maps %s to %s", (url, expected) => {
+    expect(inferProviderId(url)).toBe(expected);
   });
 });
 

--- a/src/lib/providersParity.test.ts
+++ b/src/lib/providersParity.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { AI_PROVIDERS, DEFAULT_PROVIDER_ID, findProvider, voiceProviders } from "./providers";
+import { AI_PROVIDERS as MAIN_AI_PROVIDERS } from "../../electron/main/ai/providers";
+import { MODEL_ID_PATTERN } from "../../electron/main/settingsSchema";
+
+/**
+ * The renderer and the main process each hold their own copy of the provider registry, because
+ * `electron/` and `src/` are separate TypeScript projects and tsconfig.web.json deliberately
+ * keeps renderer code from importing main's. Two copies of the same facts drift — that is
+ * exactly what happened to the settings defaults (finding S1), where a toggle read "on" in the
+ * UI while main's own view of it was "off".
+ *
+ * This test is the thing that stops it here. It lives on the renderer side because that is where
+ * both are reachable.
+ */
+describe("provider registry, renderer vs main", () => {
+  it("is identical on both sides", () => {
+    expect(MAIN_AI_PROVIDERS).toEqual(AI_PROVIDERS);
+  });
+
+  it("lists the same ids in the same order", () => {
+    // Order is not cosmetic: it is the order the onboarding chips and the Settings dropdown
+    // render in, so a reorder on one side alone would silently change the UI on that side only.
+    expect(MAIN_AI_PROVIDERS.map((p) => p.id)).toEqual(AI_PROVIDERS.map((p) => p.id));
+  });
+
+  it("offers exactly the four providers the app supports", () => {
+    expect(AI_PROVIDERS.map((p) => p.id)).toEqual(["openrouter", "openai", "anthropic", "local"]);
+  });
+});
+
+/**
+ * These are measured facts, not preferences — each was probed against the live API before being
+ * written down (see 0-cowork/plans/active/ai-providers-keys-models.md). They are pinned
+ * individually so that changing one fails with an obvious message rather than a diff of four
+ * objects, and so a future edit made on a hunch has to argue with a recorded observation.
+ */
+describe("the capability facts each provider was measured against", () => {
+  it("routes Claude and Local AI through chat completions, and the rest through responses", () => {
+    // Anthropic's OpenAI-compatible surface 404s on POST /responses; Ollama has no such endpoint
+    // either. OpenAI and OpenRouter both answer 200 there, which is why this is per-provider
+    // rather than a global setOpenAIAPI('chat_completions') switch.
+    expect(findProvider("anthropic")?.api).toBe("chat_completions");
+    expect(findProvider("local")?.api).toBe("chat_completions");
+    expect(findProvider("openai")?.api).toBe("responses");
+    expect(findProvider("openrouter")?.api).toBe("responses");
+  });
+
+  it("knows Anthropic's model listing refuses a bearer token", () => {
+    // GET https://api.anthropic.com/v1/models with `Authorization: Bearer` returns 401 "Invalid
+    // bearer token"; it wants `x-api-key` plus `anthropic-version`. Chat traffic is unaffected —
+    // the compat layer accepts bearer there, which is what the OpenAI SDK client sends — so this
+    // flag exists purely for the Settings connectivity check.
+    expect(findProvider("anthropic")?.modelsAuth).toBe("anthropic");
+    for (const id of ["openai", "openrouter", "local"]) {
+      expect(findProvider(id)?.modelsAuth, id).toBe("bearer");
+    }
+  });
+
+  it("offers voice only where /audio/* actually exists", () => {
+    // If this ever lists more than OpenAI, the Voice slot will offer a provider that 404s at the
+    // first transcription — which surfaces as a broken mic, not as a settings error.
+    expect(voiceProviders().map((p) => p.id)).toEqual(["openai"]);
+  });
+
+  it("requires a key everywhere except the local server", () => {
+    expect(findProvider("local")?.keyRequired).toBe(false);
+    for (const id of ["openai", "openrouter", "anthropic"]) {
+      expect(findProvider(id)?.keyRequired, id).toBe(true);
+    }
+  });
+
+  it("leaves the local server's URL blank, and fills every hosted one in", () => {
+    // Blank here has to mean "you must supply one" rather than the "fall back to OpenAI" that an
+    // empty chatApiUrl means in ai/provider.ts — only the user knows a self-hosted address.
+    expect(findProvider("local")?.baseUrl).toBe("");
+    for (const id of ["openai", "openrouter", "anthropic"]) {
+      expect(findProvider(id)?.baseUrl, id).toMatch(/^https:\/\//);
+    }
+  });
+});
+
+describe("every default model the registry ships", () => {
+  it("passes the write boundary's own validation", () => {
+    // The invariant that matters, and the one that was broken on the first attempt: a default
+    // this registry prefills into the model field but `validateSettingValue` would refuse is
+    // unsavable — the UI shows it, the user presses save, and the value is silently dropped with
+    // only a debug.log line to show for it. Asserting the whole set catches the next one too.
+    for (const provider of AI_PROVIDERS) {
+      if (provider.defaultChatModel === "") continue;
+      expect(MODEL_ID_PATTERN.test(provider.defaultChatModel), provider.id).toBe(true);
+    }
+  });
+
+  it("accepts OpenRouter's tilde-prefixed floating alias", () => {
+    // Named explicitly because it is the specific id that forced MODEL_ID_PATTERN to widen. The
+    // `~` is OpenRouter's own syntax, not a typo: this form is listed by their /models and
+    // returns 200, while the de-tilde'd form is refused as "not a valid model ID".
+    expect(MODEL_ID_PATTERN.test("~deepseek/deepseek-v4-flash-latest")).toBe(true);
+    expect(findProvider("openrouter")?.defaultChatModel).toBe("~deepseek/deepseek-v4-flash-latest");
+  });
+
+  it("still rejects the things a model id can never be", () => {
+    // Widening the pattern must not turn it into "anything goes" — these are the shapes the
+    // check exists to catch, including a tilde used anywhere but as a leading marker.
+    for (const bad of ["", " ", "has space", "deep~seek/model", "~", "model/", "/model", "a/b/c"]) {
+      expect(MODEL_ID_PATTERN.test(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+});
+
+describe("provider lookup", () => {
+  it("returns null for an id this build has never heard of", () => {
+    // A database can hold an id written by a build that offered a provider this one doesn't.
+    // Callers fall back to the default rather than throwing, so the app still starts.
+    expect(findProvider("gemini")).toBeNull();
+    expect(findProvider("")).toBeNull();
+  });
+
+  it("resolves the default provider id", () => {
+    expect(findProvider(DEFAULT_PROVIDER_ID)).not.toBeNull();
+  });
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -41,6 +41,11 @@ export interface AgentsSettings {
   chatApiUrl: string;
   voiceApiKey: string;
   voiceApiUrl: string;
+  /** Which entry in AI_PROVIDERS this slot is pointed at. `""` means the slot predates the
+   * provider registry and still reads the legacy chatApiKey/chatApiUrl pair — that is what keeps
+   * an existing install behaving exactly as it did. */
+  chatProviderId: string;
+  voiceProviderId: string;
   voiceInputEnabled: boolean;
   typeAnywhereEnabled: boolean;
   onboardingDone: boolean;
@@ -101,6 +106,8 @@ export const DEFAULT_SETTINGS: AgentsSettings = {
   chatApiUrl: "",
   voiceApiKey: "",
   voiceApiUrl: "",
+  chatProviderId: "",
+  voiceProviderId: "",
   voiceInputEnabled: true,
   typeAnywhereEnabled: true,
   onboardingDone: false,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -116,6 +116,8 @@ interface AgentRow {
   connector_ids: string;
   /** JSON array of http_tool_collections.id attached to this agent. */
   http_tool_collection_ids: string;
+  /** Registry id from lib/providers, or "" to follow the Chat slot. */
+  provider_id: string;
 }
 
 /** AgentRow plus derived, non-persisted fields computed by listAgentsForDisplay()
@@ -416,6 +418,9 @@ interface Window {
         }[];
         configured: { id: string; apiUrl: string; keySet: boolean }[];
       }>;
+      save: (input: { providerId: string; apiUrl?: string; apiKey?: string }) => Promise<
+        { id: string; apiUrl: string; keySet: boolean }[]
+      >;
       selectChat: (selection: {
         providerId: string;
         apiUrl?: string;
@@ -484,6 +489,7 @@ interface Window {
           tagline?: string;
           description?: string;
           model?: string;
+        providerId?: string;
           prompt?: string;
           enabled?: boolean;
           mcpServerIds?: string[];
@@ -497,6 +503,7 @@ interface Window {
         tagline?: string;
         description?: string;
         model?: string;
+        providerId?: string;
         prompt?: string;
       }) => Promise<AgentRow>;
       orchestratorPrompt: () => Promise<string>;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -400,6 +400,29 @@ interface Window {
       refresh: () => Promise<LocationData | null>;
       get: () => Promise<LocationData | null>;
     };
+    providers: {
+      list: () => Promise<{
+        catalog: {
+          id: string;
+          label: string;
+          baseUrl: string;
+          defaultChatModel: string;
+          api: string;
+          modelsAuth: string;
+          keyRequired: boolean;
+          supportsVoice: boolean;
+          defaultTranscriptionModel: string;
+          defaultTtsModel: string;
+        }[];
+        configured: { id: string; apiUrl: string; keySet: boolean }[];
+      }>;
+      selectChat: (selection: {
+        providerId: string;
+        apiUrl?: string;
+        apiKey?: string;
+        model?: string;
+      }) => Promise<{ providerId: string; model: string; updatedAgents: number }>;
+    };
     settings: {
       get: () => Promise<Record<string, unknown>>;
       update: (patch: Record<string, unknown>) => Promise<Record<string, unknown>>;

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -18,11 +18,12 @@
       "@/*": ["./src/*"]
     }
   },
-  // settingsSchema.ts is main-process code, listed here only so
-  // src/lib/settingsDefaults.test.ts can assert that the renderer's DEFAULT_SETTINGS and main's
-  // SETTING_DEFAULTS still agree — the two are separate projects, so nothing else stops them
-  // drifting, and they already had (finding S1). It is deliberately dependency-free, so pulling
-  // it into this program adds no Electron surface. This is not an invitation for renderer code
-  // to import from electron/: everything else there reaches the Electron API.
-  "include": ["src", "electron/main/settingsSchema.ts"]
+  // settingsSchema.ts and ai/providers.ts are main-process code, listed here only so
+  // src/lib/settingsDefaults.test.ts and src/lib/providersParity.test.ts can assert that the
+  // renderer's copies (DEFAULT_SETTINGS, AI_PROVIDERS) and main's still agree — the two are
+  // separate projects, so nothing else stops them drifting, and settings already had (finding
+  // S1). Both are deliberately dependency-free, so pulling them into this program adds no
+  // Electron surface. This is not an invitation for renderer code to import from electron/:
+  // everything else there reaches the Electron API, and these two are test-only imports.
+  "include": ["src", "electron/main/settingsSchema.ts", "electron/main/ai/providers.ts"]
 }


### PR DESCRIPTION
## What changed

The app had two fixed credential slots pointed at whatever OpenAI-compatible host you typed a URL for. It now has a provider concept: **OpenRouter, OpenAI, Claude and Local AI (Ollama)** are picked during onboarding with the URL and model prefilled, changed later in Settings → AI Models, and overridden per agent in Settings → Agents — so an orchestrator on OpenAI can hand off to a sub-agent on Claude. Credentials are stored per provider rather than per slot, so one key serves every agent pointed at it, and existing installs are migrated and keep working untouched.

Cost tracking follows the provider that actually served each call: OpenRouter reports its real billed figure, local models show **Free**, shipped defaults are priced from a scoped static table, and anything else shows tokens rather than a guess.

## Testing

- **Unit/integration:** 1126 passed / 109 files (baseline on `develop` was 1032 / 104)
- **E2E:** not configured — no Playwright/Cypress harness in the repo
- **Manual:** driven through the real UI against a sandboxed `userData` with live keys for all four providers. Onboarding completed separately for Claude and Local AI; provider switched in Settings and the fields updated live; an agent pinned to Claude while the orchestrator ran on OpenAI, both replying in the same session; Ollama answering through the full agent stack; cost recorded as `0` for a local call and `$0.005924` for a Claude call in the same run.

## Notes

- `@openai/agents` defaults to the Responses API. Anthropic's compatible surface 404s it and Ollama has no such endpoint, so those route through `OpenAIChatCompletionsModel` — per-provider rather than a global switch, so OpenAI and OpenRouter traffic is unchanged.
- An agent inheriting the Chat slot still gets a plain model-id string resolving through the existing global client, so the common path is byte-identical to before.
- A pinned provider that cannot be resolved falls back to the Chat slot and logs, rather than throwing — `buildOrchestrator` builds every agent before a run, so throwing there took down runs that did not involve the misconfigured agent.
- Provider selection is not agent-writable: it decides which host a key is sent to, the same exposure that already protects `chatApiUrl`.
- Includes a schema migration (`providers` table, `agents.provider_id`) that seeds from the legacy slots and leaves the old settings rows in place, so a downgrade still finds its credentials.
- Follow-up written up separately in `0-cowork/plans/active/model-pricing-catalogue.md` — pricing any model from OpenRouter's catalogue. Validated as feasible, deferred because the id matching is sharp and it adds an outbound call to a provider the user may not have chosen.
