### PR TITLE
Fix getDb() caching a half-migrated handle when migrations throw (KI-3)

### DIFF
--- a/electron/main/db/index.test.ts
+++ b/electron/main/db/index.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const state = vi.hoisted(() => ({ userDataPath: "" }));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => state.userDataPath },
+}));
+
+const runMigrationsMock = vi.hoisted(() => vi.fn());
+vi.mock("./migrations", () => ({ runMigrations: runMigrationsMock }));
+
+let parent = "";
+
+beforeEach(() => {
+  vi.resetModules();
+  runMigrationsMock.mockReset();
+  parent = mkdtempSync(path.join(os.tmpdir(), "db-index-"));
+  state.userDataPath = path.join(parent, "OpenOrbit");
+  mkdirSync(path.join(state.userDataPath, "database"), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(parent, { recursive: true, force: true });
+});
+
+describe("getDb", () => {
+  // KI-3: `db` used to be assigned before runMigrations ran, so a throwing migration left
+  // the module-level singleton set to a half-migrated handle — every call after the first
+  // returned it silently via the `if (db) return db` guard instead of retrying.
+  it("does not cache the handle when migrations fail, so the next call retries", async () => {
+    runMigrationsMock.mockImplementationOnce(() => {
+      throw new Error("migration boom");
+    });
+    const { getDb } = await import("./index");
+
+    expect(() => getDb()).toThrow("migration boom");
+    expect(runMigrationsMock).toHaveBeenCalledTimes(1);
+
+    // Second call must attempt migrations again, not return a cached half-migrated db.
+    runMigrationsMock.mockImplementationOnce(() => {});
+    const db = getDb();
+    expect(runMigrationsMock).toHaveBeenCalledTimes(2);
+    expect(db).toBeTruthy();
+  });
+
+  it("caches the handle once migrations succeed", async () => {
+    runMigrationsMock.mockImplementation(() => {});
+    const { getDb } = await import("./index");
+
+    const first = getDb();
+    const second = getDb();
+    expect(second).toBe(first);
+    expect(runMigrationsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/main/db/index.ts
+++ b/electron/main/db/index.ts
@@ -31,19 +31,24 @@ export function getDb(): Database.Database {
   migrateLegacyDbLocation(path.join(getLegacyAppRoot(), "alex.db"), dbPath);
   migrateLegacyDbLocation(path.join(app.getPath("userData"), "alex.db"), dbPath);
   migrateLegacyDbLocation(path.join(getDatabaseDir(), "alex.db"), dbPath);
-  db = new Database(dbPath);
-  db.pragma("journal_mode = WAL");
+  // Assigned to a local first, and only promoted to the module-level singleton once
+  // runMigrations returns successfully — otherwise a migration that throws leaves `db`
+  // already set, and the `if (db) return db` guard above hands every subsequent call the
+  // half-migrated connection instead of retrying or failing loudly.
+  const opened = new Database(dbPath);
+  opened.pragma("journal_mode = WAL");
   // SQLite has FK enforcement off per-connection by default — without this, messages.conversation_id's
   // REFERENCES/ON DELETE CASCADE in the schema would silently not be enforced.
-  db.pragma("foreign_keys = ON");
+  opened.pragma("foreign_keys = ON");
   // Migration v31 re-points knowledge_files.path rows after an app rename moves the
   // knowledge-files directory. The paths are resolved here rather than inside migrations.ts,
   // which stays free of runtime imports so it can run against a bare in-memory database.
   const knowledgeFilesDir = getKnowledgeFilesDir();
   const knowledgeDirName = path.basename(knowledgeFilesDir);
-  runMigrations(db, {
+  runMigrations(opened, {
     knowledgeFilesDir,
     legacyKnowledgeFilesDirs: getLegacyAppRoots().map((legacyRoot) => path.join(legacyRoot, knowledgeDirName)),
   });
+  db = opened;
   return db;
 }


### PR DESCRIPTION
## Summary
- `electron/main/db/index.ts:34` assigned the module-level `db` singleton before `runMigrations` ran. If a migration threw, `db` was already set, so the `if (db) return db` guard handed every subsequent call the half-migrated connection — silently, with no retry and no re-throw.
- The first call surfaced the migration error (correct); every call after it looked fine and quietly read/wrote against a schema that could be missing tables or columns a later migration adds.
- Fix: hold the opened connection in a local (`opened`) through both pragma setup and `runMigrations`, and only assign it to the module-level `db` once migrations return successfully. A failure now leaves the singleton `null`, so the next `getDb()` call retries from scratch instead of reusing a broken connection.

Finding KI-3 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 120 files / 1284 tests passed (2 new in `db/index.test.ts`: a throwing migration doesn't get cached, and the next call retries; a successful migration does get cached and isn't re-run)
- [x] E2E: launched the app fresh (a fresh install is the strongest exercise of this exact code path — 37 migrations from zero) in a sandboxed userData dir. Booted clean to onboarding, no errors in `debug.log`, and `schema_migrations` shows all 37 rows applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)