### PR TITLE
Add release workflow for macOS, Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     branches: [develop]
   pull_request:
     branches: [develop, main]
+  # Called by release.yml so a tag is gated by exactly this workflow rather than a
+  # copy of it that can drift.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+# Builds distributable apps for macOS, Windows and Linux on every version tag, then
+# attaches them to a GitHub Release.
+#
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# Publishing is done once, by the release job, using the `gh` CLI that is preinstalled
+# on the runners. electron-builder's own publisher is disabled via `--publish never` in
+# the package:ci script — left on, it auto-publishes whenever it detects a CI tag
+# (app-builder-lib PublishManager.js), which would mean four jobs racing to create the
+# same release.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+# Never cancel a release mid-flight: a half-built tag leaves a release with some
+# platforms missing, which is worse than a duplicate run.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # The same four gates as every PR, by reference rather than by copy. A tag can be
+  # pushed from any commit, including one that never went through a PR.
+  verify:
+    uses: ./.github/workflows/ci.yml
+
+  build:
+    name: Build ${{ matrix.os }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform failing should still yield the other two, so a partial release can
+      # be completed by hand rather than re-running everything.
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            artifact: mac-build
+            glob: dist/*.dmg
+          - os: windows-latest
+            artifact: windows-build
+            glob: dist/*.exe
+          - os: ubuntu-latest
+            artifact: linux-build
+            glob: dist/*.AppImage
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # electron-builder names artifacts from package.json's version, not from the tag.
+      # Without this, tagging v0.2.0 on an unbumped 0.1.0 produces OpenOrbit-0.1.0.dmg
+      # attached to a release called v0.2.0.
+      - name: Verify tag matches package.json version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG"
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches package.json version $PKG"
+
+      - run: npm ci
+
+      - name: Package
+        run: npm run package:ci
+        env:
+          # No signing certificate is configured. Without this, electron-builder searches
+          # the runner keychain and can pick up an unrelated identity.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.glob }}
+          # A glob that matches nothing would otherwise produce an empty artifact and a
+          # release with missing downloads.
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release and attach installers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(artifacts/*/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No artifacts were downloaded — nothing to release"
+            exit 1
+          fi
+          printf 'Attaching %s\n' "${files[@]}"
+          # A tag containing a hyphen is a prerelease by semver convention (v1.0.0-beta.1).
+          prerelease=""
+          case "$GITHUB_REF_NAME" in
+            *-*) prerelease="--prerelease" ;;
+          esac
+          # `gh release create` has no overwrite flag, so a re-run after a partially
+          # failed release aborts with "release already exists" and leaves a published
+          # release with missing installers. Upload into the existing release instead;
+          # --clobber replaces same-named assets so the re-run is idempotent.
+          if gh release view "$GITHUB_REF_NAME" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists — uploading assets into it"
+            gh release upload "$GITHUB_REF_NAME" \
+              --repo "$REPO" \
+              --clobber \
+              "${files[@]}"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --repo "$REPO" \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes \
+              --verify-tag \
+              $prerelease \
+              "${files[@]}"
+          fi


### PR DESCRIPTION
## What changed

Phase 3 of `0-cowork/plans/active/gitbub-ci.md`. Pushing a `v*` tag now builds installers on macOS, Windows and Linux and attaches them to a GitHub Release:

```bash
git tag v0.1.0 && git push origin v0.1.0
```

The gate is **`ci.yml` by reference, not a copy** — `ci.yml` gains a `workflow_call` trigger and `release.yml` calls it, so a tag is checked by exactly the four gates every PR gets. A tag can be pushed from any commit, including one that never went through a PR, so this is not redundant with branch protection.

Publishing is done once, by the release job, using the `gh` CLI preinstalled on the runners rather than a third-party action — nothing to pin, no supply-chain surface. electron-builder's own publisher stays off via `--publish never`; left on, it auto-publishes on any detected CI tag, which would mean four jobs racing to create the same release.

## Root cause (of the one defect found and fixed pre-merge)

`gh release create` has no overwrite flag. A re-run of the release job after a partial failure would abort with "release already exists" and strand a published release with missing installers. The step now probes `gh release view` and falls back to `gh release upload --clobber`, making re-runs idempotent. `--verify-tag` stops `gh` inventing a tag that was never pushed.

## Other deliberate choices

| Choice | Why |
|---|---|
| `fail-fast: false` | One platform failing still yields the other two, so a partial release can be finished by hand. |
| Tag/version guard before packaging | electron-builder names artifacts from `package.json`, so tagging `v0.2.0` on an unbumped `0.1.0` would attach `OpenOrbit-0.1.0.dmg` to a release called `v0.2.0`. |
| `if-no-files-found: error` | A wrong glob becomes a red job instead of a release with missing downloads. |
| `cancel-in-progress: false` | A cancelled release is worse than a duplicate run. |
| `CSC_IDENTITY_AUTO_DISCOVERY: false` | Otherwise electron-builder searches the runner keychain and can pick up an unrelated identity. |
| Artifacts collected into a bash array, expanded quoted | The Windows installer is `OpenOrbit Setup 0.1.0.exe` — with spaces. |

## Testing

- **Unit/integration:** 1230 passed, 118 files
- **E2E:** not configured (`playwright-core` is a runtime dependency for the app's own browser tooling; no `@playwright/test`, no config file)
- **Manual:** extracted the release step's actual `run:` block from the YAML and executed it against a mock `gh`. Verified three paths produce correct argv — create (with `--verify-tag`), existing-release (`upload --clobber`), and prerelease (`--prerelease` for hyphenated tags) — plus the empty-artifact guard exiting 1, and a spaced Windows filename surviving as a single argument.
- **Guard logic:** tested against six tag/version pairs. Notably `v1.0.0-beta.1` against `package.json` `1.0.0` correctly fails — a prerelease tag requires the prerelease suffix in `package.json` too.
- Gates: eslint **0** · `tsc -b` **0** · `npm run build` **0**

## Notes

**A claim in the plan was wrong and is retracted in this branch's plan update.** Two revisions of the plan asserted that `__APP_RELEASE_VERSION__` resolving to the *previous* release during a tag build was a defect, and proposed overriding it from `GITHUB_REF_NAME`. Reading the consumer shows the opposite — `AboutTab.tsx:139` feeds it to `isUpdateAvailable(RELEASE.version, info.packageVersion)` under a row labelled **"Latest release"**. Baking the previous release in is the intended semantic; the proposed fix would have made the two values always equal and permanently disabled the "Update available" badge. No code change made.

Still open before a first release: no code signing (Gatekeeper and SmartScreen warnings expected, documented in the plan), and no entitlements file, which notarization will need because the app spawns child processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)