### PR TITLE
Confirm a delete with Enter in DeleteConfirmModal (U11)

### DIFF
--- a/src/components/molecules/DeleteConfirmModal.test.tsx
+++ b/src/components/molecules/DeleteConfirmModal.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import DeleteConfirmModal from "./DeleteConfirmModal";
+
+describe("DeleteConfirmModal Enter-to-confirm", () => {
+  afterEach(cleanup);
+
+  it("confirms when Enter is pressed and the word matches", () => {
+    const onConfirm = vi.fn();
+    render(<DeleteConfirmModal open itemLabel="Cipher" onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText("DELETE");
+    fireEvent.change(input, { target: { value: "DELETE" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing on Enter while the word does not match", () => {
+    const onConfirm = vi.fn();
+    render(<DeleteConfirmModal open itemLabel="Cipher" onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText("DELETE");
+    fireEvent.change(input, { target: { value: "delete" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys other than Enter", () => {
+    const onConfirm = vi.fn();
+    render(<DeleteConfirmModal open itemLabel="Cipher" onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText("DELETE");
+    fireEvent.change(input, { target: { value: "DELETE" } });
+    fireEvent.keyDown(input, { key: "a" });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("clicking Delete still confirms", () => {
+    const onConfirm = vi.fn();
+    render(<DeleteConfirmModal open itemLabel="Cipher" onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("DELETE"), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/molecules/DeleteConfirmModal.tsx
+++ b/src/components/molecules/DeleteConfirmModal.tsx
@@ -41,6 +41,12 @@ export default function DeleteConfirmModal({ open, itemLabel, onConfirm, onCance
             onChange={(e) => setConfirmText(e.target.value)}
             placeholder={CONFIRM_WORD}
             autoComplete="off"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleConfirm();
+              }
+            }}
           />
         </label>
         <div className="delete-confirm-modal-actions">


### PR DESCRIPTION
## What changed

`src/components/molecules/DeleteConfirmModal.tsx` — added `onKeyDown` to the confirm input; Enter calls the existing `handleConfirm`.

`src/components/molecules/DeleteConfirmModal.test.tsx` — new, 4 tests.

## Root cause

There are no `<form>` elements anywhere in this app (`grep -rn '<form' src` returns nothing), so Enter-to-submit is never free — each component wires it by hand (`TextField.tsx:60`, `AddUrlModal.tsx:89`, `NumberField.tsx`, `McpServersTab.tsx`, `OnboardingScreen.tsx`). `DeleteConfirmModal` was the outlier: the user typed `DELETE`, the Delete button became enabled, and Enter did nothing.

`handleConfirm` already returns early unless `confirmText === "DELETE"`, so the handler needs no guard of its own. `preventDefault()` matches the house pattern in `TextField.tsx`.

## Testing

- `npx eslint src electron` → exit 0
- `npx tsc -b` → exit 0
- `npm run build` → exit 0
- `npm run test` → **1196 passed / 115 files** (baseline on `develop` was 1192 / 114; +4 from the new test file)

Live-validated in the built app (sandboxed `--user-data-dir`): created a custom agent "Testbot" in Settings → Agents, opened its Delete confirm, typed `DELETE`, pressed Enter. The agent was deleted and the modal closed — confirmed by screenshot and by `Testbot` no longer appearing in the agent list.

## Deliberately left out

The other two `DeleteConfirmModal` call sites (`HttpToolsTab.tsx:402`, `McpServersTab.tsx:355`) inherit the fix automatically — they were not exercised live, only the `AgentAccordion` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)