### PR TITLE
Split AI Models into "API keys" and "Default models"

### DIFF
--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -302,6 +302,12 @@ export const PROTECTED_SETTING_KEYS = [
   // go to, so an agent able to write these can redirect the user's key just as surely as if it
   // had written the URL itself.
   "chatProviderId",
+  // Note: nothing writes `voiceProviderId` today — not the Settings panel, not a migration, and
+  // not selectChatProvider, which only ever sets chatProviderId. It stays "" on every install, so
+  // resolveSlot("voice") always takes the legacy chatApiUrl/voiceApiUrl branch. It is read at
+  // ai/provider.ts:99 and kept for the day a second `supportsVoice` provider exists; until then
+  // there is deliberately no picker, because voiceProviders() would offer a list of one. Listed
+  // here anyway so it cannot become agent-writable ahead of that.
   "voiceProviderId",
 ] as const;
 

--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -354,3 +354,62 @@ describe("running onboarding again", () => {
     expect(onUpdate).toHaveBeenCalledExactlyOnceWith({ onboardingDone: false });
   });
 });
+
+describe("AI Models section", () => {
+  function renderModels(settings = mergeWithDefaults({})) {
+    render(
+      <SettingsPanel
+        open
+        onClose={vi.fn()}
+        settings={settings}
+        sessionElapsedMs={0}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+        agents={[]}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("tab", { name: /^Models$/i }));
+  }
+
+  // Credentials and model choice used to be interleaved per slot, across three accordions, with
+  // the Chat provider's card a different shape from every other provider's.
+  it("splits into exactly two groups — keys, then models", () => {
+    renderModels();
+    expect(screen.getByText("API keys")).toBeInTheDocument();
+    expect(screen.getByText("Default models")).toBeInTheDocument();
+    expect(screen.queryByText("Other providers")).not.toBeInTheDocument();
+  });
+
+  it("lists every provider under API keys, not just the ones that aren't Chat", () => {
+    renderModels();
+    // By field label rather than by provider name: the names also appear in the Chat provider
+    // dropdown, and a bare getByText would match either one.
+    for (const label of ["OpenRouter", "OpenAI", "Claude", "Local AI"]) {
+      expect(screen.getByLabelText(`${label} API key`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`${label} API URL`)).toBeInTheDocument();
+    }
+    // Voice keeps its own credentials — it is a slot, not a registry provider.
+    expect(screen.getByLabelText("Voice API URL")).toBeInTheDocument();
+  });
+
+  it("marks which provider the Chat slot is on", () => {
+    renderModels();
+    // Defaults infer OpenAI from an empty chatApiUrl, the same rule the migration used.
+    expect(screen.getByText(/Chat provider ·/)).toBeInTheDocument();
+  });
+
+  it("puts every model field in the models group, and no key fields there", () => {
+    renderModels();
+    for (const label of ["Chat model", "Transcription model", "Speech (TTS) model"]) {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    }
+    // The old "Model ID" label lived in the Chat credentials card.
+    expect(screen.queryByLabelText("Model ID")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -444,39 +444,137 @@ export default function SettingsPanel({
           <div className="detail-body">
             {activeSection === "models" && (
               <div className="agent-accordion-list">
-                <SettingsAccordion
-                  title="Chat"
-                  headerActions={
-                    <>
-                      {chatTestResult && (
-                        <span
-                          className={`settings-test-status ${chatTestResult.ok ? "settings-success" : "settings-error"}`}
-                          title={chatTestResult.detail}
-                        >
-                          {chatTestResult.detail}
-                        </span>
-                      )}
-                      <button
-                        type="button"
-                        className="settings-action-btn-sm settings-action-btn-ghost"
-                        onClick={() => runTestChat()}
-                        disabled={testingChat}
-                      >
-                        <TablerIcon name="ti-plug-connected" />
-                        <span>{testingChat ? "Testing…" : "Test"}</span>
-                      </button>
-                    </>
-                  }
-                >
+                <SettingsAccordion title="API keys" defaultOpen>
                   <p className="group-hint">
-                    Powers the orchestrator and every agent's chat/tool calls. Defaults to OpenAI — point it at
-                    OpenRouter, Ollama, or any other OpenAI-compatible host if you want a different model catalog.
+                    One key per provider. The Chat slot uses whichever provider is selected under
+                    Default models, and an agent pinned to a provider in Settings → Agents uses that
+                    provider's key.
+                  </p>
+                  <div className="group">
+                    <div className="card">
+                      {AI_PROVIDERS.map((provider) => {
+                        // The Chat provider's credentials still go through selectChat rather than a
+                        // plain save: the slot, its key and every inheriting agent's model are one
+                        // change, and a half-applied one is what selectChatProvider exists to prevent.
+                        const isChat = provider.id === chatSlotView.providerId;
+                        const row = providers.configured.find((entry) => entry.id === provider.id);
+                        const keySet = isChat ? chatSlotView.keySet : (row?.keySet ?? false);
+                        const saveKey = (apiKey: string) =>
+                          isChat
+                            ? void applyChat({ providerId: provider.id, apiKey })
+                            : void providers.save({ providerId: provider.id, apiKey });
+                        return (
+                          <div key={provider.id} className="row-field">
+                            <span>
+                              {provider.label}
+                              <small>
+                                {isChat ? "Chat provider · " : ""}
+                                {keySet
+                                  ? "Key saved"
+                                  : provider.keyRequired
+                                    ? "No API key yet"
+                                    : "No key needed — set the URL below"}
+                              </small>
+                            </span>
+                            <ApiKeyField
+                              label={`${provider.label} API key`}
+                              isSet={keySet}
+                              onSave={saveKey}
+                              onClear={keySet ? () => saveKey("") : undefined}
+                            />
+                            <TextField
+                              label={`${provider.label} API URL`}
+                              value={isChat ? chatSlotView.apiUrl : (row?.apiUrl ?? "")}
+                              placeholder={provider.baseUrl || "http://localhost:11434/v1"}
+                              warningFor={providerUrlWarning}
+                              onCommit={(apiUrl) =>
+                                isChat
+                                  ? void applyChat({ providerId: provider.id, apiUrl })
+                                  : void providers.save({ providerId: provider.id, apiUrl })
+                              }
+                            />
+                            {/* Only the Chat provider gets a Test button: the check resolves a
+                                credential *slot*, so there is nothing to test a provider that
+                                nothing is currently pointed at against. */}
+                            {isChat && (
+                              <div className="row-field-action">
+                                <button
+                                  type="button"
+                                  className="settings-action-btn-sm settings-action-btn-ghost"
+                                  onClick={() => runTestChat()}
+                                  disabled={testingChat}
+                                >
+                                  <TablerIcon name="ti-plug-connected" />
+                                  <span>{testingChat ? "Testing…" : "Test"}</span>
+                                </button>
+                                {chatTestResult && (
+                                  <span
+                                    className={`settings-test-status ${chatTestResult.ok ? "settings-success" : "settings-error"}`}
+                                    title={chatTestResult.detail}
+                                  >
+                                    {chatTestResult.detail}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                            {isChat && chatError && <p className="settings-error">{chatError}</p>}
+                          </div>
+                        );
+                      })}
+                      <div className="row-field">
+                        <span>
+                          Voice
+                          <small>
+                            {settings.voiceApiKeySet ? "Key saved · " : "No API key yet · "}
+                            Its own key, so speech can run on a different account from Chat
+                          </small>
+                        </span>
+                        <ApiKeyField
+                          label="Voice API key"
+                          isSet={settings.voiceApiKeySet}
+                          onSave={(key) => onUpdate({ voiceApiKey: key })}
+                        />
+                        <TextField
+                          label="Voice API URL"
+                          value={settings.voiceApiUrl}
+                          placeholder="https://api.openai.com/v1"
+                          warningFor={providerUrlWarning}
+                          onCommit={(voiceApiUrl) => onUpdate({ voiceApiUrl })}
+                        />
+                        <div className="row-field-action">
+                          <button
+                            type="button"
+                            className="settings-action-btn-sm settings-action-btn-ghost"
+                            onClick={() => runTestVoice()}
+                            disabled={testingVoice}
+                          >
+                            <TablerIcon name="ti-plug-connected" />
+                            <span>{testingVoice ? "Testing…" : "Test"}</span>
+                          </button>
+                          {voiceTestResult && (
+                            <span
+                              className={`settings-test-status ${voiceTestResult.ok ? "settings-success" : "settings-error"}`}
+                              title={voiceTestResult.detail}
+                            >
+                              {voiceTestResult.detail}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </SettingsAccordion>
+
+                <SettingsAccordion title="Default models" defaultOpen>
+                  <p className="group-hint">
+                    Which model each part of the app reaches for. An agent can name its own in
+                    Settings → Agents; every agent that doesn't follows the chat model here.
                   </p>
                   <div className="group">
                     <div className="card">
                       <label className="row-field">
                         <span>
-                          Provider
+                          Chat provider
                           <small>Switching also moves every agent that follows this slot</small>
                         </span>
                         <Combobox
@@ -486,132 +584,23 @@ export default function SettingsPanel({
                           ariaLabel="Chat provider"
                         />
                       </label>
-                      <ApiKeyField
-                        label="API Key"
-                        isSet={chatSlotView.keySet}
-                        onSave={(apiKey) => void applyChat({ providerId: chatSlotView.providerId, apiKey })}
-                        onClear={
-                          chatSlotView.keySet
-                            ? () => void applyChat({ providerId: chatSlotView.providerId, apiKey: "" })
-                            : undefined
-                        }
-                      />
                       <TextField
-                        label="API URL"
-                        value={chatSlotView.apiUrl}
-                        placeholder={chatProvider?.baseUrl || "http://localhost:11434/v1"}
-                        warningFor={providerUrlWarning}
-                        onCommit={(apiUrl) => void applyChat({ providerId: chatSlotView.providerId, apiUrl })}
-                      />
-                      <TextField
-                        label="Model ID"
+                        label="Chat model"
+                        hint="Powers the orchestrator and every agent's chat and tool calls"
                         value={settings.orchestratorModel}
                         placeholder={chatProvider?.defaultChatModel || DEFAULT_ORCHESTRATOR_MODEL}
                         onCommit={(model) => void applyChat({ providerId: chatSlotView.providerId, model })}
                       />
-                      {chatError && <p className="settings-error">{chatError}</p>}
-                    </div>
-                  </div>
-                </SettingsAccordion>
-
-                <SettingsAccordion title="Other providers">
-                  <p className="group-hint">
-                    Credentials for providers an individual agent can be pointed at, without making
-                    them your Chat provider. Set one up here, then pick it on the agent in Settings →
-                    Agents.
-                  </p>
-                  <div className="group">
-                    <div className="card">
-                      {AI_PROVIDERS.filter((provider) => provider.id !== chatSlotView.providerId).map(
-                        (provider) => {
-                          const row = providers.configured.find((entry) => entry.id === provider.id);
-                          return (
-                            <div key={provider.id} className="row-field">
-                              <span>
-                                {provider.label}
-                                <small>
-                                  {row?.keySet
-                                    ? "Configured"
-                                    : provider.keyRequired
-                                      ? "No API key yet"
-                                      : "No API URL yet"}
-                                </small>
-                              </span>
-                              <ApiKeyField
-                                label={`${provider.label} API key`}
-                                isSet={row?.keySet ?? false}
-                                onSave={(apiKey) => void providers.save({ providerId: provider.id, apiKey })}
-                                onClear={
-                                  row?.keySet
-                                    ? () => void providers.save({ providerId: provider.id, apiKey: "" })
-                                    : undefined
-                                }
-                              />
-                              <TextField
-                                label={`${provider.label} API URL`}
-                                value={row?.apiUrl ?? ""}
-                                placeholder={provider.baseUrl || "http://localhost:11434/v1"}
-                                warningFor={providerUrlWarning}
-                                onCommit={(apiUrl) => void providers.save({ providerId: provider.id, apiUrl })}
-                              />
-                            </div>
-                          );
-                        }
-                      )}
-                    </div>
-                  </div>
-                </SettingsAccordion>
-
-                <SettingsAccordion
-                  title="Voice"
-                  headerActions={
-                    <>
-                      {voiceTestResult && (
-                        <span
-                          className={`settings-test-status ${voiceTestResult.ok ? "settings-success" : "settings-error"}`}
-                          title={voiceTestResult.detail}
-                        >
-                          {voiceTestResult.detail}
-                        </span>
-                      )}
-                      <button
-                        type="button"
-                        className="settings-action-btn-sm settings-action-btn-ghost"
-                        onClick={() => runTestVoice()}
-                        disabled={testingVoice}
-                      >
-                        <TablerIcon name="ti-plug-connected" />
-                        <span>{testingVoice ? "Testing…" : "Test"}</span>
-                      </button>
-                    </>
-                  }
-                >
-                  <p className="group-hint">
-                    Powers speech transcription and spoken replies. Defaults to OpenAI, same as Chat — an
-                    independent key/URL here in case you want voice on a different provider.
-                  </p>
-                  <div className="group">
-                    <div className="card">
-                      <ApiKeyField
-                        label="API Key"
-                        isSet={settings.voiceApiKeySet}
-                        onSave={(key) => onUpdate({ voiceApiKey: key })}
-                      />
-                      <TextField
-                        label="API URL"
-                        value={settings.voiceApiUrl}
-                        placeholder="https://api.openai.com/v1"
-                        warningFor={providerUrlWarning}
-                        onCommit={(voiceApiUrl) => onUpdate({ voiceApiUrl })}
-                      />
                       <TextField
                         label="Transcription model"
+                        hint="Turns what you say into text"
                         value={settings.voiceTranscriptionModel}
                         placeholder="whisper-1"
                         onCommit={(voiceTranscriptionModel) => onUpdate({ voiceTranscriptionModel })}
                       />
                       <TextField
                         label="Speech (TTS) model"
+                        hint="Reads replies out loud"
                         value={settings.voiceTtsModel}
                         placeholder="gpt-4o-mini-tts"
                         onCommit={(voiceTtsModel) => onUpdate({ voiceTtsModel })}

--- a/src/globals.css
+++ b/src/globals.css
@@ -2096,6 +2096,17 @@ svg#oc {
   margin-top: 2px;
 }
 
+/* An action that belongs to one setting rather than to the section — the per-slot "Test" button
+   and the result it produces. Sits inside the .row-field's column flow, so it lines up under the
+   fields it tests instead of competing for space in the accordion header. */
+.group .card .row-field-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
 .group .card .row-field input,
 .group .card .row-field select {
   background: rgba(0, 4, 12, 0.4);


### PR DESCRIPTION
## What changed

Settings → Models goes from three accordions to two, cut by **what a field is** rather than **which slot it belongs to**.

| Before | After |
|---|---|
| **Chat** — provider · key · URL · model | **API keys** — every provider: key · URL, Chat one marked, plus the Voice slot's own credentials |
| **Other providers** — key · URL (no model) | **Default models** — chat provider · chat model · transcription model · TTS model · TTS voice |
| **Voice** — key · URL · 2 models · voice | |

The old split meant the Chat provider's card was a *different shape* from every other provider's, because "Other providers" filtered it out. Setting up a key was two different tasks depending on which provider you happened to be on. And there was nowhere to see all your models at once.

The per-slot **Test** button moves out of the accordion header and in beside the credentials it checks. It resolves a credential *slot*, so it belongs with the slot rather than with a section that now spans four providers. Only the Chat provider gets one — there is nothing to test a provider that nothing is currently pointed at against.

## Notes

- Layout only. No storage change, no IPC change, no migration. The Chat provider's credentials still go through `selectChat` rather than a plain `providers.save`, because the slot, its key and every inheriting agent's model are one change.
- Reuses the existing `.group > .card > .row-field` idiom throughout — label left, control beneath, same as every other settings row. One new class (`.row-field-action`) for the Test button's row.
- `voiceProviderId` deliberately gets **no** picker: nothing writes it today (not the panel, not a migration, not `selectChatProvider`), so it is `""` on every install and Voice always resolves through the legacy branch. `voiceProviders()` would offer a list of one, since OpenAI is the only `supportsVoice` entry. That is now recorded in a comment at the `PROTECTED_SETTING_KEYS` entry instead of being something the next reader has to re-derive.

## Testing

- Unit/integration: **1245 passed / 118 files** (baseline 1241 — the 4 added here). eslint 0, `tsc -b` 0, `npm run build` 0.
- New `AI Models section` block in `SettingsPanel.test.tsx`: exactly two groups and no "Other providers"; every provider present under API keys (asserted by field label, since provider names also appear in the Chat dropdown); the Chat slot is marked; every model field is in the models group and the old "Model ID" label is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)