### PR TITLE
Keep a chat render failure from taking the whole app down (U12)

### DIFF
--- a/src/components/atoms/ErrorBoundary.test.tsx
+++ b/src/components/atoms/ErrorBoundary.test.tsx
@@ -38,4 +38,46 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Custom title")).toBeTruthy();
     consoleSpy.mockRestore();
   });
+
+  // U12 — AgentsApp nests a boundary around ChatPanel inside the one around OrbitScene, because
+  // ChatPanel is rendered as OrbitScene's children. These two pin the behaviour that makes the
+  // nesting worth having: the innermost boundary catches, and its siblings stay mounted.
+  it("contains a throw to the innermost boundary, leaving siblings mounted", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary fallbackTitle="The orbit failed to load">
+        <div>
+          <p>orbit still here</p>
+          <ErrorBoundary fallbackTitle="The chat failed to load">
+            <Bomb />
+          </ErrorBoundary>
+        </div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("The chat failed to load")).toBeTruthy();
+    expect(screen.getByText("orbit still here")).toBeTruthy();
+    // The outer boundary must NOT have tripped — if it had, the sibling would be gone and the
+    // whole scene would have been replaced, which is the behaviour this finding is about.
+    expect(screen.queryByText("The orbit failed to load")).toBeNull();
+    consoleSpy.mockRestore();
+  });
+
+  it("catches at the outer boundary when the throw is outside the inner one", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary fallbackTitle="The orbit failed to load">
+        <div>
+          <Bomb />
+          <ErrorBoundary fallbackTitle="The chat failed to load">
+            <p>chat</p>
+          </ErrorBoundary>
+        </div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("The orbit failed to load")).toBeTruthy();
+    expect(screen.queryByText("chat")).toBeNull();
+    consoleSpy.mockRestore();
+  });
 });

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -7,6 +7,7 @@ import KnowledgeModal from "@/components/organisms/KnowledgeModal";
 import ChatHistoryModal from "@/components/organisms/ChatHistoryModal";
 import HttpToolApprovalModal, { type PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
 import { approvalSettledMessage } from "@/lib/approvalSettledMessage";
+import ErrorBoundary from "@/components/atoms/ErrorBoundary";
 import ToolApprovalCard from "@/components/molecules/ToolApprovalCard";
 import OnboardingScreen, { type OnboardingAnswers } from "@/components/organisms/OnboardingScreen";
 import { findProvider } from "@/lib/providers";
@@ -758,6 +759,12 @@ export default function AgentsApp() {
   return (
     <KnowledgeFilesContext.Provider value={knowledgeFiles}>
     <KnowledgeWidgetAnchorContext.Provider value={knowledgeAnchorRef}>
+      {/* Two boundaries, nested, because ChatPanel is rendered as OrbitScene's children.
+          The inner one means a chat render failure costs the transcript and leaves the orbit,
+          the widgets and Settings usable; the outer one catches the scene itself. Without
+          either, a throw in the primary UI reached the root boundary in main.tsx and took the
+          whole app down — while five secondary Settings tabs each degraded on their own. */}
+      <ErrorBoundary fallbackTitle="The orbit failed to load">
       <OrbitScene
         containerRef={containerRef}
         bgCanvasRef={bgCanvasRef}
@@ -784,6 +791,7 @@ export default function AgentsApp() {
         cognitiveState={cognitiveState}
         sessionStats={sessionStats}
       >
+        <ErrorBoundary fallbackTitle="The chat failed to load">
         <ChatPanel
           messages={messages}
           inputRef={inputRef}
@@ -806,7 +814,9 @@ export default function AgentsApp() {
           onStartVoice={startVoice}
           onStopVoice={stopVoice}
         />
+        </ErrorBoundary>
       </OrbitScene>
+      </ErrorBoundary>
       <SettingsPanel
         open={settingsOpen}
         onClose={closeSettingsPanel}


### PR DESCRIPTION
## What changed

`OrbitScene` and `ChatPanel` each get an error boundary. A render-time throw in the chat now costs the transcript instead of the application.

## Root cause

`ErrorBoundary` was mounted at the root (`main.tsx:10`) and around five *secondary* Settings tabs — MCP servers, Connectors, HTTP tools, Files, About — each with its own `fallbackTitle`. Nothing wrapped the two surfaces a user actually lives in.

The result was backwards relative to risk. The About tab degrades on its own; `ChatPanel` — which renders untrusted model output through a markdown pipeline with custom `code`, `img` and `a` components, by far the largest render-time surface in the app — took everything to the root fallback.

## Design note

The two boundaries are **nested**, because `ChatPanel` is passed as `OrbitScene`'s `children` rather than being a sibling:

```
<ErrorBoundary fallbackTitle="The orbit failed to load">
  <OrbitScene …>
    <ErrorBoundary fallbackTitle="The chat failed to load">
      <ChatPanel … />
```

The inner one is the one that matters: a chat failure leaves the orbit, the widgets and Settings usable. The outer one catches the scene itself. A single boundary around `OrbitScene` would have caught chat throws too — and replaced the whole screen, which is the behaviour being fixed.

No CSS was needed; `.error-boundary` and `.error-boundary-title` already exist.

## Testing

- Unit/integration: **1219 passed** (baseline 1217 at `5879e6c`, +2). Two tests added to the three that already existed, pinning the containment: the innermost boundary catches and its siblings stay mounted, and a throw *outside* the inner boundary still reaches the outer one. Without the second test, a change that accidentally flattened the nesting would still pass.
- E2E: not configured
- Manual: **not app-validated.** Triggering a genuine render-time throw in `ChatPanel` needs malformed model output or a deliberate code change, and simulating one would only re-test what the unit tests already cover directly. Flagging rather than claiming it.

## Notes

I predicted 1208 and got 1219 — my baseline was stale, not the suite. `develop` moved from `cf8dedd` (1206) to `5879e6c` (1217) when U14 merged mid-branch. Third time a pre-merge count has misled me today; the tip is the only baseline worth quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)