### PR TITLE
Handle interruptions in the scheduled task runner (KI-5)

### DIFF
--- a/electron/main/tasks/scheduler.test.ts
+++ b/electron/main/tasks/scheduler.test.ts
@@ -1,5 +1,78 @@
-import { describe, expect, it } from "vitest";
-import { computeNextRunAt, renderTaskPrompt } from "./scheduler";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const runMock = vi.hoisted(() => vi.fn());
+vi.mock("@openai/agents", () => ({ run: runMock }));
+
+const buildOrchestratorMock = vi.hoisted(() => vi.fn());
+vi.mock("../ai/agents", () => ({
+  buildOrchestrator: buildOrchestratorMock,
+  listAgents: vi.fn(() => []),
+}));
+
+const closeMcpServersMock = vi.hoisted(() => vi.fn());
+vi.mock("../ai/mcp", () => ({ closeMcpServers: closeMcpServersMock }));
+
+import { computeNextRunAt, renderTaskPrompt, runPromptTask } from "./scheduler";
+import type { TaskRow } from "../db/tasksStore";
+
+function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
+  return {
+    id: "task-1",
+    title: "Test task",
+    notes: null,
+    due_at: null,
+    status: "pending",
+    prompt: "Do the thing",
+    prompt_target_agent_id: null,
+    recurrence_interval_ms: null,
+    recurrence_params: "{}",
+    next_run_at: null,
+    last_run_at: null,
+    last_result: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const ORCHESTRATOR = { name: "Orbit" };
+
+beforeEach(() => {
+  runMock.mockReset();
+  closeMcpServersMock.mockReset();
+  buildOrchestratorMock.mockReset();
+  buildOrchestratorMock.mockResolvedValue({ agent: ORCHESTRATOR, mcpServers: [], allAgents: [ORCHESTRATOR] });
+});
+
+// KI-5: a scheduled task's run() call previously never inspected result.interruptions, so a
+// call to an approval-gated tool (an HTTP write, update_agent's prompt field, create_task —
+// see KI-2/KI-4) stopped the run and left finalOutput undefined, silently recorded as "".
+describe("runPromptTask", () => {
+  it("returns the final output when nothing needs approval", async () => {
+    runMock.mockResolvedValue({ finalOutput: "All done.", interruptions: [] });
+    const output = await runPromptTask(makeTask());
+    expect(output).toBe("All done.");
+    expect(closeMcpServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("declines every interruption and returns an explicit blocked message instead of finalOutput", async () => {
+    const rejectMock = vi.fn();
+    const interruption = { rawItem: { name: "send_email", callId: "call-1" } };
+    runMock.mockResolvedValue({
+      finalOutput: undefined,
+      interruptions: [interruption],
+      state: { reject: rejectMock },
+    });
+
+    const output = await runPromptTask(makeTask());
+
+    expect(rejectMock).toHaveBeenCalledTimes(1);
+    expect(rejectMock).toHaveBeenCalledWith(interruption, expect.objectContaining({ message: expect.any(String) }));
+    expect(output).toContain("Blocked");
+    expect(output).toContain("send_email");
+    expect(output).not.toBe("");
+  });
+});
 
 describe("renderTaskPrompt", () => {
   it("substitutes known placeholders from params", () => {

--- a/electron/main/tasks/scheduler.ts
+++ b/electron/main/tasks/scheduler.ts
@@ -14,6 +14,7 @@ import { closeMcpServers } from "../ai/mcp";
 import { getDueTasks, recordTaskRun, TaskRow } from "../db/tasksStore";
 import { devLog } from "../devLog";
 import { parseStringMap } from "../db/jsonColumn";
+import { extractApprovalMeta } from "../ai/runItemMeta";
 
 const POLL_INTERVAL_MS = 30_000;
 // Truncated in the OS notification body so a long agent reply doesn't overflow the
@@ -64,7 +65,9 @@ function notify(title: string, body: string): void {
   new Notification({ title, body: body.slice(0, NOTIFICATION_BODY_MAX_LENGTH) }).show();
 }
 
-async function runPromptTask(task: TaskRow): Promise<string> {
+/** Exported for testing — the interruption/auto-reject handling below is the KI-5 fix and is
+ * otherwise only reachable through the poll loop's setInterval callback. */
+export async function runPromptTask(task: TaskRow): Promise<string> {
   const { agent: orchestrator, mcpServers, allAgents } = await buildOrchestrator();
   try {
     let runTarget = orchestrator;
@@ -83,6 +86,25 @@ async function runPromptTask(task: TaskRow): Promise<string> {
     });
     devLog(`[taskScheduler] running task id=${task.id} target=${runTarget.name}`);
     const result = await run(runTarget, prompt);
+
+    // A headless run has no renderer to show the approval UI ipc/agent.ts's interactive path
+    // uses — result.interruptions was previously never inspected here, so a call to an
+    // approval-gated tool (an HTTP write, update_agent's prompt field, create_task) stopped
+    // the run and left finalOutput undefined, which this returned as "" — recorded as a
+    // completed run with no signal the work never happened. There is no user to ask, so this
+    // declines the call(s) rather than leaving the run stuck, and says so explicitly instead
+    // of reading as a model that had nothing to say.
+    if (result.interruptions.length > 0) {
+      const toolNames = result.interruptions.map((i) => extractApprovalMeta(i).toolName ?? "(unknown)");
+      for (const interruption of result.interruptions) {
+        result.state.reject(interruption, {
+          message: "Scheduled tasks run unattended and cannot ask for approval — this call was declined automatically.",
+        });
+      }
+      devLog(`[taskScheduler] task id=${task.id} blocked on approval-gated tool(s): ${toolNames.join(", ")}`);
+      return `Blocked — needs your approval for: ${toolNames.join(", ")}. Run this task interactively in chat instead.`;
+    }
+
     return result.finalOutput ?? "";
   } finally {
     await closeMcpServers(mcpServers);


### PR DESCRIPTION
## Summary
- `runPromptTask` in `tasks/scheduler.ts` called `run(runTarget, prompt)` and read `result.finalOutput ?? ""`, never inspecting `result.interruptions`. The approval-loop that handles interruptions lives only in the interactive path (`ipc/agent.ts`), which has a renderer to prompt.
- A scheduled task that reaches an approval-gated tool — an HTTP write, `update_agent`'s prompt field, `create_task` (KI-2/KI-4 both added gates this run can now hit) — stopped at the interruption and returned no final output. That surfaced as `notify(task.title, "(no response)")`, with the task recorded as having run successfully. No signal it was blocked, or that the work never happened.
- Fix: `runPromptTask` now checks `result.interruptions` after the run. Since a headless run has no renderer and no user to ask, it declines every interruption explicitly (`result.state.reject`) and returns a message naming the blocked tool(s), instead of resuming or silently returning empty output. `last_result` and the OS notification both say what actually happened.

Finding KI-5 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1288 tests passed (2 new in `scheduler.test.ts`: a normal run still returns `finalOutput`; an interrupted run rejects every interruption and returns an explicit "Blocked — ..." message naming the tool)
- [x] E2E: launched the app fresh in a sandboxed userData dir — the task scheduler starts on app launch, clean boot, no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)