### PR TITLE
Gate create_task/update_task behind approval for prompt tasks (KI-4)

### DIFF
--- a/electron/main/ai/tools/taskAgentTools.test.ts
+++ b/electron/main/ai/tools/taskAgentTools.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { promptTaskNeedsApproval } from "./taskAgentTools";
+
+describe("promptTaskNeedsApproval (backs create_task/update_task's needsApproval)", () => {
+  // KI-4: create_task ran unattended regardless of whether it carried a prompt, and a
+  // one-shot or recurring prompt task runs through a full orchestrator (MCP servers,
+  // connectors, HTTP tools all attached) at a time the conversation that created it may no
+  // longer be open — the same persistence risk update_agent's prompt field carries.
+  it("does not require approval for a plain reminder (no prompt)", () => {
+    expect(promptTaskNeedsApproval(null)).toBe(false);
+  });
+
+  it("requires approval for a prompt task, one-shot or recurring", () => {
+    expect(promptTaskNeedsApproval("Summarize my unread email")).toBe(true);
+  });
+});

--- a/electron/main/ai/tools/taskAgentTools.ts
+++ b/electron/main/ai/tools/taskAgentTools.ts
@@ -8,13 +8,23 @@ import { tool } from "@openai/agents";
 import { z } from "zod";
 import { createTask, deleteTask, listTasks, updateTask } from "../../db/tasksStore";
 
+/** Shared by create_task and update_task: a prompt task — one-shot or recurring — runs
+ * unattended through a full orchestrator (MCP servers, connectors, HTTP tools all attached,
+ * see tasks/scheduler.ts) at a time the conversation that created it may no longer be open.
+ * A plain reminder just fires a notification, so it carries none of that risk. Exported so
+ * the invariant is unit-testable without invoking the SDK's tool-calling machinery. */
+export function promptTaskNeedsApproval(prompt: string | null): boolean {
+  return prompt !== null;
+}
+
 export const createTaskTool = tool({
   name: "create_task",
   description:
     "Create a reminder or prompt task. Omit prompt for a plain reminder (fires a notification when due). " +
     "Set prompt for a task that runs through an agent when due — set recurrenceIntervalMs to make it repeat " +
     "every that many milliseconds after each run, or omit it for a one-shot run. recurrenceParams are dynamic " +
-    "values substituted into {{key}} placeholders in the prompt at run time.",
+    "values substituted into {{key}} placeholders in the prompt at run time. Creating a prompt task pauses for " +
+    "the user's approval; a plain reminder (no prompt) does not.",
   parameters: z.object({
     title: z.string().min(1),
     notes: z.string().nullable(),
@@ -27,6 +37,7 @@ export const createTaskTool = tool({
     recurrenceIntervalMs: z.number().nullable().describe("Repeat interval in milliseconds. Null = one-shot."),
     recurrenceParams: z.record(z.string(), z.string()).nullable(),
   }),
+  needsApproval: async (_ctx, { prompt }) => promptTaskNeedsApproval(prompt),
   execute: async ({ title, notes, dueAt, prompt, promptTargetAgentId, recurrenceIntervalMs, recurrenceParams }) => {
     const created = createTask({
       title,
@@ -62,7 +73,10 @@ export const listTasksTool = tool({
 
 export const updateTaskTool = tool({
   name: "update_task",
-  description: "Update an existing task's fields. Use list_tasks first to get its id. Only supplied fields change.",
+  description:
+    "Update an existing task's fields. Use list_tasks first to get its id. Only supplied fields change. " +
+    "Setting prompt pauses for the user's approval, same as create_task — otherwise a plain reminder could be " +
+    "turned into a prompt task without ever going through that gate.",
   parameters: z.object({
     id: z.string(),
     title: z.string().nullable(),
@@ -73,6 +87,10 @@ export const updateTaskTool = tool({
     recurrenceIntervalMs: z.number().nullable(),
     recurrenceParams: z.record(z.string(), z.string()).nullable(),
   }),
+  // Mirrors create_task's gate: without this, a plain reminder created unattended could be
+  // turned into a prompt task by a second, equally-unattended update_task call — the same
+  // outcome as create_task's needsApproval, reached one step later.
+  needsApproval: async (_ctx, { prompt }) => promptTaskNeedsApproval(prompt),
   execute: async ({ id, ...rest }) => {
     const patch: Parameters<typeof updateTask>[1] = {};
     if (rest.title !== null) patch.title = rest.title;


### PR DESCRIPTION
## Summary
- `create_task` ran unattended regardless of whether it carried a `prompt`. A one-shot or recurring prompt task runs through a full orchestrator (MCP servers, connectors, HTTP tools all attached — `tasks/scheduler.ts`) at a time the conversation that created it may no longer be open — the same persistence risk `update_agent`'s prompt field carried before KI-2.
- `create_task` now pauses for approval only when `prompt` is set. A plain reminder (no prompt, just a notification) stays unattended.
- `update_task` gets the identical gate on its `prompt` field — otherwise a plain reminder created unattended could be turned into a prompt task by a second, equally-unattended `update_task` call, bypassing the point of the `create_task` gate entirely.
- Extracted the shared predicate to `promptTaskNeedsApproval` so it's unit-testable without the SDK's tool-calling machinery.

Finding KI-4 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1286 tests passed (2 new: plain reminder doesn't require approval, prompt task does)
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`. (Conversational e2e of the approval-prompt UI itself is limited by the local test model's tool-calling reliability, same caveat noted in KI-2's PR — the gate mechanism is unit-tested and reuses the same shared, already-production interruption/approval loop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)