### PR TITLE
Stop a partial Chat-provider write from resetting the fields it didn't mention

### DIFF
--- a/electron/main/ai/selectProvider.test.ts
+++ b/electron/main/ai/selectProvider.test.ts
@@ -96,6 +96,60 @@ describe("selectChatProvider", () => {
     expect(getProviderCredentials("openrouter")?.apiUrl).toBe("https://proxy.example.com/v1");
   });
 
+  // Settings saves the key, the URL and the model as three separate writes, so every one of them
+  // arrives here as a partial selection. Falling through to the registry defaults made each of
+  // those destructive: rotating a key reset a custom model *and* re-aimed a private-gateway URL
+  // at api.openai.com, taking the user's key with it.
+  describe("a partial write keeps what it did not mention", () => {
+    beforeEach(() => {
+      selectChatProvider({
+        providerId: "openai",
+        apiKey: "sk-1",
+        apiUrl: "https://proxy.example.com/v1",
+        model: "gpt-4.1",
+      });
+    });
+
+    it("rotating the key leaves the custom model and URL alone", () => {
+      selectChatProvider({ providerId: "openai", apiKey: "sk-2" });
+
+      expect(setting("appSettings.orchestratorModel")).toBe("gpt-4.1");
+      expect(getProviderCredentials("openai")).toEqual({
+        apiUrl: "https://proxy.example.com/v1",
+        apiKey: "sk-2",
+      });
+    });
+
+    it("editing the URL leaves the custom model alone", () => {
+      selectChatProvider({ providerId: "openai", apiUrl: "https://proxy2.example.com/v1" });
+
+      expect(setting("appSettings.orchestratorModel")).toBe("gpt-4.1");
+      expect(getProviderCredentials("openai")?.apiUrl).toBe("https://proxy2.example.com/v1");
+    });
+
+    it("editing the model leaves the custom URL alone", () => {
+      selectChatProvider({ providerId: "openai", model: "gpt-4.1-nano" });
+
+      expect(setting("appSettings.orchestratorModel")).toBe("gpt-4.1-nano");
+      expect(getProviderCredentials("openai")?.apiUrl).toBe("https://proxy.example.com/v1");
+    });
+
+    it("still moves the model to the new provider's default when the provider actually changes", () => {
+      seedAgent("inheritor", "gpt-4.1");
+      selectChatProvider({ providerId: "anthropic", apiKey: "sk-ant" });
+
+      expect(setting("appSettings.orchestratorModel")).toBe("claude-haiku-4-5-20251001");
+      expect(modelOf("inheritor")).toBe("claude-haiku-4-5-20251001");
+    });
+
+    it("restores a provider's own stored URL when switching back to it", () => {
+      selectChatProvider({ providerId: "anthropic", apiKey: "sk-ant" });
+      selectChatProvider({ providerId: "openai" });
+
+      expect(getProviderCredentials("openai")?.apiUrl).toBe("https://proxy.example.com/v1");
+    });
+  });
+
   it("takes an Ollama name:tag model", () => {
     const result = selectChatProvider({
       providerId: "local",

--- a/electron/main/ai/selectProvider.ts
+++ b/electron/main/ai/selectProvider.ts
@@ -1,7 +1,8 @@
 import { getDb } from "../db";
 import { setSetting } from "../db/settingsStore";
-import { saveProvider } from "../db/providersStore";
-import { findProvider } from "./providers";
+import { listVisibleProviders, saveProvider } from "../db/providersStore";
+import { findProvider, inferProviderId } from "./providers";
+import { readAppSetting } from "../appSettings";
 import { validateSettingValue } from "../settingsSchema";
 import { devLog } from "../devLog";
 
@@ -22,11 +23,13 @@ import { devLog } from "../devLog";
 export interface ChatProviderSelection {
   /** A registry id from ./providers. */
   providerId: string;
-  /** Omit to keep whatever URL is stored; the provider's own default fills a blank. */
+  /** Omit to keep the URL already stored for this provider; the provider's own default fills a
+   * blank. */
   apiUrl?: string;
   /** Omit to leave the stored key alone — see saveProvider's three-state apiKey. */
   apiKey?: string;
-  /** Omit to take the provider's default model. */
+  /** Omit to keep the current model when this provider is already the Chat slot, or to take the
+   * provider's default when switching to a different one. */
   model?: string;
 }
 
@@ -41,14 +44,32 @@ export function selectChatProvider(selection: ChatProviderSelection): ChatProvid
   const provider = findProvider(selection.providerId);
   if (!provider) throw new Error(`Unknown provider "${selection.providerId}".`);
 
-  const apiUrl = selection.apiUrl?.trim() ?? provider.baseUrl;
+  // Which provider the Chat slot is on *before* this call. An install that predates the registry
+  // has no id stored, so it is inferred from the legacy URL — the same rule useProviders.chatSlot
+  // uses to decide what to show selected, so the UI and this function agree about what counts as
+  // a switch.
+  const currentProviderId = readAppSetting("chatProviderId") || inferProviderId(readAppSetting("chatApiUrl"));
+  const switchingProvider = currentProviderId !== provider.id;
+  const storedUrl = listVisibleProviders().find((row) => row.id === provider.id)?.apiUrl ?? "";
+
+  // Omitted fields keep what is already stored rather than snapping back to the registry default.
+  //
+  // They used to fall through to `provider.baseUrl` / `provider.defaultChatModel` unconditionally,
+  // which made every partial write destructive: the Settings panel saves the key on its own, so
+  // rotating a key reset a custom model *and* a custom API URL. On a setup pointed at a private
+  // gateway that silently re-aimed the slot at api.openai.com and sent the user's key there.
+  const apiUrl = selection.apiUrl?.trim() || storedUrl || provider.baseUrl;
   // A hosted provider always has a default URL to fall back on; `local` does not, because only
   // the user knows where their server is.
   if (apiUrl === "") throw new Error(`${provider.label} needs an API URL.`);
   const urlCheck = validateSettingValue("chatApiUrl", apiUrl);
   if (!urlCheck.ok) throw new Error(`That API URL ${urlCheck.reason}.`);
 
-  const model = selection.model?.trim() || provider.defaultChatModel;
+  // Switching provider still moves the model — that is the whole point of this function, and a
+  // model id from the old host is exactly what breaks against the new one. Staying put keeps it.
+  const model =
+    selection.model?.trim() ||
+    (switchingProvider ? provider.defaultChatModel : readAppSetting("orchestratorModel"));
   if (model === "") throw new Error(`${provider.label} needs a model id.`);
   const modelCheck = validateSettingValue("orchestratorModel", model);
   if (!modelCheck.ok) throw new Error(`That model id ${modelCheck.reason}.`);


### PR DESCRIPTION
## What changed

`selectChatProvider` now keeps whatever is already stored for any field the caller omits. Switching to a **different** provider still moves the model to that provider's default — that is the function's whole purpose, and a model id from the old host is exactly what breaks against the new one.

## Root cause

Settings saves the Chat API key, URL and model as three **separate** writes, so each one reaches `selectChatProvider` as a partial selection. Omitted fields fell through to the registry defaults unconditionally:

```ts
const apiUrl = selection.apiUrl?.trim() ?? provider.baseUrl;
const model  = selection.model?.trim()  || provider.defaultChatModel;
```

That made every partial write destructive:

- rotating the API key reset a custom model (`gpt-4.1` → `gpt-4.1-mini`) **and** reset a custom API URL to the provider's default host
- editing the URL reset the model
- and since the slot re-points every inheriting agent to the new model, one key rotation moved all of them too

The URL half is the serious one: on a setup pointed at a private gateway (`https://proxy.example.com/v1`), rotating the key silently re-aimed the Chat slot at `api.openai.com` — and sent the user's key there on the next request.

## Testing

- Unit/integration: **1241 passed / 118 files** (baseline 1236 — the 5 added here). eslint 0, `tsc -b` 0, `npm run build` 0.
- New cases in `electron/main/ai/selectProvider.test.ts`: key rotation preserves model + URL; URL edit preserves model; model edit preserves URL; a real provider switch still moves the model and re-points inheriting agents; switching back to a provider restores that provider's own stored URL.
- Found by writing the assertion first and watching it fail — the received values in that run were `{model: "gpt-4.1-mini", apiUrl: "https://api.openai.com/v1"}`.

## Notes

- An install predating the provider registry has no `chatProviderId`, so "is this a switch?" is decided by `inferProviderId(chatApiUrl)` — the same rule `useProviders.chatSlot` uses to decide what to show selected, so the UI and this function agree on what counts as a switch.
- No schema change, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)