### PR TITLE
Name args when testTool is given the wrong key (U20)

### DIFF
--- a/electron/main/ipc/httpTools.test.ts
+++ b/electron/main/ipc/httpTools.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn() },
+}));
+
+// The store reaches the real database and none of it is what these tests are about — only
+// the handler's own argument validation is.
+vi.mock("../db/httpToolsStore", () => ({
+  createHttpTool: vi.fn(),
+  createHttpToolCollection: vi.fn(),
+  deleteHttpTool: vi.fn(),
+  deleteHttpToolCollection: vi.fn(),
+  getDecryptedCollectionHeaders: vi.fn(),
+  getDecryptedToolHeaders: vi.fn(),
+  listHttpToolCollections: vi.fn(),
+  listHttpTools: vi.fn(),
+  updateHttpTool: vi.fn(),
+  updateHttpToolCollection: vi.fn(),
+  HTTP_METHODS: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+}));
+
+const buildHttpRequestMock = vi.hoisted(() => vi.fn());
+vi.mock("../ai/httpToolRequest", () => ({ buildHttpRequest: buildHttpRequestMock }));
+vi.mock("../net/urlSafety", () => ({ assertPublicHttpUrl: vi.fn() }));
+
+import { ipcMain } from "electron";
+import { registerHttpToolHandlers } from "./httpTools";
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+function handlerFor(channel: string): Handler {
+  registerHttpToolHandlers();
+  const call = vi.mocked(ipcMain.handle).mock.calls.find((c) => c[0] === channel);
+  if (!call) throw new Error(`${channel} was never registered`);
+  return call[1] as Handler;
+}
+
+function testTool(input: unknown): Promise<unknown> {
+  return handlerFor("httpTools:testTool")(null, input) as Promise<unknown>;
+}
+
+const VALID = {
+  baseUrl: "https://api.example.com",
+  path: "/things/{id}",
+  method: "GET",
+  params: [{ name: "id", description: "the id", type: "string", location: "path", required: true }],
+  args: { id: "1" },
+};
+
+describe("httpTools:testTool argument names", () => {
+  beforeEach(() => {
+    vi.mocked(ipcMain.handle).mockClear();
+    buildHttpRequestMock.mockReset();
+    buildHttpRequestMock.mockReturnValue({
+      url: "https://api.example.com/things/1",
+      method: "GET",
+      headers: {},
+      body: undefined,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, statusText: "OK", text: async () => "{}" }))
+    );
+  });
+
+  it("names args when the sample values arrive under the wrong key", async () => {
+    // The whole finding: this used to reach buildHttpRequest with no args at all and fail
+    // with `Missing required parameter "id"`, blaming the param definition.
+    const { args, ...rest } = VALID;
+    void args;
+    await expect(testTool({ ...rest, values: { id: "1" } })).rejects.toThrow(
+      /does not accept "values".*accepted keys are .*\bargs\b/s
+    );
+    expect(buildHttpRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("names every unrecognised key, not just the first", async () => {
+    await expect(testTool({ ...VALID, values: {}, timeout: 5 })).rejects.toThrow(
+      /does not accept "values", "timeout"/
+    );
+  });
+
+  it("accepts every documented key", async () => {
+    await testTool({
+      ...VALID,
+      headers: { authorization: "Bearer x" },
+      bodyTemplate: "",
+      allowPrivateHosts: false,
+    });
+    expect(buildHttpRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still accepts an input carrying only the required key", async () => {
+    await testTool({ baseUrl: "https://api.example.com" });
+    expect(buildHttpRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a non-object input before looking at its keys", async () => {
+    await expect(testTool("https://api.example.com")).rejects.toThrow(
+      "httpTools:testTool requires a plain object input"
+    );
+  });
+
+  it("still reports a missing baseUrl as a missing baseUrl", async () => {
+    await expect(testTool({ path: "/things" })).rejects.toThrow(
+      "httpTools:testTool requires a non-empty baseUrl"
+    );
+  });
+});

--- a/electron/main/ipc/httpTools.ts
+++ b/electron/main/ipc/httpTools.ts
@@ -90,6 +90,30 @@ function assertParamsShape(value: unknown, prefix: string): asserts value is Htt
   }
 }
 
+// A misspelled key is otherwise indistinguishable from an omitted one, and the omission is
+// what gets reported: passing `values` instead of `args` surfaced as `Missing required
+// parameter "id"`, which reads as a bad param definition rather than a wrong key name.
+// Naming the accepted set puts the real key in front of the caller.
+function assertNoUnknownKeys(value: Record<string, unknown>, allowed: readonly string[], prefix: string): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (unknown.length > 0) {
+    throw new Error(
+      `${prefix} does not accept ${unknown.map((key) => `"${key}"`).join(", ")} — accepted keys are ${allowed.join(", ")}`
+    );
+  }
+}
+
+const TEST_TOOL_KEYS = [
+  "baseUrl",
+  "path",
+  "method",
+  "params",
+  "args",
+  "headers",
+  "bodyTemplate",
+  "allowPrivateHosts",
+] as const;
+
 export function registerHttpToolHandlers() {
   ipcMain.handle("httpTools:listCollections", () => listHttpToolCollections());
 
@@ -179,6 +203,7 @@ export function registerHttpToolHandlers() {
       }
     ): Promise<{ ok: boolean; status?: number; statusText?: string; body?: string; error?: string }> => {
       assertPlainObject(input, "httpTools:testTool requires a plain object input");
+      assertNoUnknownKeys(input, TEST_TOOL_KEYS, "httpTools:testTool");
       assertNonEmptyString(input.baseUrl, "httpTools:testTool requires a non-empty baseUrl");
       if (input.method !== undefined) assertMethod(input.method, "httpTools:testTool");
       if (input.headers !== undefined) assertHeadersShape(input.headers, "httpTools:testTool");


### PR DESCRIPTION
## What changed

- `electron/main/ipc/httpTools.ts` — `assertNoUnknownKeys` plus a `TEST_TOOL_KEYS` list, applied to `httpTools:testTool` right after the plain-object check.
- `electron/main/ipc/httpTools.test.ts` — new, 6 tests. There was no test file for this module before.

## Root cause

`httpTools:testTool` reads `input.args`. A misspelled or wrong key is indistinguishable from an omitted one, so `values` produced an input with no sample values at all, which failed downstream in `buildHttpRequest`:

```
Missing required parameter "id".
```

That blames the parameter definition for what is a wrong key name. Every neighbouring validator in the file is specific (`requires a non-empty baseUrl`, `param "id" description must be a string`) — this path was the outlier.

Now:

```
httpTools:testTool does not accept "values" — accepted keys are baseUrl, path, method, params, args, headers, bodyTemplate, allowPrivateHosts
```

Rejecting the unknown key rather than only naming `args` also catches the general case, and it runs before the shape checks so a typo is reported as a typo instead of surviving into the request build.

The only caller, `HttpToolsTab.tsx:157`, sends exactly these eight keys, matching `HttpToolTestInput` (`src/vite-env.d.ts:265-274`) and the preload signature — so nothing legitimate is newly rejected.

## Testing

- `npx eslint src electron` → exit 0
- `npx tsc -b` → exit 0
- `npm run build` → exit 0
- `npm run test` → **1229 passed / 118 files**. Baseline re-measured on this branch's `develop` (`git stash -u && npm test`) = **1223 / 118**; +6 from this branch.

**Negative control on the new tests:** with the `assertNoUnknownKeys` call commented out, the 2 tests covering new behaviour fail and the 4 regression guards still pass — the tests are actually testing the fix.

**Confirmed the old message is real**, by calling the real `buildHttpRequest` with an empty `args`: it throws exactly `Missing required parameter "id".`

Live-validated against the running app (sandboxed `--user-data-dir`), calling the IPC through the preload bridge from the renderer:

| input | result |
|---|---|
| `{…, values: {id}}` | `httpTools:testTool does not accept "values" — accepted keys are baseUrl, path, method, params, args, headers, bodyTemplate, allowPrivateHosts` |
| `{…, values, timeout}` | `… does not accept "values", "timeout" — …` |
| `{…, args: {id}}` | request went out, HTTP 200-path reached (GitHub answered 404 for my deliberately short sample path) — **no regression on the happy path** |
| `{path}` only | `httpTools:testTool requires a non-empty baseUrl` — unchanged |

## Deliberately left out

Only `testTool` gets the unknown-key check. The other handlers in this file take domain objects that go on to be persisted, where a strict key list would need to track the store's schema; `testTool` takes a transient form payload with a fixed, local shape, which is what makes the list safe to pin here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)