### PR TITLE
Make the orbit's orbs keyboard reachable (U14)

### DIFF
--- a/src/components/molecules/AgentOrb.test.tsx
+++ b/src/components/molecules/AgentOrb.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import AgentOrb from "./AgentOrb";
+import { AgentLayoutItem } from "@/lib/agents";
+
+const agent: AgentLayoutItem = {
+  id: "knowledgeAgent",
+  name: "Atlas",
+  icon: "ti-book",
+  tagline: "Know & Reference",
+  description: "Keeps the knowledge base.",
+  prompt: "",
+  model: "gpt-4.1-mini",
+  tools: "[]",
+  enabled: 1,
+  system: 1,
+  created_at: "2026-01-01",
+  mcp_server_ids: "[]",
+  connector_ids: "[]",
+  http_tool_collection_ids: "[]",
+  provider_id: "",
+  toolNames: ["search_knowledge"],
+  connectorToolCount: 0,
+  angle: 0,
+  orbitTime: 0,
+  band: "inner",
+};
+
+function renderOrb() {
+  return render(<AgentOrb agent={agent} status="standby" side="left" orbRef={() => {}} />);
+}
+
+describe("AgentOrb keyboard reachability", () => {
+  afterEach(cleanup);
+
+  it("exposes the orb as a focusable button named after the agent", () => {
+    renderOrb();
+    const orb = screen.getByRole("button", { name: "Atlas details" });
+    expect(orb.getAttribute("tabindex")).toBe("0");
+  });
+
+  it.each(["Enter", " "])("opens the info modal on %s", (key) => {
+    renderOrb();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Atlas details" }), { key });
+    expect(screen.getByRole("dialog", { name: "Atlas" })).toBeTruthy();
+  });
+
+  it("ignores other keys", () => {
+    renderOrb();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Atlas details" }), { key: "a" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("still opens the info modal on click", () => {
+    renderOrb();
+    fireEvent.click(screen.getByRole("button", { name: "Atlas details" }));
+    expect(screen.getByRole("dialog", { name: "Atlas" })).toBeTruthy();
+  });
+
+  it("does not let the status dot's label become the button's name", () => {
+    renderOrb();
+    expect(screen.queryByRole("button", { name: /status/ })).toBeNull();
+  });
+});

--- a/src/components/molecules/AgentOrb.tsx
+++ b/src/components/molecules/AgentOrb.tsx
@@ -38,9 +38,23 @@ export default function AgentOrb({ agent, status, side, orbRef }: AgentOrbProps)
           <motion.div
             className="agent-node-snap"
             style={{ x, y }}
+            role="button"
+            tabIndex={0}
+            // Named explicitly: the only text inside is the status dot's own label, which
+            // would otherwise become this button's name and read as "status" rather than
+            // "opens agent details".
+            aria-label={`${agent.name} details`}
             onClick={(e) => {
               onClick(e);
               setInfoOpen(true);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                // No snap on the keyboard path — useSnapOnClick aims the nudge at the
+                // pointer, and a key event has no coordinates to aim at.
+                setInfoOpen(true);
+              }
             }}
           >
             <TablerIcon name={agent.icon} className="agent-node-icon" />

--- a/src/components/molecules/OrchestratorOrb.test.tsx
+++ b/src/components/molecules/OrchestratorOrb.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, afterEach } from "vitest";
 import { createRef } from "react";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import OrchestratorOrb from "./OrchestratorOrb";
 
 function renderOrb(cognitiveState: string, sessionStats: string) {
@@ -33,5 +33,29 @@ describe("OrchestratorOrb", () => {
     const { container } = renderOrb("orchestrator", "");
     expect(container.querySelector(".ss")).toBeNull();
     expect(container.textContent).not.toContain("0");
+  });
+
+  it("exposes the orb as a focusable button with a stable name", () => {
+    renderOrb("thinking", "3 messages · 12m");
+    const orb = screen.getByRole("button", { name: "Orbit details" });
+    expect(orb.getAttribute("tabindex")).toBe("0");
+  });
+
+  it.each(["Enter", " "])("opens the info modal on %s", (key) => {
+    renderOrb("orchestrator", "");
+    fireEvent.keyDown(screen.getByRole("button", { name: "Orbit details" }), { key });
+    expect(screen.getByRole("dialog", { name: "Orbit" })).toBeTruthy();
+  });
+
+  it("ignores other keys", () => {
+    renderOrb("orchestrator", "");
+    fireEvent.keyDown(screen.getByRole("button", { name: "Orbit details" }), { key: "a" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("still opens the info modal on click", () => {
+    renderOrb("orchestrator", "");
+    fireEvent.click(screen.getByRole("button", { name: "Orbit details" }));
+    expect(screen.getByRole("dialog", { name: "Orbit" })).toBeTruthy();
   });
 });

--- a/src/components/molecules/OrchestratorOrb.tsx
+++ b/src/components/molecules/OrchestratorOrb.tsx
@@ -39,9 +39,22 @@ export default function OrchestratorOrb({
         <motion.div
           className="orchestrator-snap"
           style={{ x, y }}
+          role="button"
+          tabIndex={0}
+          // Named explicitly rather than from its own text: cognitiveState and sessionStats
+          // change on every run, so the derived name would keep shifting under the user.
+          aria-label={`${name} details`}
           onClick={(e) => {
             onClick(e);
             setInfoOpen(true);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              // No snap on the keyboard path — useSnapOnClick aims the nudge at the
+              // pointer, and a key event has no coordinates to aim at.
+              setInfoOpen(true);
+            }
           }}
         >
           <div id="ap" className={speaking ? "speaking" : undefined} />

--- a/src/globals.css
+++ b/src/globals.css
@@ -167,6 +167,18 @@ svg#oc {
   justify-content: center;
   width: 100%;
   height: 100%;
+  /* A square box filling a round orb — a radius keeps the focus outline on the orb's
+     own shape instead of drawing a box around it. */
+  border-radius: 50%;
+}
+
+/* Both orbs sit on a dark nebula inside a transformed scene, where the app-wide ring
+   (1.5px at 0.55 alpha) is not readable. Brighter and further out, still outline-only so
+   the orb's own box-shadow — the status glow and the delegation ripple — survives. */
+.agent-node-snap:focus-visible,
+.orchestrator-snap:focus-visible {
+  outline: 2.5px solid rgba(150, 215, 255, 0.95);
+  outline-offset: 5px;
 }
 
 .agent-node-circle.active {
@@ -388,6 +400,8 @@ svg#oc {
   width: 100%;
   height: 100%;
   cursor: pointer;
+  /* Square box filling the round orchestrator — see .agent-node-snap. */
+  border-radius: 50%;
 }
 
 #orchestrator {


### PR DESCRIPTION
## What changed

- `src/components/molecules/AgentOrb.tsx` — `role="button"`, `tabIndex={0}`, explicit `aria-label`, Enter/Space `onKeyDown` on the snap div.
- `src/components/molecules/OrchestratorOrb.tsx` — same.
- `src/globals.css` — `border-radius: 50%` on `.agent-node-snap` / `.orchestrator-snap`, plus a dedicated `:focus-visible` ring for both.
- `src/components/molecules/AgentOrb.test.tsx` — new, 6 tests.
- `src/components/molecules/OrchestratorOrb.test.tsx` — +5 tests.

## Root cause

Both orbs were a bare `motion.div` carrying `onClick`. Clicking an orb is how a user opens `AgentInfoModal`, so the primary controls on the app's main screen had no keyboard equivalent at all — fixing the modal's own focus handling (U1–U4) did nothing for a user who could not open it. `KnowledgeModal.tsx:149-164` already had the correct pattern; this brings the orbs in line.

Two details worth calling out:

- **The keyboard path deliberately skips `useSnapOnClick`.** The snap animation nudges the orb toward `e.clientX/clientY`; a key event has no coordinates to aim at, and passing a `KeyboardEvent` there would not type-check anyway.
- **Both orbs get an explicit `aria-label` rather than a derived name.** The agent orb's only text is the status dot's `aria-label`, so the button would have been named "Atlas status: standby". The orchestrator's text includes `cognitiveState` and `sessionStats`, which change on every run — a derived name would shift under the user mid-session. A test pins each.

The focus ring needed its own rule: the app-wide `:focus-visible` is 1.5px at 0.55 alpha, which is not readable against the nebula backdrop. The new ring is outline-only, per the existing comment at `globals.css:20-32` — a `box-shadow` glow here would erase the orb's status glow and delegation ripple.

## Testing

- `npx eslint src electron` → exit 0
- `npx tsc -b` → exit 0
- `npm run build` → exit 0
- `npm run test` → **1207 passed / 116 files** (base `develop` was 1196 / 115; +11 from this branch)

Live-validated in the built app (sandboxed `--user-data-dir`), driven over CDP:

- Tab from the top of the document reaches `.orchestrator-snap` on the 16th hop, then `.agent-node-snap` ("Cipher details") on the 17th — both orbs are in the natural tab order.
- **Looked at the render:** the focus ring is a bright pale-blue circle, clearly separate from the orb's own border and clearly readable against the dark backdrop, on both the orchestrator and the small agent orbs. It follows the circle rather than boxing it.
- Enter on the focused Cipher orb opened the info modal; focus moved inside the dialog; Escape closed it and restored focus to the orb. Space opens it too.

## Deliberately left out

`Tooltip` is still hover-only — its doc comment says "non-interactive content only (no focus handling needed)", which is no longer strictly true now that its child is focusable, so a keyboard user gets the modal but not the tool-list tooltip. The modal lists the same tools, so nothing is unreachable. Changing `Tooltip` affects every other call site and is a separate finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)