### PR TITLE
Stop agent create, update and delete failing silently (U7, U8, U9)

### DIFF
--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -145,6 +145,7 @@ export default function AgentsApp() {
   const {
     agents,
     rawAgents,
+    error: agentsError,
     updateAgent,
     createAgent,
     refreshAgents,
@@ -179,7 +180,9 @@ export default function AgentsApp() {
   const handleCreateAgent = useCallback(
     async (input: Parameters<typeof createAgent>[0]) => {
       const result = await createAgent(input);
-      playSfx("agentCreated");
+      // Only on a real creation. The sound used to play unconditionally, so a failed create
+      // still chimed as though it had worked.
+      if (result) playSfx("agentCreated");
       return result;
     },
     [createAgent, playSfx]
@@ -187,8 +190,9 @@ export default function AgentsApp() {
 
   const handleDeleteAgent = useCallback(
     async (id: string) => {
-      await deleteAgent(id);
-      playSfx("agentDeleted");
+      const deleted = await deleteAgent(id);
+      // Same reason as handleCreateAgent — a failed delete announced itself as a success.
+      if (deleted) playSfx("agentDeleted");
     },
     [deleteAgent, playSfx]
   );
@@ -810,6 +814,7 @@ export default function AgentsApp() {
         settings={settings}
         sessionElapsedMs={sessionElapsedMs}
         onUpdate={updateSettings}
+        agentsError={agentsError}
         onReset={handleResetSettings}
         agents={rawAgents}
         onUpdateAgent={updateAgent}

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -40,6 +40,9 @@ interface SettingsPanelProps {
    * section. Timed there rather than here so no component reads the clock during render. */
   sessionElapsedMs: number;
   onUpdate: (patch: Partial<AgentsSettings>) => void;
+  /** Surfaced from useAgents. Agent create/update/delete/import failures used to reject into
+   * nothing — this is the one place the user can see that the thing they clicked didn't work. */
+  agentsError?: string | null;
   onReset: () => Promise<void>;
   agents: AgentRow[];
   onUpdateAgent: (
@@ -224,6 +227,7 @@ export default function SettingsPanel({
   settings,
   sessionElapsedMs,
   onUpdate,
+  agentsError,
   onReset,
   agents,
   onUpdateAgent,
@@ -662,6 +666,9 @@ export default function SettingsPanel({
                     </button>
                   </div>
                 </div>
+                {/* Every other data tab renders its hook's error this way (McpServersTab:365).
+                    Agents had no error to render because useAgents never produced one. */}
+                {agentsError && <p className="settings-error">{agentsError}</p>}
                 <div className="agent-accordion-list">
                   <AgentAccordion
                     icon="ti-sparkles"

--- a/src/hooks/useAgents.test.ts
+++ b/src/hooks/useAgents.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useAgents } from "./useAgents";
+
+function row(id: string, overrides: Partial<AgentDisplayRow> = {}): AgentDisplayRow {
+  return {
+    id,
+    name: id,
+    icon: "ti-robot",
+    tagline: "",
+    description: "",
+    prompt: "",
+    model: "gpt-4.1",
+    tools: "[]",
+    enabled: 1,
+    system: 0,
+    created_at: "2026-08-03 00:00:00",
+    mcp_server_ids: "[]",
+    connector_ids: "[]",
+    http_tool_collection_ids: "[]",
+    toolNames: [],
+    connectorToolCount: 0,
+    ...overrides,
+  } as AgentDisplayRow;
+}
+
+function installBridge(agent: Record<string, unknown>) {
+  (window as unknown as { agentsAPI: unknown }).agentsAPI = {
+    agent: {
+      list: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue(row("new")),
+      update: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      exportToFile: vi.fn().mockResolvedValue({ canceled: false }),
+      importFromFile: vi.fn().mockResolvedValue([]),
+      ...agent,
+    },
+  };
+}
+
+const BOOM = new Error("bridge exploded");
+
+describe("useAgents error handling", () => {
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no error", async () => {
+    installBridge({});
+    const { result } = renderHook(() => useAgents());
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  // U8 — the mount fetch had no .catch(), so a rejection was unhandled and the orbit rendered
+  // empty. That is indistinguishable from a genuinely fresh install.
+  it("surfaces a failure of the initial list instead of silently showing no agents", async () => {
+    installBridge({ list: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.agents).toEqual([]);
+  });
+
+  // U7 — the core of it: create and delete rejected into nothing at all.
+  it("surfaces a failed create and resolves undefined", async () => {
+    installBridge({ create: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    let created: unknown = "sentinel";
+    await act(async () => {
+      created = await result.current.createAgent({ name: "Nope" });
+    });
+
+    expect(created).toBeUndefined();
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("surfaces a failed delete and resolves false", async () => {
+    installBridge({ delete: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteAgent("knowledgeAgent");
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("resolves true when the delete actually succeeds", async () => {
+    installBridge({});
+    const { result } = renderHook(() => useAgents());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deleteAgent("knowledgeAgent");
+    });
+
+    expect(ok).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  // U9 — deleteAgent used to splice local state, removing the row on the strength of the call
+  // not throwing. It now refetches, like updateAgent and createAgent already did.
+  it("refetches after a delete rather than splicing local state", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce([row("a"), row("b")])
+      .mockResolvedValue([row("b")]);
+    installBridge({ list });
+    const { result } = renderHook(() => useAgents());
+
+    await waitFor(() => expect(result.current.rawAgents).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.deleteAgent("a");
+    });
+
+    expect(result.current.rawAgents.map((r) => r.id)).toEqual(["b"]);
+    // Once on mount, once after the delete — the splice version never called it a second time.
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces a failed update", async () => {
+    installBridge({ update: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    await act(async () => {
+      await result.current.updateAgent("a", { name: "x" });
+    });
+
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("surfaces a failed import and resolves an empty list", async () => {
+    installBridge({ importFromFile: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    let created: unknown;
+    await act(async () => {
+      created = await result.current.importAgents();
+    });
+
+    expect(created).toEqual([]);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("surfaces a failed export and reports it as canceled", async () => {
+    installBridge({ exportToFile: vi.fn().mockRejectedValue(BOOM) });
+    const { result } = renderHook(() => useAgents());
+
+    let res: { canceled: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.exportAgent("a");
+    });
+
+    expect(res).toEqual({ canceled: true });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("clears a previous error when the next operation succeeds", async () => {
+    const del = vi.fn().mockRejectedValueOnce(BOOM).mockResolvedValue(undefined);
+    installBridge({ delete: del });
+    const { result } = renderHook(() => useAgents());
+
+    await act(async () => {
+      await result.current.deleteAgent("a");
+    });
+    expect(result.current.error).toBeTruthy();
+
+    await act(async () => {
+      await result.current.deleteAgent("a");
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useAgents.ts
+++ b/src/hooks/useAgents.ts
@@ -1,16 +1,30 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { hasAgentsAPI } from "@/lib/agentsApi";
+import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { AgentLayoutItem, computeAgentLayout } from "@/lib/agents";
 
 export function useAgents() {
   const [rawAgents, setRawAgents] = useState<AgentDisplayRow[]>([]);
+  /** Same shape and same formatter as useKnowledgeFiles, useConnectors, useMcpServers and
+   * useHttpTools. This was the one data hook with no error state at all: every operation
+   * rejected into nothing, so a failed create or delete produced no message and no rollback —
+   * the user clicked Delete, the modal closed, and the agent was still there. */
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!hasAgentsAPI()) return;
     let cancelled = false;
-    window.agentsAPI.agent.list().then((rows) => {
-      if (!cancelled) setRawAgents(rows);
-    });
+    window.agentsAPI.agent
+      .list()
+      .then((rows) => {
+        if (!cancelled) setRawAgents(rows);
+      })
+      // Without this the rejection was unhandled and rawAgents stayed [], so the orbit rendered
+      // empty — visually identical to a genuinely fresh install. A backend failure looked like
+      // normal first-run state.
+      .catch((e: unknown) => {
+        if (!cancelled) setError(formatHumanizedError(humanizeError(e)));
+      });
     return () => {
       cancelled = true;
     };
@@ -21,8 +35,13 @@ export function useAgents() {
   // which this hook's local state has no other way of learning about.
   const refreshAgents = useCallback(async () => {
     if (!hasAgentsAPI()) return;
-    const rows = await window.agentsAPI.agent.list();
-    setRawAgents(rows);
+    setError(null);
+    try {
+      const rows = await window.agentsAPI.agent.list();
+      setRawAgents(rows);
+    } catch (e) {
+      setError(formatHumanizedError(humanizeError(e)));
+    }
   }, []);
 
   const updateAgent = useCallback(
@@ -42,17 +61,24 @@ export function useAgents() {
       }
     ) => {
       if (!hasAgentsAPI()) return;
-      await window.agentsAPI.agent.update(id, patch);
-      // Refetch rather than splice the raw AgentRow update() returns in — toolNames/
-      // connectorToolCount are derived server-side (listAgentsForDisplay) and aren't
-      // part of that response, and a patch can change mcp_server_ids/connector_ids
-      // (connectorToolCount's inputs), so a stale merge could show a wrong count.
-      const rows = await window.agentsAPI.agent.list();
-      setRawAgents(rows);
+      setError(null);
+      try {
+        await window.agentsAPI.agent.update(id, patch);
+        // Refetch rather than splice the raw AgentRow update() returns in — toolNames/
+        // connectorToolCount are derived server-side (listAgentsForDisplay) and aren't
+        // part of that response, and a patch can change mcp_server_ids/connector_ids
+        // (connectorToolCount's inputs), so a stale merge could show a wrong count.
+        const rows = await window.agentsAPI.agent.list();
+        setRawAgents(rows);
+      } catch (e) {
+        setError(formatHumanizedError(humanizeError(e)));
+      }
     },
     []
   );
 
+  /** Resolves to the created row, or undefined when it failed — the caller uses that to decide
+   * whether to report success. */
   const createAgent = useCallback(
     async (input: {
       name: string;
@@ -60,41 +86,78 @@ export function useAgents() {
       tagline?: string;
       description?: string;
       model?: string;
-        providerId?: string;
+      providerId?: string;
       prompt?: string;
     }) => {
       if (!hasAgentsAPI()) return;
-      const created = await window.agentsAPI.agent.create(input);
-      // Refetch for the same reason as updateAgent above — created is a raw AgentRow,
-      // missing the derived toolNames/connectorToolCount fields.
-      const rows = await window.agentsAPI.agent.list();
-      setRawAgents(rows);
-      return created;
+      setError(null);
+      try {
+        const created = await window.agentsAPI.agent.create(input);
+        // Refetch for the same reason as updateAgent above — created is a raw AgentRow,
+        // missing the derived toolNames/connectorToolCount fields.
+        const rows = await window.agentsAPI.agent.list();
+        setRawAgents(rows);
+        return created;
+      } catch (e) {
+        setError(formatHumanizedError(humanizeError(e)));
+        return undefined;
+      }
     },
     []
   );
 
-  const deleteAgent = useCallback(async (id: string) => {
-    if (!hasAgentsAPI()) return;
-    await window.agentsAPI.agent.delete(id);
-    setRawAgents((prev) => prev.filter((a) => a.id !== id));
+  /** Resolves true only when the row is actually gone. AgentsApp plays a "deleted" sound on
+   * the result, and that must not fire on a failure. */
+  const deleteAgent = useCallback(async (id: string): Promise<boolean> => {
+    if (!hasAgentsAPI()) return false;
+    setError(null);
+    try {
+      await window.agentsAPI.agent.delete(id);
+      // Refetch rather than filtering locally, matching updateAgent and createAgent. The local
+      // splice removed the row on the strength of the call not throwing; a refetch removes it on
+      // the strength of the list actually saying so.
+      const rows = await window.agentsAPI.agent.list();
+      setRawAgents(rows);
+      return true;
+    } catch (e) {
+      setError(formatHumanizedError(humanizeError(e)));
+      return false;
+    }
   }, []);
 
   const exportAgent = useCallback(async (id: string) => {
     if (!hasAgentsAPI()) return { canceled: true };
-    return window.agentsAPI.agent.exportToFile([id]);
+    setError(null);
+    try {
+      return await window.agentsAPI.agent.exportToFile([id]);
+    } catch (e) {
+      setError(formatHumanizedError(humanizeError(e)));
+      return { canceled: true };
+    }
   }, []);
 
   const exportAllAgents = useCallback(async () => {
     if (!hasAgentsAPI()) return { canceled: true };
-    return window.agentsAPI.agent.exportToFile();
+    setError(null);
+    try {
+      return await window.agentsAPI.agent.exportToFile();
+    } catch (e) {
+      setError(formatHumanizedError(humanizeError(e)));
+      return { canceled: true };
+    }
   }, []);
 
   const importAgents = useCallback(async () => {
     if (!hasAgentsAPI()) return [];
-    const created = await window.agentsAPI.agent.importFromFile();
-    if (created.length > 0) setRawAgents(await window.agentsAPI.agent.list());
-    return created;
+    setError(null);
+    try {
+      const created = await window.agentsAPI.agent.importFromFile();
+      if (created.length > 0) setRawAgents(await window.agentsAPI.agent.list());
+      return created;
+    } catch (e) {
+      setError(formatHumanizedError(humanizeError(e)));
+      return [];
+    }
   }, []);
 
   // The orbit UI only ever shows delegate-able agents — a disabled agent can't be
@@ -110,6 +173,7 @@ export function useAgents() {
   return {
     agents,
     rawAgents,
+    error,
     updateAgent,
     createAgent,
     refreshAgents,


### PR DESCRIPTION
## What changed

`useAgents` gains the error state its four siblings already had, and the failures it used to swallow now reach the user in Settings → Agents.

## Root cause

It was the **only** data hook with no error handling at all — zero `try`/`catch` across eight operations and no `error` in its return. `useKnowledgeFiles`, `useConnectors`, `useMcpServers` and `useHttpTools` all share one pattern (`setError(formatHumanizedError(humanizeError(e)))`); this one never adopted it. The callers didn't compensate either: `AgentsApp` awaited `createAgent`/`deleteAgent` bare. A failed create or delete produced no message, no toast and no rollback — the user clicked Delete, the modal closed, and the agent was still there.

- **U7** — error state in every operation, rendered in the Agents section the way `McpServersTab:365` already renders its own.
- **U8** — the mount fetch had no `.catch()`. The rejection was unhandled and `rawAgents` stayed `[]`, so the orbit rendered empty. That is visually identical to a genuinely fresh install, so a backend failure looked like normal first-run state.
- **U9** — `deleteAgent` spliced local state while its two siblings refetched. It now refetches: the row leaves the list because the list says so, not because the call didn't throw.

## The sounds were lying

`handleCreateAgent` and `handleDeleteAgent` played `"agentCreated"` / `"agentDeleted"` **unconditionally** after awaiting. A failed delete chimed as a success. `createAgent` now resolves `undefined` on failure and `deleteAgent` resolves `false`, and the sfx are gated on that. This wasn't in the original finding — it only showed up once the operations could fail visibly.

## Testing

- Unit/integration: **1206 passed** (baseline 1196 after #46/#55, +10). Predicted before running; matched.
- E2E: not configured
- Manual: driven in the running app against a sandboxed `userData`, using a **real** failure rather than an injected one.

  My first attempt stubbed `window.agentsAPI.agent.delete` to reject — it silently did nothing, because `contextBridge` objects are frozen, so the real delete ran and the test reported a false pass. Worth knowing for any future fault injection in this app.

  The genuine path: delete the row from the DB behind the renderer's back, then click Delete on the now-stale row. `ai/agents.ts:809-811` throws `Unknown agent: <id>`. That is reachable for real — Cipher's own tools can delete an agent mid-session. Result: **"Something went wrong: Unknown agent: ghostagent. Try again, and let us know if it keeps happening."** rendered in red above the agent list. Before this change, nothing appeared at all.

## Notes

- `SettingsPanel` gains an optional `agentsError` prop. It is the only surface that lists agents, so it is where the message belongs.
- Not touched: the stray indentation at the old `providerId?: string;` line came in with #54 and is left alone rather than mixed into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)