### PR TITLE
Resolve a blank agent model against that agent's own provider

### DIFF
--- a/electron/main/ai/agents.test.ts
+++ b/electron/main/ai/agents.test.ts
@@ -29,6 +29,7 @@ import {
   updateAgent,
 } from "./agents";
 import { saveConnectorCredentials } from "../db/connectorsStore";
+import { setSetting } from "../db/settingsStore";
 
 describe("settings ConfigAgent may write (backs Cipher's update_setting tool)", () => {
   // The point of these: a reply is assembled from text this app did not author — web search
@@ -226,6 +227,64 @@ describe("updateAgent (backs Cipher's update_agent tool)", () => {
   it("rejects an explicitly blank name instead of silently keeping the old one", () => {
     const created = createAgent({ name: "Recipe Helper", prompt: "p1" });
     expect(() => updateAgent(created.id, { name: "   " })).toThrow("Agent name cannot be blank.");
+  });
+});
+
+// The bug these cover: both writers resolved a blank model to the *static*
+// SETTING_DEFAULTS.orchestratorModel — the literal "gpt-4.1-mini". So on an install pointed at
+// Claude, clearing an agent's Model ID stored an OpenAI id, and the next run 404'd against
+// Anthropic for an agent the user had only tried to reset.
+describe("a blank model id resolves against the agent's own provider", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  it("takes the pinned provider's default, not the build's", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+    const updated = updateAgent(created.id, { providerId: "anthropic", model: "" });
+
+    expect(updated.provider_id).toBe("anthropic");
+    expect(updated.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("takes the live orchestrator model when the agent follows the Chat slot", () => {
+    setSetting("appSettings.orchestratorModel", "claude-haiku-4-5-20251001");
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+
+    expect(updateAgent(created.id, { model: "" }).model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("takes the live orchestrator model for `local`, which has no default of its own", () => {
+    setSetting("appSettings.orchestratorModel", "~deepseek/deepseek-v4-flash-latest");
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+    const updated = updateAgent(created.id, { providerId: "local", model: "" });
+
+    expect(updated.provider_id).toBe("local");
+    expect(updated.model).toBe("~deepseek/deepseek-v4-flash-latest");
+  });
+
+  it("reads the incoming provider id, not the stored one, when both move at once", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+    updateAgent(created.id, { providerId: "anthropic" });
+    // Settings patches provider and model together; the model must follow the provider being
+    // set in this same call, not the one the row still holds.
+    const updated = updateAgent(created.id, { providerId: "openrouter", model: "" });
+
+    expect(updated.model).toBe("~deepseek/deepseek-v4-flash-latest");
+  });
+
+  it("seeds a new agent from the live Chat model rather than the compile-time default", () => {
+    setSetting("appSettings.orchestratorModel", "claude-haiku-4-5-20251001");
+
+    expect(createAgent({ name: "Researcher", prompt: "p" }).model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("still refuses an unknown provider id rather than falling back to a default", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+    expect(() => updateAgent(created.id, { providerId: "not-a-provider", model: "" })).toThrow(
+      /is not a provider this app knows about/
+    );
   });
 });
 

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -59,6 +59,26 @@ export const DEFAULT_MODEL = SETTING_DEFAULTS.orchestratorModel;
 // provider.ts, with a comment saying so — are now read from SETTING_DEFAULTS along with
 // everything else. That duplication is what finding S1 was about.
 
+/**
+ * The model an agent should carry when its Model ID field is left blank.
+ *
+ * "Blank means the default" is only meaningful once you say *whose* default. Both writers below
+ * used DEFAULT_MODEL — the *static* `SETTING_DEFAULTS.orchestratorModel`, i.e. the literal
+ * "gpt-4.1-mini" — which is neither the model the Chat slot is currently on nor one the agent's
+ * own provider serves. So clearing the field on a Claude-backed install stored an OpenAI id and
+ * the next run 404'd against Anthropic. That is the exact failure ai/selectProvider.ts exists to
+ * prevent, in the one path it did not cover.
+ *
+ * A pinned agent takes its own provider's default. Everything else takes the *live* orchestrator
+ * model: an agent inheriting the Chat slot (`""`), a `local` provider (no default, because only
+ * the user knows which model they have pulled), and an id from a build that offered a provider
+ * this one doesn't. The live value is also what selectChatProvider writes across every inheriting
+ * agent, so a blank save and a provider switch agree by construction rather than by coincidence.
+ */
+export function resolveAgentModel(providerId: string): string {
+  return findProvider(providerId.trim())?.defaultChatModel || readAppSetting("orchestratorModel");
+}
+
 // Prompts are seeded/imported with {{agentName}}/{{userName}}/{{currentDateTime}}
 // placeholders still in them so a rename doesn't require rewriting stored prompt text —
 // substitution happens live at Agent-build time, using whatever settings currently hold.
@@ -696,13 +716,6 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
   if (patch.enabled === false && existing.system) {
     throw new Error(`${existing.name} is a system agent and cannot be disabled.`);
   }
-  // Blank model field means "use the default" rather than being rejected; anything
-  // else must match the same shape createAgent enforces, otherwise a bad model id
-  // silently persists here and only surfaces later as an opaque provider-side error.
-  const nextModel = patch.model === undefined ? existing.model : patch.model.trim() || DEFAULT_MODEL;
-  if (!MODEL_ID_PATTERN.test(nextModel)) {
-    throw new Error(`"${nextModel}" doesn't look like a valid model ID (expected "model" or "provider/model").`);
-  }
   // Unlike the other optional fields, an explicitly-supplied but blank name is rejected
   // rather than silently kept — otherwise a caller (e.g. Cipher's update_agent tool)
   // could report success while actually leaving the name unchanged.
@@ -712,9 +725,21 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
   // Empty is a real value here — "follow the Chat slot" — so only a non-empty id is checked
   // against the registry. An unknown one is refused rather than stored, because a row naming a
   // provider this build has never heard of silently falls back at run time.
+  //
+  // Resolved before the model on purpose: a blank model means "this provider's default", so the
+  // provider has to be settled first. Patching both at once — which is what the Settings panel
+  // does when you change an agent's provider — must read the *incoming* id, not the stored one.
   const nextProviderId = patch.providerId === undefined ? existing.provider_id : patch.providerId.trim();
   if (nextProviderId !== "" && !findProvider(nextProviderId)) {
     throw new Error(`"${nextProviderId}" is not a provider this app knows about.`);
+  }
+  // Blank model field means "use the default" rather than being rejected; anything
+  // else must match the same shape createAgent enforces, otherwise a bad model id
+  // silently persists here and only surfaces later as an opaque provider-side error.
+  const nextModel =
+    patch.model === undefined ? existing.model : patch.model.trim() || resolveAgentModel(nextProviderId);
+  if (!MODEL_ID_PATTERN.test(nextModel)) {
+    throw new Error(`"${nextModel}" doesn't look like a valid model ID (expected "model" or "provider/model").`);
   }
 
   const next = {
@@ -782,7 +807,10 @@ export function createAgent(input: AgentCreateInput): AgentRow {
   if (!name) {
     throw new Error("Agent name is required.");
   }
-  const model = input.model?.trim() || DEFAULT_MODEL;
+  // A new agent follows the Chat slot, so a blank model means the model that slot is on right
+  // now — not the build's compile-time default, which is a different provider's id the moment
+  // the user has pointed Chat anywhere but OpenAI.
+  const model = input.model?.trim() || resolveAgentModel("");
   if (!MODEL_ID_PATTERN.test(model)) {
     throw new Error(`"${model}" doesn't look like a valid model ID (expected "model" or "provider/model").`);
   }


### PR DESCRIPTION
## What changed

Clearing an agent's Model ID in Settings → Agents now leaves it on a model its own provider actually serves, instead of the build's compile-time OpenAI default.

`resolveAgentModel()` gives "blank means the default" an owner: a **pinned** agent takes its provider's `defaultChatModel`; **everything else** — an agent following the Chat slot, a `local` provider (which has no default, because only the user knows what they have pulled), or an id from a build that offered a provider this one doesn't — takes the **live** orchestrator model. That live value is exactly what `selectChatProvider` already writes across every inheriting agent, so a blank save and a Chat-provider switch now agree by construction rather than by coincidence.

`updateAgent` also resolves the provider id *before* the model, so a patch that moves both at once (what the Settings panel sends when you change an agent's provider) reads the incoming provider rather than the stored one.

## Root cause

Both writers did `patch.model.trim() || DEFAULT_MODEL`, where `DEFAULT_MODEL` is the **static** `SETTING_DEFAULTS.orchestratorModel` — the literal `"gpt-4.1-mini"`. Neither the live Chat model nor the pinned provider's. With Chat on Claude, clearing one agent's model stored an OpenAI id and the next run 404'd against Anthropic.

This is the same failure `electron/main/ai/selectProvider.ts` was written to prevent ("four agents asking Anthropic for an OpenAI model"), reintroduced through the one path that file does not cover.

## Testing

- Unit/integration: **1236 passed / 118 files** (baseline 1230 — the 6 added here). eslint 0, `tsc -b` 0, `npm run build` 0.
- New cases in `electron/main/ai/agents.test.ts`: pinned provider default; live orchestrator model when following Chat; `local` falling through to the live model; provider+model patched together reading the incoming id; a new agent seeded from the live Chat model; an unknown provider id still refused rather than silently defaulted.
- Manual: end-to-end app validation is running against a sandboxed userData as part of the follow-up work on this branch.

## Notes

- No schema change and no migration. This only affects what a *future* write stores, so it cannot strand existing rows and reverts cleanly.
- `DEFAULT_MODEL` stays exported — `ipc/settings.ts` and `ipc/knowledgeBase.ts` still use it.
- Read-side backstop in `modelForAgent` (`ai/provider.ts:173`) is deliberately left in place for rows written by earlier builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)