### PR TITLE
Make an agent's model field honest about its provider

### DIFF
--- a/electron/main/ai/agents.test.ts
+++ b/electron/main/ai/agents.test.ts
@@ -280,6 +280,38 @@ describe("a blank model id resolves against the agent's own provider", () => {
     expect(createAgent({ name: "Researcher", prompt: "p" }).model).toBe("claude-haiku-4-5-20251001");
   });
 
+  // Before this, createAgent's INSERT omitted provider_id entirely, so every new agent started on
+  // "" no matter what was asked for — you had to create it, reopen it and switch, which then
+  // overwrote the model you had just typed.
+  it("pins a new agent to the provider it was created with, and takes that provider's model", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p", providerId: "anthropic" });
+
+    expect(created.provider_id).toBe("anthropic");
+    expect(created.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("keeps an explicit model when one is given alongside the provider", () => {
+    const created = createAgent({
+      name: "Researcher",
+      prompt: "p",
+      providerId: "openrouter",
+      model: "anthropic/claude-3.5-sonnet",
+    });
+
+    expect(created.provider_id).toBe("openrouter");
+    expect(created.model).toBe("anthropic/claude-3.5-sonnet");
+  });
+
+  it("defaults to following the Chat slot when no provider is named", () => {
+    expect(createAgent({ name: "Researcher", prompt: "p" }).provider_id).toBe("");
+  });
+
+  it("refuses an unknown provider id at create, not just at update", () => {
+    expect(() => createAgent({ name: "Researcher", prompt: "p", providerId: "not-a-provider" })).toThrow(
+      /is not a provider this app knows about/
+    );
+  });
+
   it("still refuses an unknown provider id rather than falling back to a default", () => {
     const created = createAgent({ name: "Researcher", prompt: "p" });
     expect(() => updateAgent(created.id, { providerId: "not-a-provider", model: "" })).toThrow(

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -181,6 +181,9 @@ export interface AgentCreateInput {
   tagline?: string;
   description?: string;
   model?: string;
+  /** Registry id this agent runs on, or "" / omitted to follow the Chat slot — the same meaning
+   * `provider_id` carries on the row and that updateAgent's patch uses. */
+  providerId?: string;
   prompt?: string;
 }
 
@@ -813,10 +816,17 @@ export function createAgent(input: AgentCreateInput): AgentRow {
   if (!name) {
     throw new Error("Agent name is required.");
   }
-  // A new agent follows the Chat slot, so a blank model means the model that slot is on right
-  // now — not the build's compile-time default, which is a different provider's id the moment
-  // the user has pointed Chat anywhere but OpenAI.
-  const model = input.model?.trim() || resolveAgentModel("");
+  // Empty means "follow the Chat slot"; anything else is checked against the registry, for the
+  // same reason updateAgent checks it — a row naming a provider this build has never heard of
+  // silently falls back at run time, so the refusal belongs at the write.
+  const providerId = input.providerId?.trim() ?? "";
+  if (providerId !== "" && !findProvider(providerId)) {
+    throw new Error(`"${providerId}" is not a provider this app knows about.`);
+  }
+  // A blank model means whatever this agent's own provider defaults to — the Chat slot's current
+  // model when it follows the slot, not the build's compile-time default, which is a different
+  // provider's id the moment the user has pointed Chat anywhere but OpenAI.
+  const model = input.model?.trim() || resolveAgentModel(providerId);
   if (!MODEL_ID_PATTERN.test(model)) {
     throw new Error(`"${model}" doesn't look like a valid model ID (expected "model" or "provider/model").`);
   }
@@ -828,8 +838,8 @@ export function createAgent(input: AgentCreateInput): AgentRow {
   const prompt = input.prompt?.trim() ?? "";
 
   db.prepare(
-    "INSERT INTO agents (id, name, icon, tagline, description, prompt, model, tools, enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
-  ).run(id, name, icon, tagline, description, prompt, model, "[]", 1);
+    "INSERT INTO agents (id, name, icon, tagline, description, prompt, model, tools, enabled, provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+  ).run(id, name, icon, tagline, description, prompt, model, "[]", 1, providerId);
 
   return db.prepare("SELECT * FROM agents WHERE id = ?").get(id) as AgentRow;
 }

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -624,6 +624,13 @@ export function registerAgentHandlers() {
     if (typeof input.name !== "string" || input.name.trim().length === 0) {
       throw new Error("agent:create requires a non-empty name");
     }
+    // Shape only — whether the id names a provider this build knows is createAgent's call, the
+    // same division agent:update uses.
+    for (const field of ["icon", "tagline", "description", "model", "providerId", "prompt"] as const) {
+      if (input[field] !== undefined && typeof input[field] !== "string") {
+        throw new Error(`agent:create input.${field} must be a string`);
+      }
+    }
     return createAgent(input);
   });
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -224,7 +224,7 @@ const agentsAPI = {
       tagline?: string;
       description?: string;
       model?: string;
-        providerId?: string;
+      providerId?: string;
       prompt?: string;
     }): Promise<AgentRow> => ipcRenderer.invoke("agent:create", input),
     orchestratorPrompt: (): Promise<string> => ipcRenderer.invoke("agent:orchestratorPrompt"),

--- a/src/components/molecules/AddAgentForm.tsx
+++ b/src/components/molecules/AddAgentForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
+import Combobox from "@/components/atoms/Combobox";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
+import { AI_PROVIDERS, findProvider } from "@/lib/providers";
 import { DEFAULT_ORCHESTRATOR_MODEL } from "@/lib/settings";
 
 interface AddAgentFormProps {
@@ -9,6 +11,7 @@ interface AddAgentFormProps {
     tagline?: string;
     description?: string;
     model?: string;
+    providerId?: string;
     prompt?: string;
   }) => Promise<unknown>;
   onCancel: () => void;
@@ -19,9 +22,20 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
   const [tagline, setTagline] = useState("");
   const [description, setDescription] = useState("");
   const [model, setModel] = useState(defaultModel);
+  const [providerId, setProviderId] = useState("");
   const [prompt, setPrompt] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  /** Moving the provider moves the model with it, the same way the accordion does for an agent
+   * that already exists — otherwise the field still holds the Chat slot's id, which the newly
+   * chosen provider has never heard of. A provider with no default of its own (`local`) leaves
+   * the field alone for the user to fill. */
+  const changeProvider = (nextProviderId: string) => {
+    setProviderId(nextProviderId);
+    const nextModel = nextProviderId === "" ? defaultModel : findProvider(nextProviderId)?.defaultChatModel;
+    if (nextModel) setModel(nextModel);
+  };
 
   const handleSubmit = async () => {
     const trimmedName = name.trim();
@@ -29,11 +43,12 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
     setSubmitting(true);
     setError(null);
     try {
-      await onCreate({ name: trimmedName, tagline, description, model, prompt });
+      await onCreate({ name: trimmedName, tagline, description, model, providerId, prompt });
       setName("");
       setTagline("");
       setDescription("");
       setModel(defaultModel);
+      setProviderId("");
       setPrompt("");
       onCancel();
     } catch (err) {
@@ -79,12 +94,31 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
           />
         </label>
         <label className="settings-field">
-          <span>Model ID</span>
+          <span>Provider</span>
+          <Combobox
+            value={providerId}
+            // "" first and always present: following the Chat slot is what an agent gets when
+            // nobody chooses, and the only way back once one has been picked.
+            options={[
+              { value: "", label: "Same as Chat" },
+              ...AI_PROVIDERS.map((provider) => ({ value: provider.id, label: provider.label })),
+            ]}
+            onChange={changeProvider}
+            ariaLabel="Provider for the new agent"
+            size="sm"
+          />
+        </label>
+        <label className="settings-field">
+          <span>
+            <span>Model ID</span>
+            <small>Leave blank to use {findProvider(providerId)?.defaultChatModel || defaultModel}</small>
+          </span>
           <input
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder={DEFAULT_ORCHESTRATOR_MODEL}
+            placeholder={findProvider(providerId)?.defaultChatModel || defaultModel || DEFAULT_ORCHESTRATOR_MODEL}
+            aria-label="Model ID"
             autoComplete="off"
           />
         </label>

--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -24,6 +24,10 @@ interface AgentAccordionProps {
   onChangeTagline?: (tagline: string) => void;
   onChangeDescription?: (description: string) => void;
   onChangeModel?: (model: string) => void;
+  /** What a blank Model ID resolves to for *this* agent — its provider's default, or the Chat
+   * model when it follows the slot. Shown as the placeholder and stated under the label, because
+   * a field advertising `gpt-4.1-mini` while the agent runs on Claude reads as a fact. */
+  modelPlaceholder?: string;
   /** Registry id this agent runs on, or "" to follow the Chat slot. Omitted for the
    * orchestrator, which *is* the Chat slot. */
   providerId?: string;
@@ -61,6 +65,7 @@ export default function AgentAccordion({
   tagline,
   description,
   model,
+  modelPlaceholder,
   providerId,
   onChangeProviderId,
   providerWarning,
@@ -248,7 +253,10 @@ export default function AgentAccordion({
           )}
           {onChangeModel !== undefined && (
             <label className="settings-field">
-              <span>Model ID</span>
+              <span>
+                <span>Model ID</span>
+                <small>Leave blank to use {modelPlaceholder || DEFAULT_ORCHESTRATOR_MODEL}</small>
+              </span>
               <input
                 type="text"
                 value={modelDraft}
@@ -259,7 +267,8 @@ export default function AgentAccordion({
                   if (modelDraft !== (model ?? "")) onChangeModel(modelDraft);
                 }}
                 onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-                placeholder={DEFAULT_ORCHESTRATOR_MODEL}
+                placeholder={modelPlaceholder || DEFAULT_ORCHESTRATOR_MODEL}
+                aria-label="Model ID"
                 autoComplete="off"
               />
             </label>

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -26,7 +26,7 @@ import { useHttpTools } from "@/hooks/useHttpTools";
 import { useUserContext } from "@/hooks/useUserContext";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { providerUrlWarning } from "@/lib/providerUrlWarning";
-import { AI_PROVIDERS, findProvider } from "@/lib/providers";
+import { AI_PROVIDERS, findProvider, modelBelongsToProvider } from "@/lib/providers";
 import { DEFAULT_SETTINGS_SECTION, sectionOnTransition } from "@/lib/settingsSection";
 import { SoundFxEvent, sfxPreviewSrc } from "@/hooks/useSoundFX";
 
@@ -290,7 +290,7 @@ export default function SettingsPanel({
    * agent must not take down a run it isn't part of. The cost is that the fallback is invisible,
    * so this is the surface that makes it visible where the user set it.
    */
-  const providerWarningFor = (providerId: string): string | undefined => {
+  const providerWarningFor = (providerId: string, model: string): string | undefined => {
     if (providerId === "") return undefined;
     const provider = findProvider(providerId);
     if (!provider) return `Unknown provider — this agent falls back to the Chat provider.`;
@@ -301,6 +301,12 @@ export default function SettingsPanel({
     }
     if (!row.apiUrl && !provider.baseUrl) {
       return `${provider.label} has no API URL — this agent falls back to the Chat provider.`;
+    }
+    // Credentials are fine, so the run reaches the provider — and is refused by it. Switching to
+    // a provider with no default model leaves the previous one's id in place (only the user knows
+    // which model they pulled onto a local server), and until now nothing said so.
+    if (!modelBelongsToProvider(providerId, model)) {
+      return `"${model}" doesn't look like a ${provider.label} model — this agent will likely fail on its first run.`;
     }
     return undefined;
   };
@@ -720,7 +726,13 @@ export default function SettingsPanel({
                           ...(nextModel ? { model: nextModel } : {}),
                         });
                       }}
-                      providerWarning={providerWarningFor(agent.provider_id)}
+                      providerWarning={providerWarningFor(agent.provider_id, agent.model)}
+                      // What a blank field would resolve to, so "leave it empty" is a stated
+                      // option rather than something the user has to discover. Mirrors
+                      // resolveAgentModel in electron/main/ai/agents.ts.
+                      modelPlaceholder={
+                        findProvider(agent.provider_id)?.defaultChatModel || settings.orchestratorModel
+                      }
                       onChangePrompt={(prompt) => onUpdateAgent(agent.id, { prompt })}
                       onChangeEnabled={(enabled) => onUpdateAgent(agent.id, { enabled })}
                       availableMcpServers={mcpServers}

--- a/src/globals.css
+++ b/src/globals.css
@@ -2238,6 +2238,16 @@ svg#oc {
   color: rgba(200, 230, 255, 0.65);
 }
 
+/* Same sub-label treatment the Models rows use (.group .card .row-field span small). Without the
+   block display it runs on inline and reads as "Model IDLeave blank to use gpt-4.1-mini". */
+.settings-field span small {
+  display: block;
+  font-size: 10.5px;
+  color: rgba(150, 190, 230, 0.55);
+  font-weight: 400;
+  margin-top: 2px;
+}
+
 /* The prompt label carries a "reset to default" control on its right when the prompt has been
    customised. Without this the button stacks under the label text, since .settings-field is a
    column and its spans are plain inline text everywhere else. */

--- a/src/lib/providers.test.ts
+++ b/src/lib/providers.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { AI_PROVIDERS, modelBelongsToProvider } from "./providers";
+
+/**
+ * The check is advisory — it drives a warning, never a refused write — so the bar is different
+ * from a validator's: a missed mismatch costs a warning nobody saw, a false one tells a user
+ * their working setup is broken. These cases pin both directions.
+ */
+describe("modelBelongsToProvider", () => {
+  describe("says nothing where a judgment would be guesswork", () => {
+    it("a blank model id — that means 'use the default'", () => {
+      expect(modelBelongsToProvider("anthropic", "")).toBe(true);
+      expect(modelBelongsToProvider("anthropic", "   ")).toBe(true);
+    });
+
+    it("an agent following the Chat slot — there is no provider to compare against", () => {
+      expect(modelBelongsToProvider("", "claude-haiku-4-5-20251001")).toBe(true);
+    });
+
+    it("an unrecognised provider — that has its own, more specific warning", () => {
+      expect(modelBelongsToProvider("not-a-provider", "gpt-4.1-mini")).toBe(true);
+    });
+
+    it("a local server, where the user names their own models", () => {
+      expect(modelBelongsToProvider("local", "llama3.1:8b")).toBe(true);
+      expect(modelBelongsToProvider("local", "anything-at-all")).toBe(true);
+    });
+  });
+
+  describe("accepts what each provider actually serves", () => {
+    it("OpenRouter's namespaced ids, with or without the ~latest marker", () => {
+      expect(modelBelongsToProvider("openrouter", "anthropic/claude-3.5-sonnet")).toBe(true);
+      expect(modelBelongsToProvider("openrouter", "~deepseek/deepseek-v4-flash-latest")).toBe(true);
+    });
+
+    it("Anthropic's claude-* ids", () => {
+      expect(modelBelongsToProvider("anthropic", "claude-haiku-4-5-20251001")).toBe(true);
+    });
+
+    it("OpenAI's chat, reasoning and audio families", () => {
+      for (const model of ["gpt-4.1-mini", "chatgpt-4o-latest", "o3-mini", "whisper-1", "tts-1"]) {
+        expect(modelBelongsToProvider("openai", model)).toBe(true);
+      }
+    });
+
+    it("every provider's own registry default", () => {
+      for (const provider of AI_PROVIDERS) {
+        expect(modelBelongsToProvider(provider.id, provider.defaultChatModel)).toBe(true);
+      }
+    });
+  });
+
+  describe("flags the mismatch that actually happens", () => {
+    // Switching an agent to a provider with no defaultChatModel leaves the previous provider's
+    // id in place, so this is the exact state a user lands in.
+    it("an OpenAI id pointed at Anthropic", () => {
+      expect(modelBelongsToProvider("anthropic", "gpt-4.1-mini")).toBe(false);
+    });
+
+    it("a Claude id pointed at OpenAI", () => {
+      expect(modelBelongsToProvider("openai", "claude-haiku-4-5-20251001")).toBe(false);
+    });
+
+    it("a bare id pointed at OpenRouter, which namespaces everything", () => {
+      expect(modelBelongsToProvider("openrouter", "gpt-4.1-mini")).toBe(false);
+    });
+
+    it("regardless of case", () => {
+      expect(modelBelongsToProvider("anthropic", "GPT-4.1-Mini")).toBe(false);
+    });
+  });
+});

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -149,3 +149,38 @@ export function inferProviderId(url: string): string {
 export function voiceProviders(): AiProvider[] {
   return AI_PROVIDERS.filter((provider) => provider.supportsVoice);
 }
+
+/**
+ * Whether a model id looks like one the given provider actually serves.
+ *
+ * Advisory only — it drives a warning, never a refused write. A model catalogue is not something
+ * this app holds, and OpenRouter alone lists hundreds, so the honest thing is a shape check that
+ * is confident about the obvious mismatches and silent about everything else.
+ *
+ * It exists because switching an agent to a provider with no `defaultChatModel` leaves the old
+ * provider's id in place — deliberately, since only the user knows which model they pulled onto a
+ * local server — and nothing said so. An agent reading "Local AI" while still naming
+ * `claude-haiku-4-5-20251001` looks configured and 404s on first use.
+ *
+ * Returns true wherever a judgment would be guesswork: a blank id (that means "use the default"),
+ * an agent following the Chat slot, an unrecognised provider (which has its own warning), and
+ * `local`, where any id can be legitimate because the user names their own models.
+ */
+export function modelBelongsToProvider(providerId: string, modelId: string): boolean {
+  const model = modelId.trim().toLowerCase();
+  if (model === "" || providerId === "" || !findProvider(providerId)) return true;
+
+  switch (providerId) {
+    // OpenRouter namespaces every id as `vendor/model`, optionally behind its `~latest` marker.
+    case "openrouter":
+      return model.includes("/") || model.startsWith("~");
+    case "anthropic":
+      return model.startsWith("claude");
+    // Their catalogue is families rather than a single prefix: chat (gpt-, chatgpt-), reasoning
+    // (o1/o3/o4-), and the audio models the Voice slot uses.
+    case "openai":
+      return /^(gpt-|chatgpt-|o\d+-|whisper-|tts-)/.test(model);
+    default:
+      return true;
+  }
+}


### PR DESCRIPTION
## What changed

Three gaps around the per-agent provider picker (which already shipped — this doesn't rebuild it):

**1. The placeholder lied.** Model ID always advertised `DEFAULT_ORCHESTRATOR_MODEL`, so an agent pinned to Claude still showed `gpt-4.1-mini` as its default. It now shows what a blank field would actually resolve to — the provider's own default, or the Chat model when the agent follows the slot — and states it under the label ("Leave blank to use …"). Mirrors `resolveAgentModel` in main.

**2. A stale model after a provider switch was invisible.** Switching an agent to a provider with no `defaultChatModel` (`local`) leaves the previous provider's id in place. That is deliberate — only the user knows which model they pulled onto their own server — but nothing said so, and an agent reading "Local AI" while still naming `claude-haiku-4-5-20251001` looks configured and 404s on first use. `providerWarningFor` now also flags a model that doesn't look like one the chosen provider serves.

**3. You couldn't pick a provider when creating an agent.** `AddAgentForm` had no provider field, and `createAgent`'s INSERT omitted `provider_id` entirely, so every new agent started on `""`. The flow was: create → reopen → switch provider → which then overwrote the model you had just typed. The form now carries the same picker the accordion uses, moving the model with the provider, and `createAgent` stores it — validated against the registry the way `updateAgent` already was.

Also: the preload already declared `providerId` on `agent:create`, but `AgentCreateInput` didn't have it and `createAgent` never read it. Now wired through, and `agent:create` type-checks its optional string fields the way `agent:update` does.

## On `modelBelongsToProvider`

Advisory only — it drives a warning, never a refused write. This app holds no model catalogue and OpenRouter alone lists hundreds, so it is a shape check that is confident about the obvious mismatches and silent about everything else. It returns `true` wherever a judgment would be guesswork: a blank id, an agent following the Chat slot, an unrecognised provider (which has its own warning), and `local`, where any id can be legitimate.

A false warning telling someone their working setup is broken is worse than a missed one, so the tests pin both directions.

## Testing

- Unit/integration: **1261 passed / 119 files** (baseline 1245). eslint 0, `tsc -b` 0, `npm run build` 0.
- New `src/lib/providers.test.ts` (12 cases): silence where a judgment would be guesswork; each provider's real id shapes accepted, including every registry default; and the mismatches that actually happen (OpenAI id at Anthropic, Claude id at OpenAI, bare id at OpenRouter, case-insensitively).
- New cases in `agents.test.ts`: a new agent pins to its provider and takes that provider's model; an explicit model survives; no provider still means "follow Chat"; an unknown provider id is refused at create, not only at update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)