### PR TITLE
Say so when the onboarding answers didn't save (U13)

### DIFF
--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -8,6 +8,11 @@ import ChatHistoryModal from "@/components/organisms/ChatHistoryModal";
 import HttpToolApprovalModal, { type PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
 import { approvalSettledMessage } from "@/lib/approvalSettledMessage";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
+
+/** How long the entrance animation runs before the greeting lands. Named because the
+ * onboarding-failure notice below has to queue behind it — a warning that arrives before
+ * "Hi, I'm Orbit" reads as though something broke on launch. */
+const GREETING_DELAY_MS = 1400;
 import ToolApprovalCard from "@/components/molecules/ToolApprovalCard";
 import OnboardingScreen, { type OnboardingAnswers } from "@/components/organisms/OnboardingScreen";
 import { findProvider } from "@/lib/providers";
@@ -583,6 +588,9 @@ export default function AgentsApp() {
   // here. Queued rather than kept as a single value: one turn can interrupt on several
   // tool calls, and the SDK hands them over one at a time — dropping any would strand the
   // run until its 5-minute approval timeout declined it.
+  /** Set when the onboarding answers failed to persist, so the notice can be queued behind the
+   * greeting rather than racing it. */
+  const [onboardingFactsFailed, setOnboardingFactsFailed] = useState(false);
   const [approvalQueue, setApprovalQueue] = useState<PendingToolApproval[]>([]);
   useEffect(() => {
     if (!hasAgentsAPI()) return;
@@ -714,6 +722,12 @@ export default function AgentsApp() {
         if (facts.length > 0) {
           void window.agentsAPI.userInfo.seedFacts(facts).catch((error: unknown) => {
             window.agentsAPI.dev.log("[onboarding] seedFacts failed", error);
+            // The user typed these answers a moment ago. Losing them silently is the worst
+            // outcome: nothing on screen changes, so there is no reason to suspect anything and
+            // no reason to visit the one screen where they could be re-entered. Unlike the
+            // selectChat failure above — which announces itself the first time a message is
+            // sent — a missing fact never surfaces on its own.
+            setOnboardingFactsFailed(true);
           });
         }
       }
@@ -730,11 +744,27 @@ export default function AgentsApp() {
     const timer = setTimeout(() => {
       appendMessage({ role: "assistant", text: greeting, avatarLabel: settings.agentName[0]?.toUpperCase() || "A" });
       speak(greeting);
-    }, 1400);
+    }, GREETING_DELAY_MS);
     return () => clearTimeout(timer);
     // Fires once when onboarding hands off into the main UI.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entering]);
+
+  // Queued behind the greeting rather than appended from the catch directly: the rejection
+  // usually lands within milliseconds, which would put "I couldn't save your details" above
+  // "Hi, I'm Orbit". Cleared as it fires so a later re-render cannot repeat it.
+  useEffect(() => {
+    if (!onboardingFactsFailed) return;
+    const timer = setTimeout(() => {
+      appendMessage({
+        role: "assistant",
+        text: "I couldn't save the details you just gave me, so I don't have them yet. You can add them again in Settings → General → About you.",
+        avatarLabel: settings.agentName[0]?.toUpperCase() || "A",
+      });
+      setOnboardingFactsFailed(false);
+    }, GREETING_DELAY_MS + 600);
+    return () => clearTimeout(timer);
+  }, [onboardingFactsFailed, appendMessage, settings.agentName]);
 
   if (!loaded) return null;
 

--- a/src/lib/userContext.test.ts
+++ b/src/lib/userContext.test.ts
@@ -15,6 +15,18 @@ describe("USER_CONTEXT_FIELDS", () => {
     ]);
   });
 
+  // U13 — main drops a seeded fact silently when either side is blank (isValidFact in
+  // ipc/userInfo.ts:21-23) rather than throwing, deliberately, so a bad fact can't fail
+  // onboarding. That makes a non-empty factQuestion the thing standing between a real answer
+  // and a silent disappearance: the renderer already filters blank *answers* before sending
+  // (AgentsApp's onboarding handler), so a blank *question* here would be the only way a
+  // genuine answer could vanish with no error and no catch to report it.
+  it("never ships a blank factQuestion, which main would silently drop", () => {
+    for (const field of USER_CONTEXT_FIELDS) {
+      expect(field.factQuestion.trim().length, `field "${field.key}"`).toBeGreaterThan(0);
+    }
+  });
+
   it("gives every field a unique key and a label", () => {
     const keys = USER_CONTEXT_FIELDS.map((field) => field.key);
     expect(new Set(keys).size).toBe(keys.length);


### PR DESCRIPTION
## What changed

If the answers a user gives during onboarding fail to persist, the app now says so instead of carrying on as though nothing happened.

## Root cause

`userInfo.seedFacts` was fire-and-forget and its rejection only reached `devLog`. Onboarding completed, `setMessages([])` / `setEntering(true)` ran regardless, the app opened — and the answers were gone. Nothing on screen changed, so there was no reason to suspect anything, and no reason to visit Settings → General → About you, the one place they could be re-entered.

The `selectChat` failure directly above it is left as it is, deliberately: a missing provider announces itself the first time a message is sent. A missing fact never surfaces on its own.

## Why the notice is delayed

It's queued behind the greeting rather than appended from the `catch`. The rejection usually lands within milliseconds, which would put *"I couldn't save your details"* above *"Hi, I'm Orbit"* and read as though something broke on launch. The greeting's 1400 ms delay is now `GREETING_DELAY_MS` so the dependency between the two is visible rather than two unrelated magic numbers. The flag clears as the notice fires, so a re-render can't repeat it.

## Scope, honestly

This `catch` can realistically only fire on an IPC transport failure or a disk error inside `upsertUserInfoFact`. `ipc/userInfo.ts:29-39` **never throws on its input** — malformed facts are skipped with `continue`, deliberately, so that a bad fact cannot fail onboarding. Rare, but silent data loss is exactly where a rare failure hurts most.

That is also why the failure branch **cannot be app-validated from outside**: `contextBridge` objects are frozen so `seedFacts` can't be stubbed from the page (learned the hard way in #56, where a stub silently didn't apply and produced a false pass), and no input makes the handler reject.

## Testing

- Unit/integration: **1230 passed** (baseline 1229 at `ce59452`, +1). Predicted; matched.

  The test pins the invariant that actually protects a real answer from vanishing with no error *and no catch*: every `factQuestion` must be non-empty. The renderer already filters blank *answers*, so a blank *question* is the one remaining way `isValidFact` would silently drop a genuine answer — a case this PR's `catch` would never see, because nothing rejects.
- E2E: not configured
- Manual: onboarding driven to completion in a fresh sandbox. Onboarding cleared, greeting still lands (*"Hi Ada, I'm Orbit."*), **no** notice on the happy path, and all four facts persisted — verified through `userInfo.list()`.

## Notes

Not fixed here: the `selectChat` catch above, for the reason given. Its comment already documents the choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)