### PR TITLE
Fix SSRF guard bypassed by redirect (KI-1)

### DIFF
--- a/electron/main/ai/httpTools.ts
+++ b/electron/main/ai/httpTools.ts
@@ -10,7 +10,7 @@ import {
   type HttpToolParam,
   type HttpToolRow,
 } from "../db/httpToolsStore";
-import { assertPublicHttpUrl } from "../net/urlSafety";
+import { safeFetch } from "../net/urlSafety";
 import { buildHttpRequest, toolParamsSchema, type HttpToolArgValue } from "./httpToolRequest";
 import { requiresApproval, type ApprovalPolicy } from "./approvalPolicy";
 import { readAppSetting } from "../appSettings";
@@ -68,21 +68,23 @@ async function executeHttpTool(
     bodyTemplate: row.body_template,
   });
 
-  if (collection.allow_private_hosts) {
-    assertHttpProtocol(request.url);
-  } else {
-    // Also re-checks DNS-resolved addresses, so a public-looking hostname that resolves
-    // into private space at request time is still refused (rebinding defense).
-    await assertPublicHttpUrl(request.url);
-  }
-
   devLog(`[http-tool] ${row.tool_name} -> ${request.method} ${request.url}`);
-  const response = await fetch(request.url, {
+  const fetchInit: RequestInit = {
     method: request.method,
     headers: request.headers,
     body: request.body,
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+  };
+  let response: Response;
+  if (collection.allow_private_hosts) {
+    assertHttpProtocol(request.url);
+    response = await fetch(request.url, fetchInit);
+  } else {
+    // Also re-checks DNS-resolved addresses, so a public-looking hostname that resolves
+    // into private space at request time is still refused (rebinding defense). safeFetch
+    // re-validates every redirect hop too, so a 302 to private space is caught as well.
+    response = await safeFetch(request.url, fetchInit);
+  }
 
   const raw = await response.text();
   const truncated = raw.length > MAX_RESPONSE_CHARS;

--- a/electron/main/ipc/httpTools.test.ts
+++ b/electron/main/ipc/httpTools.test.ts
@@ -22,7 +22,7 @@ vi.mock("../db/httpToolsStore", () => ({
 
 const buildHttpRequestMock = vi.hoisted(() => vi.fn());
 vi.mock("../ai/httpToolRequest", () => ({ buildHttpRequest: buildHttpRequestMock }));
-vi.mock("../net/urlSafety", () => ({ assertPublicHttpUrl: vi.fn() }));
+vi.mock("../net/urlSafety", () => ({ assertPublicHttpUrl: vi.fn(), safeFetch: vi.fn() }));
 
 import { ipcMain } from "electron";
 import { registerHttpToolHandlers } from "./httpTools";

--- a/electron/main/ipc/httpTools.ts
+++ b/electron/main/ipc/httpTools.ts
@@ -18,7 +18,7 @@ import {
   type HttpToolPatch,
 } from "../db/httpToolsStore";
 import { buildHttpRequest } from "../ai/httpToolRequest";
-import { assertPublicHttpUrl } from "../net/urlSafety";
+import { safeFetch } from "../net/urlSafety";
 
 export type { HttpToolCollectionRow, HttpToolRow, HttpToolParam } from "../db/httpToolsStore";
 
@@ -220,15 +220,17 @@ export function registerHttpToolHandlers() {
           collectionHeaders: input.headers,
           bodyTemplate: input.bodyTemplate,
         });
-        if (!input.allowPrivateHosts) {
-          await assertPublicHttpUrl(request.url);
-        }
-        const response = await fetch(request.url, {
+        const fetchInit: RequestInit = {
           method: request.method,
           headers: request.headers,
           body: request.body,
           signal: AbortSignal.timeout(15_000),
-        });
+        };
+        // safeFetch re-validates every redirect hop, so a 302 to private space is caught
+        // even though the initial URL passed assertPublicHttpUrl.
+        const response = input.allowPrivateHosts
+          ? await fetch(request.url, fetchInit)
+          : await safeFetch(request.url, fetchInit);
         const body = await response.text();
         return {
           ok: response.ok,

--- a/electron/main/ipc/sitemapDiscovery.test.ts
+++ b/electron/main/ipc/sitemapDiscovery.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../net/urlSafety", () => ({
   assertPublicHttpUrl: async (url: string) => new URL(url),
+  // Redirect-following behavior is covered by urlSafety.test.ts — here it's a passthrough
+  // so these tests can keep asserting against the plain global `fetch` mock.
+  safeFetch: async (url: string, init?: RequestInit) => (globalThis.fetch as typeof fetch)(url, init),
 }));
 
 import { fetchSitemapUrls } from "./sitemapDiscovery";

--- a/electron/main/ipc/sitemapDiscovery.ts
+++ b/electron/main/ipc/sitemapDiscovery.ts
@@ -1,4 +1,4 @@
-import { assertPublicHttpUrl } from "../net/urlSafety";
+import { safeFetch } from "../net/urlSafety";
 import { MAX_DISCOVERED_LINKS } from "./knowledgeUrlDiscovery";
 
 const SITEMAP_FETCH_TIMEOUT_MS = 10_000;
@@ -12,15 +12,12 @@ const MAX_CHILD_SITEMAPS = 20;
  * in this environment) — a direct guarded fetch keeps this independently testable without
  * depending on undocumented daemon internals. */
 async function guardedFetchText(url: string): Promise<string | null> {
-  try {
-    await assertPublicHttpUrl(url);
-  } catch {
-    return null;
-  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), SITEMAP_FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { signal: controller.signal });
+    // safeFetch validates the URL and re-validates every redirect hop, so a sitemap host
+    // that 302s to a private/metadata address is refused rather than followed blind.
+    const res = await safeFetch(url, { signal: controller.signal });
     if (!res.ok) return null;
     return await res.text();
   } catch {

--- a/electron/main/net/urlSafety.test.ts
+++ b/electron/main/net/urlSafety.test.ts
@@ -8,7 +8,7 @@ vi.mock("node:dns", () => ({
 }));
 
 import dns from "node:dns";
-import { assertPublicHttpUrl } from "./urlSafety";
+import { assertPublicHttpUrl, safeFetch } from "./urlSafety";
 
 describe("assertPublicHttpUrl", () => {
   afterEach(() => {
@@ -58,5 +58,59 @@ describe("assertPublicHttpUrl", () => {
 
   it("rejects an invalid URL string", async () => {
     await expect(assertPublicHttpUrl("not a url")).rejects.toThrow(/not a valid URL/);
+  });
+});
+
+describe("safeFetch", () => {
+  afterEach(() => {
+    vi.mocked(dns.promises.lookup).mockReset();
+    vi.mocked(dns.promises.lookup).mockImplementation(async () => Promise.reject(new Error("ENOTFOUND")));
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses a redirect to a private/metadata address instead of following it", async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    const fetchMock = vi.fn(async () =>
+      new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data/" } })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(safeFetch("https://example.com/redirector")).rejects.toThrow(/local\/private/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows a redirect to a public address and re-validates it", async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://example.com/final" } }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await safeFetch("https://example.com/redirector");
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual" });
+  });
+
+  it("caps the number of redirects it will follow", async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    const fetchMock = vi.fn(async () =>
+      new Response(null, { status: 302, headers: { location: "https://example.com/next" } })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(safeFetch("https://example.com/loop", {}, 2)).rejects.toThrow(/more than 2 redirects/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns a non-redirect response directly", async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    const fetchMock = vi.fn(async () => new Response("body", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await safeFetch("https://example.com/docs");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("body");
   });
 });

--- a/electron/main/net/urlSafety.ts
+++ b/electron/main/net/urlSafety.ts
@@ -100,3 +100,22 @@ export async function assertPublicHttpUrl(url: string): Promise<URL> {
 
   return parsed;
 }
+
+/** Node's fetch defaults to `redirect: "follow"`, which only ever runs assertPublicHttpUrl
+ * against the *first* URL — a remote host can 302 to a private/metadata address and the
+ * guard never sees it. This follows redirects manually, re-validating every hop, so the
+ * guard holds for the URL actually fetched from, not just the one the caller supplied. */
+export async function safeFetch(url: string, init: RequestInit = {}, maxRedirects = 5): Promise<Response> {
+  let currentUrl = url;
+  for (let hop = 0; ; hop++) {
+    await assertPublicHttpUrl(currentUrl);
+    const response = await fetch(currentUrl, { ...init, redirect: "manual" });
+    const isRedirect = response.status >= 300 && response.status < 400;
+    const location = response.headers.get("location");
+    if (!isRedirect || !location) return response;
+    if (hop >= maxRedirects) {
+      throw new Error(`Refusing to follow more than ${maxRedirects} redirects for "${url}"`);
+    }
+    currentUrl = new URL(location, currentUrl).toString();
+  }
+}


### PR DESCRIPTION
## Summary
- `assertPublicHttpUrl()` validated only the initial URL; `fetch()`'s default `redirect: "follow"` meant a `302` to a private/metadata address (e.g. `169.254.169.254`) was silently followed and the response returned to the model.
- Added `safeFetch()` in `electron/main/net/urlSafety.ts`, which follows redirects manually and re-validates every hop with `assertPublicHttpUrl`.
- Switched the three affected call sites to use it: `electron/main/ai/httpTools.ts`, `electron/main/ipc/httpTools.ts` (`testTool`, non-private-host branch), `electron/main/ipc/sitemapDiscovery.ts`.
- Out of scope, tracked separately: `ipc/httpTools.ts`'s missing protocol check when `allowPrivateHosts` is true (KI-12).

Finding KI-1 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 119 files / 1278 tests passed (4 new: `safeFetch` redirect-refuse, redirect-follow-and-revalidate, redirect-cap, non-redirect passthrough)
- [x] E2E: launched the app in a sandboxed userData dir, created an HTTP Tools collection against `jsonplaceholder.typicode.com`, hit **Test** — real `200 OK` with body returned, no console/log errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)