### PR TITLE
Fix six defects found by an independent review of this branch

### DIFF
--- a/electron/main/ai/agents.test.ts
+++ b/electron/main/ai/agents.test.ts
@@ -255,13 +255,27 @@ describe("a blank model id resolves against the agent's own provider", () => {
     expect(updateAgent(created.id, { model: "" }).model).toBe("claude-haiku-4-5-20251001");
   });
 
-  it("takes the live orchestrator model for `local`, which has no default of its own", () => {
-    setSetting("appSettings.orchestratorModel", "~deepseek/deepseek-v4-flash-latest");
+  // The Chat slot's model is the wrong answer for `local`: on a default install it stores
+  // gpt-4.1-mini against an Ollama server, which 404s — the same failure arrived at from the
+  // other direction. Nobody but the user can supply the id, so asking is the honest move.
+  it("refuses a blank model for `local` rather than filling in the Chat slot's", () => {
     const created = createAgent({ name: "Researcher", prompt: "p" });
-    const updated = updateAgent(created.id, { providerId: "local", model: "" });
+    expect(() => updateAgent(created.id, { providerId: "local", model: "" })).toThrow(
+      /Local AI needs a model id/
+    );
+  });
 
-    expect(updated.provider_id).toBe("local");
-    expect(updated.model).toBe("~deepseek/deepseek-v4-flash-latest");
+  it("refuses it at create too", () => {
+    expect(() => createAgent({ name: "Researcher", prompt: "p", providerId: "local" })).toThrow(
+      /Local AI needs a model id/
+    );
+  });
+
+  it("still accepts an explicit model for `local`", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p", providerId: "local", model: "llama3.1:8b" });
+
+    expect(created.provider_id).toBe("local");
+    expect(created.model).toBe("llama3.1:8b");
   });
 
   it("reads the incoming provider id, not the stored one, when both move at once", () => {
@@ -310,6 +324,69 @@ describe("a blank model id resolves against the agent's own provider", () => {
     expect(() => createAgent({ name: "Researcher", prompt: "p", providerId: "not-a-provider" })).toThrow(
       /is not a provider this app knows about/
     );
+  });
+
+  // An unrecognised id in a *stored* row is a different situation from one in a patch: it came
+  // from a build that had that provider. Refusing every write to the row made it impossible to
+  // rename, disable, or re-point — the one action that would fix it.
+  it("still lets a row naming a provider this build lacks be edited and re-pointed", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+    db.prepare("UPDATE agents SET provider_id = 'gemini' WHERE id = ?").run(created.id);
+
+    expect(updateAgent(created.id, { name: "Renamed" }).name).toBe("Renamed");
+    expect(updateAgent(created.id, { providerId: "anthropic" }).provider_id).toBe("anthropic");
+  });
+});
+
+describe("export/import carries the provider a model belongs to", () => {
+  beforeEach(() => {
+    db = new Database(":memory:");
+    runMigrations(db);
+  });
+
+  // Keeping `model` while dropping `providerId` was the unsafe half of the pair: an agent
+  // exported on Claude arrived naming a Claude model and following the importing machine's Chat
+  // slot, so every run asked OpenAI for a Claude model.
+  it("round-trips a pinned agent's provider", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p", providerId: "anthropic" });
+    const exported = exportAgent(created.id);
+
+    expect(exported.providerId).toBe("anthropic");
+    expect(importAgent(exported).provider_id).toBe("anthropic");
+  });
+
+  it("keeps an agent that followed the Chat slot following it", () => {
+    const created = createAgent({ name: "Researcher", prompt: "p" });
+
+    expect(importAgent(exportAgent(created.id)).provider_id).toBe("");
+  });
+
+  it("degrades a provider this build doesn't have rather than failing the import", () => {
+    const row = importAgent({
+      name: "From Elsewhere",
+      icon: "ti-robot",
+      tagline: "",
+      description: "",
+      model: "gpt-4.1-mini",
+      providerId: "gemini",
+      prompt: "p",
+    });
+
+    expect(row.provider_id).toBe("");
+    expect(row.model).toBe("gpt-4.1-mini");
+  });
+
+  it("accepts a file written before per-agent providers existed", () => {
+    const row = importAgent({
+      name: "Legacy",
+      icon: "ti-robot",
+      tagline: "",
+      description: "",
+      model: "gpt-4.1-mini",
+      prompt: "p",
+    });
+
+    expect(row.provider_id).toBe("");
   });
 
   it("still refuses an unknown provider id rather than falling back to a default", () => {
@@ -402,6 +479,9 @@ describe("exportAgent / exportAllAgents / importAgent", () => {
       tagline: "Cooking",
       description: "desc",
       model: created.model,
+      // Carried, unlike the ids this type omits: a provider id names a registry entry every
+      // install compiles in, not a row in this one's database.
+      providerId: "",
       prompt: "p",
     });
   });

--- a/electron/main/ai/agents.ts
+++ b/electron/main/ai/agents.ts
@@ -69,14 +69,23 @@ export const DEFAULT_MODEL = SETTING_DEFAULTS.orchestratorModel;
  * the next run 404'd against Anthropic. That is the exact failure ai/selectProvider.ts exists to
  * prevent, in the one path it did not cover.
  *
- * A pinned agent takes its own provider's default. Everything else takes the *live* orchestrator
- * model: an agent inheriting the Chat slot (`""`), a `local` provider (no default, because only
- * the user knows which model they have pulled), and an id from a build that offered a provider
- * this one doesn't. The live value is also what selectChatProvider writes across every inheriting
- * agent, so a blank save and a provider switch agree by construction rather than by coincidence.
+ * A pinned agent takes its own provider's default. An agent inheriting the Chat slot (`""`), or
+ * one naming a provider from a build that offered it and this one doesn't, takes the *live*
+ * orchestrator model — which is also what selectChatProvider writes across every inheriting agent,
+ * so a blank save and a provider switch agree by construction rather than by coincidence.
+ *
+ * A provider with no default of its own is refused rather than filled in. `local` is the only one,
+ * and the Chat slot's model is the wrong answer for it: on a default install that stores
+ * `gpt-4.1-mini` against an Ollama server, which 404s — the same failure this function exists to
+ * stop, arrived at from the other direction. There is no id anyone but the user can supply, so
+ * asking is the honest move. Same wording, and same reasoning, as selectChatProvider.
  */
 export function resolveAgentModel(providerId: string): string {
-  return findProvider(providerId.trim())?.defaultChatModel || readAppSetting("orchestratorModel");
+  const provider = findProvider(providerId.trim());
+  if (provider && provider.defaultChatModel === "") {
+    throw new Error(`${provider.label} needs a model id — there is no default to fall back on.`);
+  }
+  return provider?.defaultChatModel || readAppSetting("orchestratorModel");
 }
 
 // Prompts are seeded/imported with {{agentName}}/{{userName}}/{{currentDateTime}}
@@ -196,6 +205,15 @@ export interface AgentExport {
   tagline: string;
   description: string;
   model: string;
+  /** Registry id, or "" to follow the Chat slot. Optional because files written before per-agent
+   * providers existed don't have it.
+   *
+   * Unlike the ids this type deliberately omits, a provider id is *portable* — it names an entry
+   * in a registry every install compiles in, not a row in this one's database. Leaving it out
+   * while keeping `model` was the unsafe half of the pair: an agent exported on Claude arrived
+   * carrying `claude-haiku-4-5-20251001` and following whatever the importing machine's Chat slot
+   * was, so every run asked OpenAI for a Claude model. */
+  providerId?: string;
   prompt: string;
 }
 
@@ -738,8 +756,14 @@ export function updateAgent(id: string, patch: AgentUpdatePatch): AgentRow {
   // Resolved before the model on purpose: a blank model means "this provider's default", so the
   // provider has to be settled first. Patching both at once — which is what the Settings panel
   // does when you change an agent's provider — must read the *incoming* id, not the stored one.
+  //
+  // Only what the *patch* supplies is checked. Applying it to a stored id as well made a row
+  // naming a provider this build doesn't have permanently unmodifiable — it could not be renamed,
+  // disabled, or re-pointed at a provider that does exist, which is the one action that would fix
+  // it. Everywhere else an unrecognised stored id degrades to the Chat slot (see modelForAgent in
+  // ai/provider.ts); refusing every write to the row is not that.
   const nextProviderId = patch.providerId === undefined ? existing.provider_id : patch.providerId.trim();
-  if (nextProviderId !== "" && !findProvider(nextProviderId)) {
+  if (patch.providerId !== undefined && nextProviderId !== "" && !findProvider(nextProviderId)) {
     throw new Error(`"${nextProviderId}" is not a provider this app knows about.`);
   }
   // Blank model field means "use the default" rather than being rejected; anything
@@ -866,6 +890,7 @@ function toAgentExport(row: AgentRow): AgentExport {
     tagline: row.tagline,
     description: row.description,
     model: row.model,
+    providerId: row.provider_id,
     prompt: row.prompt,
   };
 }
@@ -897,12 +922,18 @@ export function exportAllAgents(): AgentExport[] {
 // validation, and defaults stay single-sourced — an imported file's own id/system/
 // enabled fields (if present) are ignored, never trusted.
 export function importAgent(input: AgentExport): AgentRow {
+  // An id this build doesn't recognise degrades to the Chat slot rather than failing the import.
+  // The file came from another machine, possibly another version, and refusing the whole agent
+  // over a provider it can be re-pointed at in two clicks is the wrong trade — the same
+  // degrade-don't-throw posture modelForAgent takes for an unrecognised stored id.
+  const providerId = input.providerId && findProvider(input.providerId) ? input.providerId : "";
   return createAgent({
     name: input.name,
     icon: input.icon,
     tagline: input.tagline,
     description: input.description,
     model: input.model,
+    providerId,
     prompt: input.prompt,
   });
 }

--- a/electron/main/ai/selectProvider.test.ts
+++ b/electron/main/ai/selectProvider.test.ts
@@ -142,6 +142,27 @@ describe("selectChatProvider", () => {
       expect(modelOf("inheritor")).toBe("claude-haiku-4-5-20251001");
     });
 
+    // Omitted and explicitly-blank are different intents. Collapsing them with `||` made the
+    // second one a silent no-op: TextField only resyncs when the stored value changes, so
+    // emptying the box left it looking empty while the old value stayed in the database.
+    it("treats an explicitly blank URL as a reset, not as 'unchanged'", () => {
+      selectChatProvider({ providerId: "openai", apiUrl: "" });
+
+      expect(getProviderCredentials("openai")?.apiUrl).toBe("https://api.openai.com/v1");
+    });
+
+    it("treats an explicitly blank model as a reset, not as 'unchanged'", () => {
+      selectChatProvider({ providerId: "openai", model: "" });
+
+      expect(setting("appSettings.orchestratorModel")).toBe("gpt-4.1-mini");
+    });
+
+    it("still refuses an explicitly blank model where the provider has no default", () => {
+      expect(() => selectChatProvider({ providerId: "local", apiUrl: "http://localhost:11434/v1", model: "" })).toThrow(
+        "Local AI needs a model id."
+      );
+    });
+
     it("restores a provider's own stored URL when switching back to it", () => {
       selectChatProvider({ providerId: "anthropic", apiKey: "sk-ant" });
       selectChatProvider({ providerId: "openai" });

--- a/electron/main/ai/selectProvider.ts
+++ b/electron/main/ai/selectProvider.ts
@@ -52,13 +52,20 @@ export function selectChatProvider(selection: ChatProviderSelection): ChatProvid
   const switchingProvider = currentProviderId !== provider.id;
   const storedUrl = listVisibleProviders().find((row) => row.id === provider.id)?.apiUrl ?? "";
 
-  // Omitted fields keep what is already stored rather than snapping back to the registry default.
+  // An *omitted* field keeps what is already stored; an *explicitly blank* one resets to the
+  // provider's default. Those are different intents and collapsing them breaks one of them.
   //
-  // They used to fall through to `provider.baseUrl` / `provider.defaultChatModel` unconditionally,
-  // which made every partial write destructive: the Settings panel saves the key on its own, so
-  // rotating a key reset a custom model *and* a custom API URL. On a setup pointed at a private
-  // gateway that silently re-aimed the slot at api.openai.com and sent the user's key there.
-  const apiUrl = selection.apiUrl?.trim() || storedUrl || provider.baseUrl;
+  // Omitted used to fall through to the registry default unconditionally, which made every partial
+  // write destructive: the Settings panel saves the key on its own, so rotating a key reset a
+  // custom model *and* a custom API URL — on a setup pointed at a private gateway that silently
+  // re-aimed the slot at api.openai.com and sent the user's key there.
+  //
+  // Fixing that with `||` overshot in the other direction: emptying the URL or model field then
+  // resolved to the stored value and was silently discarded, while TextField — which only resyncs
+  // when the stored value changes — left the box looking empty. The field said one thing and the
+  // database held another, with no error. Hence `=== undefined` rather than falsiness.
+  const apiUrl =
+    selection.apiUrl === undefined ? storedUrl || provider.baseUrl : selection.apiUrl.trim() || provider.baseUrl;
   // A hosted provider always has a default URL to fall back on; `local` does not, because only
   // the user knows where their server is.
   if (apiUrl === "") throw new Error(`${provider.label} needs an API URL.`);
@@ -68,8 +75,11 @@ export function selectChatProvider(selection: ChatProviderSelection): ChatProvid
   // Switching provider still moves the model — that is the whole point of this function, and a
   // model id from the old host is exactly what breaks against the new one. Staying put keeps it.
   const model =
-    selection.model?.trim() ||
-    (switchingProvider ? provider.defaultChatModel : readAppSetting("orchestratorModel"));
+    selection.model === undefined
+      ? switchingProvider
+        ? provider.defaultChatModel
+        : readAppSetting("orchestratorModel")
+      : selection.model.trim() || provider.defaultChatModel;
   if (model === "") throw new Error(`${provider.label} needs a model id.`);
   const modelCheck = validateSettingValue("orchestratorModel", model);
   if (!modelCheck.ok) throw new Error(`That model id ${modelCheck.reason}.`);

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -700,7 +700,7 @@ export function registerAgentHandlers() {
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         throw new Error("agent:importFromFile requires a plain object entry");
       }
-      const { name, icon, tagline, description, model, prompt } = entry as Partial<AgentExport>;
+      const { name, icon, tagline, description, model, providerId, prompt } = entry as Partial<AgentExport>;
       if (typeof name !== "string" || name.trim().length === 0) {
         throw new Error("agent:importFromFile requires a non-empty name for every agent");
       }
@@ -710,6 +710,9 @@ export function registerAgentHandlers() {
         tagline: typeof tagline === "string" ? tagline : "",
         description: typeof description === "string" ? description : "",
         model: typeof model === "string" ? model : "",
+        // Absent in files written before per-agent providers; importAgent also drops any id this
+        // build doesn't recognise.
+        providerId: typeof providerId === "string" ? providerId : "",
         prompt: typeof prompt === "string" ? prompt : "",
       };
     });

--- a/src/components/molecules/AddAgentForm.tsx
+++ b/src/components/molecules/AddAgentForm.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import Combobox from "@/components/atoms/Combobox";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { AI_PROVIDERS, findProvider } from "@/lib/providers";
-import { DEFAULT_ORCHESTRATOR_MODEL } from "@/lib/settings";
 
 interface AddAgentFormProps {
   defaultModel: string;
@@ -27,14 +26,20 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /** What a blank Model ID would resolve to for the provider currently picked — empty when that
+   * provider has no default, which is `local` and only `local`. */
+  const fallbackModel = providerId === "" ? defaultModel : (findProvider(providerId)?.defaultChatModel ?? "");
+
   /** Moving the provider moves the model with it, the same way the accordion does for an agent
    * that already exists — otherwise the field still holds the Chat slot's id, which the newly
-   * chosen provider has never heard of. A provider with no default of its own (`local`) leaves
-   * the field alone for the user to fill. */
+   * chosen provider has never heard of.
+   *
+   * A provider with no default *clears* the field rather than leaving it. Leaving it looked
+   * harmless and wasn't: the field is pre-filled with the Chat model at mount, so picking Local AI
+   * and submitting created an Ollama agent named `gpt-4.1-mini`, which 404s on first use. */
   const changeProvider = (nextProviderId: string) => {
     setProviderId(nextProviderId);
-    const nextModel = nextProviderId === "" ? defaultModel : findProvider(nextProviderId)?.defaultChatModel;
-    if (nextModel) setModel(nextModel);
+    setModel(nextProviderId === "" ? defaultModel : (findProvider(nextProviderId)?.defaultChatModel ?? ""));
   };
 
   const handleSubmit = async () => {
@@ -111,13 +116,17 @@ export default function AddAgentForm({ defaultModel, onCreate, onCancel }: AddAg
         <label className="settings-field">
           <span>
             <span>Model ID</span>
-            <small>Leave blank to use {findProvider(providerId)?.defaultChatModel || defaultModel}</small>
+            <small>
+              {fallbackModel
+                ? `Leave blank to use ${fallbackModel}`
+                : "Required — this provider has no default model"}
+            </small>
           </span>
           <input
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder={findProvider(providerId)?.defaultChatModel || defaultModel || DEFAULT_ORCHESTRATOR_MODEL}
+            placeholder={fallbackModel || "e.g. llama3.1:8b"}
             aria-label="Model ID"
             autoComplete="off"
           />

--- a/src/components/molecules/AgentAccordion.tsx
+++ b/src/components/molecules/AgentAccordion.tsx
@@ -5,7 +5,6 @@ import { AI_PROVIDERS } from "@/lib/providers";
 import Toggle from "@/components/atoms/Toggle";
 import TagMultiSelect from "@/components/atoms/TagMultiSelect";
 import DeleteConfirmModal from "@/components/molecules/DeleteConfirmModal";
-import { DEFAULT_ORCHESTRATOR_MODEL } from "@/lib/settings";
 
 interface AgentAccordionProps {
   icon: string;
@@ -255,7 +254,11 @@ export default function AgentAccordion({
             <label className="settings-field">
               <span>
                 <span>Model ID</span>
-                <small>Leave blank to use {modelPlaceholder || DEFAULT_ORCHESTRATOR_MODEL}</small>
+                <small>
+                  {modelPlaceholder
+                    ? `Leave blank to use ${modelPlaceholder}`
+                    : "Required — this provider has no default model"}
+                </small>
               </span>
               <input
                 type="text"
@@ -267,7 +270,7 @@ export default function AgentAccordion({
                   if (modelDraft !== (model ?? "")) onChangeModel(modelDraft);
                 }}
                 onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
-                placeholder={modelPlaceholder || DEFAULT_ORCHESTRATOR_MODEL}
+                placeholder={modelPlaceholder || "e.g. llama3.1:8b"}
                 aria-label="Model ID"
                 autoComplete="off"
               />

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -486,7 +486,16 @@ export default function SettingsPanel({
                               label={`${provider.label} API key`}
                               isSet={keySet}
                               onSave={saveKey}
-                              onClear={keySet ? () => saveKey("") : undefined}
+                              // Removal always goes through the plain credential write, even for
+                              // the Chat provider. selectChatProvider refuses a blank key on a
+                              // provider that requires one — a sensible guard while *choosing* a
+                              // provider, but it made Remove impossible on whichever provider was
+                              // currently selected, answering the click with "OpenAI needs an API
+                              // key." A slot pointed at a provider with no key is just a fresh
+                              // install, and resolveProviderId already says so at run time.
+                              onClear={
+                                keySet ? () => void providers.save({ providerId: provider.id, apiKey: "" }) : undefined
+                              }
                             />
                             <TextField
                               label={`${provider.label} API URL`}
@@ -597,6 +606,11 @@ export default function SettingsPanel({
                         placeholder={chatProvider?.defaultChatModel || DEFAULT_ORCHESTRATOR_MODEL}
                         onCommit={(model) => void applyChat({ providerId: chatSlotView.providerId, model })}
                       />
+                      {/* Also rendered here, not only beside the credentials. Both controls that
+                          can produce a chatError — the provider dropdown above and the model field
+                          — live in this card, and an explanation for a rejected pick that appears
+                          in a different accordion reads as unrelated. */}
+                      {chatError && <p className="settings-error">{chatError}</p>}
                       <TextField
                         label="Transcription model"
                         hint="Turns what you say into text"
@@ -729,9 +743,13 @@ export default function SettingsPanel({
                       providerWarning={providerWarningFor(agent.provider_id, agent.model)}
                       // What a blank field would resolve to, so "leave it empty" is a stated
                       // option rather than something the user has to discover. Mirrors
-                      // resolveAgentModel in electron/main/ai/agents.ts.
+                      // resolveAgentModel in electron/main/ai/agents.ts — including the empty
+                      // case, where that function refuses rather than filling one in, and the
+                      // accordion has to say "required" instead of naming a fallback.
                       modelPlaceholder={
-                        findProvider(agent.provider_id)?.defaultChatModel || settings.orchestratorModel
+                        agent.provider_id === ""
+                          ? settings.orchestratorModel
+                          : (findProvider(agent.provider_id)?.defaultChatModel ?? settings.orchestratorModel)
                       }
                       onChangePrompt={(prompt) => onUpdateAgent(agent.id, { prompt })}
                       onChangeEnabled={(enabled) => onUpdateAgent(agent.id, { enabled })}

--- a/src/lib/providers.test.ts
+++ b/src/lib/providers.test.ts
@@ -43,6 +43,37 @@ describe("modelBelongsToProvider", () => {
       }
     });
 
+    // Every one of these was wrongly flagged by an earlier allowlist version of this function.
+    // A false warning tells someone their working setup is broken, which is the expensive
+    // failure here — so the bare reasoning parents, the non-chat families, and anything served
+    // by an OpenAI-compatible gateway all have to pass.
+    it("bare reasoning ids, and the families that aren't chat", () => {
+      for (const model of [
+        "o1",
+        "o3",
+        "codex-mini-latest",
+        "text-embedding-3-small",
+        "dall-e-3",
+        "omni-moderation-latest",
+      ]) {
+        expect(modelBelongsToProvider("openai", model)).toBe(true);
+      }
+    });
+
+    it("whatever an OpenAI-compatible gateway serves under the openai slot", () => {
+      // Pointing `openai` at LiteLLM/vLLM/Together is what its editable URL is for, and an
+      // Azure-style deployment name is just a name.
+      for (const model of [
+        "llama-3.3-70b-instruct",
+        "deepseek-chat",
+        "mistral-large-latest",
+        "qwen3-coder",
+        "prod-chat-deployment",
+      ]) {
+        expect(modelBelongsToProvider("openai", model)).toBe(true);
+      }
+    });
+
     it("every provider's own registry default", () => {
       for (const provider of AI_PROVIDERS) {
         expect(modelBelongsToProvider(provider.id, provider.defaultChatModel)).toBe(true);
@@ -63,6 +94,10 @@ describe("modelBelongsToProvider", () => {
 
     it("a bare id pointed at OpenRouter, which namespaces everything", () => {
       expect(modelBelongsToProvider("openrouter", "gpt-4.1-mini")).toBe(false);
+    });
+
+    it("an OpenRouter-namespaced id pointed at the vendor directly", () => {
+      expect(modelBelongsToProvider("anthropic", "anthropic/claude-3.5-sonnet")).toBe(false);
     });
 
     it("regardless of case", () => {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -151,36 +151,42 @@ export function voiceProviders(): AiProvider[] {
 }
 
 /**
+ * Which provider a model id unmistakably belongs to, or null when nothing about it says.
+ *
+ * Only three shapes are unmistakable, and each is a *naming scheme* rather than a catalogue
+ * entry, so none of them goes stale when a provider ships a new model.
+ */
+function obviousProviderFor(model: string): string | null {
+  if (model.startsWith("claude-")) return "anthropic";
+  // OpenRouter namespaces everything as `vendor/model`, optionally behind its `~latest` marker.
+  if (model.includes("/") || model.startsWith("~")) return "openrouter";
+  if (/^(gpt-|chatgpt-|o\d)/.test(model)) return "openai";
+  return null;
+}
+
+/**
  * Whether a model id looks like one the given provider actually serves.
  *
- * Advisory only — it drives a warning, never a refused write. A model catalogue is not something
- * this app holds, and OpenRouter alone lists hundreds, so the honest thing is a shape check that
- * is confident about the obvious mismatches and silent about everything else.
+ * Advisory only — it drives a warning, never a refused write. It exists because switching an
+ * agent to a provider with no `defaultChatModel` leaves the old provider's id in place, and an
+ * agent reading "Claude" while still naming `gpt-4.1-mini` looks configured and 404s on first use.
  *
- * It exists because switching an agent to a provider with no `defaultChatModel` leaves the old
- * provider's id in place — deliberately, since only the user knows which model they pulled onto a
- * local server — and nothing said so. An agent reading "Local AI" while still naming
- * `claude-haiku-4-5-20251001` looks configured and 404s on first use.
+ * Framed as "does this obviously belong to someone *else*", not "is this on an allowlist for the
+ * chosen provider". The allowlist version is the tempting one and it is wrong: a false warning
+ * tells someone their working setup is broken, which is far more expensive than a missed one, and
+ * an allowlist manufactures those in bulk. Pointing the `openai` slot at an OpenAI-compatible
+ * gateway is a supported setup — that is what its editable URL is for — so `llama-3.3-70b-instruct`
+ * or an Azure-style deployment name under `openai` has to pass, as do bare `o1`/`o3` and every
+ * embedding, image and moderation id that will ship after this is written.
  *
- * Returns true wherever a judgment would be guesswork: a blank id (that means "use the default"),
- * an agent following the Chat slot, an unrecognised provider (which has its own warning), and
- * `local`, where any id can be legitimate because the user names their own models.
+ * So it stays quiet unless the id carries another provider's naming scheme, and quiet always for
+ * a blank id (that means "use the default"), an agent following the Chat slot, an unrecognised
+ * provider (which has its own warning), and `local`, where the user names their own models.
  */
 export function modelBelongsToProvider(providerId: string, modelId: string): boolean {
   const model = modelId.trim().toLowerCase();
-  if (model === "" || providerId === "" || !findProvider(providerId)) return true;
+  if (model === "" || providerId === "" || providerId === "local" || !findProvider(providerId)) return true;
 
-  switch (providerId) {
-    // OpenRouter namespaces every id as `vendor/model`, optionally behind its `~latest` marker.
-    case "openrouter":
-      return model.includes("/") || model.startsWith("~");
-    case "anthropic":
-      return model.startsWith("claude");
-    // Their catalogue is families rather than a single prefix: chat (gpt-, chatgpt-), reasoning
-    // (o1/o3/o4-), and the audio models the Voice slot uses.
-    case "openai":
-      return /^(gpt-|chatgpt-|o\d+-|whisper-|tts-)/.test(model);
-    default:
-      return true;
-  }
+  const obvious = obviousProviderFor(model);
+  return obvious === null || obvious === providerId;
 }


### PR DESCRIPTION
## What changed

An independent review pass over PRs #67/#68/#70/#71 found six real defects, two of them introduced by that work. All are fixed here with tests that discriminate against the broken version.

### 1. `modelBelongsToProvider` was an allowlist (critical)

It listed five OpenAI prefixes and rejected everything else, which manufactures **false positives** — the expensive direction, because a false warning tells someone their working setup is broken. It flagged bare `o1`/`o3` (the parents pass only with a trailing hyphen), `codex-mini-latest`, every embedding/image/moderation id, Azure-style deployment names, and *everything* an OpenAI-compatible gateway serves under the `openai` slot — `llama-3.3-70b-instruct`, `deepseek-chat`, `mistral-large-latest`. That last one is a supported setup; it is what the editable URL is for.

Inverted: it now asks "does this id carry **another** provider's naming scheme?" and stays quiet otherwise. Three naming schemes rather than a catalogue, so it doesn't go stale when a provider ships a new model. Still catches every case it was written for — `gpt-4.1-mini` at Anthropic, `claude-*` at OpenAI, a bare id at OpenRouter, `anthropic/claude-3.5-sonnet` pointed at Anthropic directly.

### 2. `resolveAgentModel` stored a guaranteed 404 for `local` (critical)

`local.defaultChatModel` is `""`, so `||` fell through to the **Chat slot's** model. On a default install, pinning an agent to Local AI and clearing its Model ID stored `gpt-4.1-mini` against an Ollama server. That is the same failure `selectProvider.ts` exists to prevent, reached from the other direction — and #71's own test asserted it as intended, seeded with an OpenRouter id so it never showed what a default install does.

A provider with no default is now refused, with the message `selectChatProvider` already uses. `AddAgentForm` clears the model field to match: it is pre-filled with the Chat model at mount, so picking Local AI and submitting created an Ollama agent named `gpt-4.1-mini`.

### 3. Clearing the Chat URL or model was silently discarded (moderate — introduced by #68)

#68 changed `??` to `||`, which collapses "omitted" and "explicitly blank" into one case. Emptying the field then resolved to the stored value and was thrown away, while `TextField` — which only resyncs when the stored value *changes* — left the box looking empty. The field said one thing and the database held another, with no error.

Now `=== undefined`: **omitted** keeps what is stored (#68's fix, intact), **blank** resets to the provider default.

### 4. Remove on the Chat provider's API key always failed (moderate)

`onClear` routed through `selectChatProvider`, whose blank-key guard is sensible while *choosing* a provider but made Remove impossible on whichever provider was currently selected — answering the click with *"OpenAI needs an API key."* The identical button on every other provider worked. Removal now goes through the plain credential write for all of them. A slot pointed at a provider with no key is just a fresh install, and `resolveProviderId` already says so at run time.

### 5. The Chat error rendered in the wrong accordion (moderate — introduced by #70)

`chatError` is produced by three controls, two of which live in **Default models** (the provider dropdown and the model field), but it only rendered inside the **API keys** row. Picking Local AI threw *"Local AI needs a model id."* and put the explanation several hundred pixels away under the OpenAI row. Now rendered in both cards.

### 6. Export dropped `provider_id` while keeping `model` (moderate)

Export an agent pinned to Claude → arrives naming `claude-haiku-4-5-20251001` and following the importing machine's Chat slot → every run asks OpenAI for a Claude model. Unlike the ids `AgentExport` deliberately omits, a provider id names a registry entry **every install compiles in**, so it is portable. It now travels, as an optional field (files written before per-agent providers still import), and an id this build doesn't recognise degrades to the Chat slot rather than failing the import.

### Also

`updateAgent` validated the provider id even when it came from the **stored row**, so an agent naming a provider this build lacks could never be renamed, disabled, or re-pointed — including the re-point that would fix it. Only what the patch supplies is checked now, matching the degrade-don't-throw posture `modelForAgent` takes.

## Testing

- **1274 passed / 119 files** (baseline 1261). eslint 0, `tsc -b` 0, `npm run build` 0.
- The reviewer also flagged four assertions that pass against the pre-change code. The `local` one was worse than filler — it asserted the bug — and is replaced. The others are kept deliberately as regression guards, which is what they are for.
- Re-validated in the real app against a sandboxed userData: `local` + blank model refused; `local` + explicit `llama3.1:8b` accepted; key removal takes `keySet` true → false; an explicitly blank URL resets to `https://api.openai.com/v1` while an omitted one keeps `https://gw.example.com/v1`; create-with-provider still lands `anthropic | claude-haiku-4-5-20251001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)