### PR TITLE
Give the click-to-open chat image a keyboard path (U15)

### DIFF
--- a/src/components/atoms/ChatImage.test.tsx
+++ b/src/components/atoms/ChatImage.test.tsx
@@ -79,6 +79,40 @@ describe("ChatImage", () => {
     expect(open).not.toHaveBeenCalled();
   });
 
+  it("opens the image externally from the keyboard", () => {
+    // The point of the wrapping button: an <img onClick> had no keyboard path at all.
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const { getByRole } = render(<ChatImage src="https://example.com/a.png" alt="a chart" autoLoadRemote />);
+    // A real button, so Enter and Space are the browser's job — clicking it is what a key
+    // press produces, and that is what this asserts is wired.
+    const button = getByRole("button", { name: "Open image in browser: a chart" });
+    button.focus();
+    expect(document.activeElement).toBe(button);
+    fireEvent.click(button);
+    expect(open).toHaveBeenCalledWith("https://example.com/a.png");
+  });
+
+  it("names the open control without alt text when the author gave none", () => {
+    const { getByRole } = render(<ChatImage src="https://example.com/a.png" autoLoadRemote />);
+    expect(getByRole("button", { name: "Open image in browser" })).not.toBeNull();
+  });
+
+  it("keeps the img an img rather than giving it a button role", () => {
+    const { container } = render(<ChatImage src="https://example.com/a.png" alt="a chart" autoLoadRemote />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img.getAttribute("role")).toBeNull();
+    expect(img.getAttribute("tabindex")).toBeNull();
+    expect(img.parentElement?.tagName).toBe("BUTTON");
+  });
+
+  it("wraps no button around an image that cannot be opened", () => {
+    // A data: URI is never handed to the OS, so there is no action to expose as a control.
+    const { container, queryByRole } = render(<ChatImage src="data:image/png;base64,iVBORw0KGgo=" />);
+    expect(queryByRole("button")).toBeNull();
+    expect(container.querySelector("img")?.parentElement?.tagName).not.toBe("BUTTON");
+  });
+
   it("omits alt entirely when the author gave none", () => {
     // Better for a screen reader to skip a decorative image than to read out a CDN path.
     const { container } = render(<ChatImage src="https://example.com/a.png" autoLoadRemote />);

--- a/src/components/atoms/ChatImage.tsx
+++ b/src/components/atoms/ChatImage.tsx
@@ -102,10 +102,10 @@ export default function ChatImage({ src, alt, title, autoLoadRemote = false }: C
     // An image inside a link would otherwise fire the anchor's handler too, opening twice.
     e.preventDefault();
     e.stopPropagation();
-    if (openable) window.open(src);
+    window.open(src);
   };
 
-  return (
+  const image = (
     <img
       className={openable ? "chat-image chat-image--openable" : "chat-image"}
       src={src}
@@ -113,8 +113,23 @@ export default function ChatImage({ src, alt, title, autoLoadRemote = false }: C
       // long CDN path is worse than skipping a decorative image.
       alt={alt ?? ""}
       title={title}
-      onClick={open}
       onError={() => setFailedSrc(src)}
     />
+  );
+
+  if (!openable) return image;
+
+  // A real button rather than ARIA on the <img>: the image stays an image, and the
+  // open-externally action becomes a control the keyboard can reach. The button carries the
+  // whole accessible name because the img's alt is empty whenever the author gave none.
+  return (
+    <button
+      type="button"
+      className="chat-image-open"
+      onClick={open}
+      aria-label={alt ? `Open image in browser: ${alt}` : "Open image in browser"}
+    >
+      {image}
+    </button>
   );
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -1045,6 +1045,17 @@ svg#oc {
   cursor: pointer;
 }
 
+/* The button that wraps an openable image. Contributes no box of its own — the image keeps
+   its own margin, radius and border, and the focus ring is the only thing the button draws. */
+.chat-image-open {
+  display: block;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  border-radius: 10px;
+}
+
 /* Shown instead of an <img> for a scheme we won't render (file:, non-image data:) or after a
    load failure — a blank gap would read as a rendering bug rather than a missing image. */
 .chat-image-fallback {


### PR DESCRIPTION
## What changed

- `src/components/atoms/ChatImage.tsx` — an openable image is wrapped in a real `<button>`; the `<img>` no longer carries `onClick`.
- `src/globals.css` — `.chat-image-open`, a box-less wrapper so the image keeps its own margin/radius/border and the button draws only the focus ring.
- `src/components/atoms/ChatImage.test.tsx` — +4 tests.

## Root cause

`<img onClick={open}>` with no `role`, no `tabIndex` and no key handler — the open-externally affordance was mouse-only. Wrapping in a `<button>` (rather than adding ARIA to the `<img>`) keeps the image an image and makes the action a control, so focus, Enter and Space come from the platform instead of being reimplemented.

Two things fell out of it:

- **The `openable` guard is now structural.** `open` used to be `if (openable) window.open(src)` on an `<img>` that was always clickable; now only an openable image gets a button at all, so a `data:` URI has no control to activate. The existing test that asserts a `data:` URI is never handed to `shell.openExternal` still passes unchanged.
- **The button carries the whole accessible name** (`"Open image in browser: <alt>"`, or just `"Open image in browser"`). It cannot be derived from the image: `alt` is deliberately empty when the author gave none, which would leave the control unlabelled.

`alt` handling at `:112-114` is untouched, as is the remote-image consent gate.

## Testing

- `npx eslint src electron` → exit 0
- `npx tsc -b` → exit 0
- `npm run build` → exit 0
- `npm run test` → **1221 passed / 117 files**. Baseline re-measured on this branch's `develop` (`git stash -u && npm test`) = **1217 / 117**; +4 from this branch. All 16 pre-existing `ChatImage` tests pass unmodified, including the two that click the `<img>` directly.

Live-validated in the built app (sandboxed `--user-data-dir`), driven over CDP. Seeded a conversation containing `![the Google logo](https://…/googlelogo…png)`, opened it via `/chat-history`, clicked through the remote-image consent gate:

- DOM is `button.chat-image-open[aria-label="Open image in browser: the Google logo"] > img.chat-image` — `img` has no `role` and no `tabindex`, `alt` is intact, `naturalWidth` 272 so the image really loaded.
- Tab reaches the button; **looked at the render** — the focus ring is a pale-blue rounded rect hugging the image, clearly visible.
- Enter fired `window.open` with exactly the image URL.

## Not verified

**Space activation could not be confirmed live.** A CDP-synthesized Space does not activate any native button in this app — I checked with a positive control (a plain `<button>` appended to the page: 0 clicks from the same key press), so this is a driver limitation, not a defect. Space on a real `<button>` is platform behaviour and needs no code here.

## Known limitation, deliberately not addressed

Markdown of the form `[![alt](img)](url)` renders `<a><button><img></button></a>` — an interactive element nested in another, which is invalid HTML. It is not a regression: the pre-existing `preventDefault`/`stopPropagation` in `open` exists precisely because that shape occurs, and it still prevents the double-open. Fixing it properly means telling `ChatImage` whether an ancestor anchor exists, which needs a context from `ChatBubble` — more surface than this finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)