### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# Runs the same four gates the project requires locally (CLAUDE.md -> Verify Gate):
+# eslint, tsc -b, tests, build — in that order, so a type error fails in seconds
+# rather than after a full test run.
+#
+# One job rather than four chained with `needs:`, because each job would re-run
+# `npm ci` from scratch — including the ~100 MB Electron binary download, which
+# setup-node's `cache: 'npm'` does not cover (that caches ~/.npm; Electron caches
+# to ~/.cache/electron). The stages are strictly sequential either way, so one job
+# gives identical fail-fast behaviour at roughly a third of the wall time.
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # Not covered by setup-node's npm cache, and `npm ci` downloads it every run.
+      # The test suite needs the binary present: electron/main/ai/agents.test.ts fails
+      # with "Electron failed to install correctly" without it, hiding ~48 tests.
+      - name: Cache Electron binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc -b
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenOrbit
 
+[![CI](https://github.com/maneja81/OpenOrbit/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/maneja81/OpenOrbit/actions/workflows/ci.yml)
+
 <img src="public/openorbit-logo.svg" alt="OpenOrbit logo" width="120" height="120">
 
 A desktop app that runs a team of AI agents on your own machine — a central orchestrator


### PR DESCRIPTION
Phase 1 of `0-cowork/plans/active/gitbub-ci.md`. Adds one workflow that runs the four gates this project already requires locally (`CLAUDE.md` → *Verify Gate*) on every push to `develop` and every PR targeting `develop` or `main`.

```
eslint  →  tsc -b  →  tests  →  build
```

Typecheck sits ahead of the suite so a type error fails in seconds rather than after a full test run.

## Design notes

**One job, not four chained with `needs:`.** Four jobs would each re-run `npm ci` from scratch, including the ~100 MB Electron binary download — which `setup-node`'s `cache: 'npm'` does *not* cover, since that caches `~/.npm` while Electron caches to `~/.cache/electron`. The stages are strictly sequential either way, so one job gives identical fail-fast behaviour at roughly a third of the wall time. A separate `actions/cache` step covers the Electron download.

**Node 22, not the 20 the plan originally specified.** Node 20 reached EOL in April 2026, and local development runs 26.5.0. Pinning CI to a Node nobody runs means it can go red on something that cannot happen locally, and stay green on something that can.

**No `xvfb`.** `npm run build` is `tsc -b` plus three Vite/Rollup bundles and spawns no Electron process, so there is no display to provide. `sudo apt-get install` without a preceding `apt-get update` is also a routine 404 on GitHub runners, and `ubuntu-latest` ships xvfb regardless.

**`permissions: contents: read`** and a `concurrency` group with `cancel-in-progress`, so superseded runs on force-push don't pile up. `push` fires only on `develop`, so a feature-branch PR produces one run, not two.

## Baseline

**1230 tests across 118 files**, measured locally on `e779a5c` — the tip this branches from. That is the number the first CI run has to reproduce.

If Linux reports around **1182**, that is not a Linux incompatibility: it is the Electron binary failing to install. `electron/main/ai/agents.test.ts` needs the binary present and accounts for exactly that 48-test gap. It has happened four times locally in this repo. The repair is in `CLAUDE.md`; the one thing never to do is "fix" it with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`, which causes it.

## Verification

Locally on this branch: eslint **0** · `tsc -b` **0** · `npm run build` **0** · **1230/1230, 118 files**. Workflow YAML parsed and structurally checked.

This PR targets `develop`, so opening it triggers the workflow itself — the run on this PR is the real test, and the badge added to the README goes live once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)