### PR TITLE
Add electron-builder packaging config

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,52 @@
     "build:web": "tsc -b && vite build",
     "preview": "electron-vite preview",
     "package": "npm run build && electron-builder",
+    "package:ci": "npm run build && electron-builder --publish never",
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest"
+  },
+  "build": {
+    "appId": "com.mohitaneja.openorbit",
+    "productName": "OpenOrbit",
+    "directories": {
+      "output": "dist",
+      "buildResources": "build"
+    },
+    "files": [
+      "dist-electron/**",
+      "package.json"
+    ],
+    "asarUnpack": [
+      "**/*.node"
+    ],
+    "mac": {
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["x64", "arm64"]
+        }
+      ],
+      "category": "public.app-category.productivity",
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        }
+      ]
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        }
+      ],
+      "category": "Utility"
+    }
   },
   "dependencies": {
     "@openai/agents": "^0.13.5",


### PR DESCRIPTION
Phase 2 of `0-cowork/plans/active/gitbub-ci.md`. There was **no electron-builder config at all** — only a `build` *script*. Running `electron-builder` today would have used every default: appId `com.electron.openorbit`, no icons, and `files: ["**/*"]`.

## The default that mattered

`files: ["**/*"]` packs the entire project directory. In the main checkout that means **`.env` and `.env.bak`** — live OpenRouter/OpenAI keys and a Google OAuth client secret — inside `app.asar` in a publicly downloadable installer, plus `.claude/worktrees/` (three full checkouts of this repo, each with its own `node_modules`) and `0-cowork/`.

CI checkouts wouldn't have those files, but the plan's own guidance is to run `npm run package` locally first — which is precisely the run that would have done it. The explicit allowlist closes all three at once.

## Config decisions

| Setting | Why |
|---|---|
| `files: ["dist-electron/**", "package.json"]` | `main` is `dist-electron/main/index.js`; preload, renderer and the separately-bundled `xlsWorker` entry all live there. Production `node_modules` are resolved independently of this list. |
| `asarUnpack: ["**/*.node"]` | Native code cannot be `dlopen`'d from inside an asar. Smart-unpack usually catches it; stating it removes the doubt. |
| `mac.arch: ["x64", "arm64"]` | Two separate dmgs, **not** a universal binary. Deliberate: a universal build merges two app bundles and is exactly the case that gets fragile around differing native `.node` files. |
| `mac.artifactName` | electron-builder omits the arch for x64, so the pair came out `OpenOrbit-0.1.0-arm64.dmg` and `OpenOrbit-0.1.0.dmg`. Which one is x64 isn't something a user should have to infer. |
| `package:ci` → `--publish never` | electron-builder auto-publishes on a detected CI tag (`app-builder-lib/out/publish/PublishManager.js:52-56`). Without this it would race the release workflow's own publish step across four jobs. |

## Verified by packaging, not by reading

**Asar contents** — top level is exactly:
```
/node_modules
/dist-electron
/package.json
```
No `.env`, no `0-cowork`, no `.claude`, no `src/`, no `public/`. 15,713 entries, all accounted for.

**The packaged app actually runs.** Launched `dist/mac-arm64/OpenOrbit.app` against a sandboxed `--user-data-dir`:
```
15 tables created · 37 migrations applied · 4 agents seeded · WAL sidecars present
```
That is the `asarUnpack` proof — `better-sqlite3` loaded its binding from `app.asar.unpacked`. **No unit test covers this**; a packaging mistake here is invisible until launch.

**The real user data was untouched.** `~/Library/Application Support/OpenOrbit/database/agents.db` sha256 identical before and after, 30 entries both times, nothing modified. `getLegacyAppRoots()` only walks siblings of the *current* root, so a scratchpad `--user-data-dir` cannot reach it.

**Artifacts:** `dist/*.dmg` matches exactly two files, both arch-labelled, 190 MB and 192 MB.

Gates: eslint **0** · `tsc -b` **0** · `npm run build` **0** · **1230/1230 tests, 118 files**.

## Follow-ups, not fixed here

- **All eight `better-sqlite3` prebuilds ship in every platform's app** (`win32-x64`, `linux-arm64`, `linuxmusl-*`, …) — roughly 20 MB of binaries for platforms the artifact cannot run on. Same for `koffi`. Trimming needs per-platform `files` exclusions with `${platform}`/`${arch}` macros, which is fiddly enough to be worth its own change rather than risking the native load path in this one.
- **`jsdom` is a production dependency**, pulled in by `open-websearch@2.1.11`. Not a devDependency leak — checked — but it is ~540 files of DOM emulation inside a desktop app.
- **No `entitlements`**. The app spawns child processes (`xlsWorker`, `MCPServerStdio`, Playwright). Once hardened runtime and notarization are enabled, those need explicit entitlements or they fail at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)