### PR TITLE
Drop the unused `node` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "framer-motion": "^12.42.2",
         "jszip": "^3.10.1",
         "mammoth": "^1.12.0",
-        "node": "^26.5.0",
         "node-pptx-parser": "^1.0.1",
         "node-xlrd": "^0.3.10",
         "open-websearch": "^2.1.11",
@@ -9263,22 +9262,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node": {
-      "version": "26.5.1",
-      "resolved": "https://registry.npmjs.org/node/-/node-26.5.1.tgz",
-      "integrity": "sha512-jMR0E6e5HtjOdc3oj0e2MSC6Z5/yAf849Mykpkt1UAnThDg61AnztpXdsrXILd8Dz3gHDHaxqsMFNJs/lhiRyQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
     "node_modules/node-abi": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
@@ -9336,12 +9319,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/node-bin-setup": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.4.tgz",
-      "integrity": "sha512-vWNHOne0ZUavArqPP5LJta50+S8R261Fr5SvGul37HbEDcowvLjwdvd0ZeSr0r2lTSrPxl6okq9QUw8BFGiAxA==",
-      "license": "ISC"
     },
     "node_modules/node-gyp": {
       "version": "12.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "framer-motion": "^12.42.2",
     "jszip": "^3.10.1",
     "mammoth": "^1.12.0",
-    "node": "^26.5.0",
     "node-pptx-parser": "^1.0.1",
     "node-xlrd": "^0.3.10",
     "open-websearch": "^2.1.11",


### PR DESCRIPTION
`"node": "^26.5.0"` was listed under `dependencies`. Nothing imports it — the only occurrence of the string anywhere in `src/`, `electron/`, `scripts/` or the build configs was the declaration itself.

## It was not inert

The package declares `bin: { "node": "bin/node" }`, so npm linked it:

```
node_modules/.bin/node -> ../node/bin/node
$ node_modules/.bin/node --version
v26.5.1                       # system node is v26.5.0
```

npm puts `node_modules/.bin` first on PATH when running scripts, so every `npm test`, `npm run build` and `npm run dev` executed under **26.5.1 from a dependency**, not the system Node. At a patch's distance that changed nothing observable — but the runtime version for every script was being pinned by a package nobody knew was installed, and it would have kept drifting as the caret range resolved forward.

## What it cost

- **139 MB packed into every platform installer.** electron-builder bundles all production dependencies. On macOS this is worse than bloat: an unsigned nested Mach-O binary fails notarization outright, so it would have blocked signing later.
- **An unvetted install script.** `npm ci` warned about 7 packages with install scripts outside `allowScripts`; it now warns about 6.
- **Disk:** `node_modules` 1.0G → 841M.

## Diff

Removal only, no replacement. The lockfile change is exactly `node` and its sole dependency `node-bin-setup` — 23 lines, no incidental churn.

## Verification

eslint **0** · `tsc -b` **0** · `npm run build` **0** · **1230/1230 tests, 118 files** — unchanged from the `70e62a4` baseline, which is what you would expect from removing something nothing referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)