### PR TITLE
Fix unreachable SIGKILL escalation for the search daemon (KI-6)

### DIFF
--- a/electron/main/ai/webSearchDaemon.test.ts
+++ b/electron/main/ai/webSearchDaemon.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 
 type SpawnOptions = { env: Record<string, string>; stdio: unknown };
-type MockChild = EventEmitter & { kill: () => void; killed: boolean; stderr: EventEmitter };
+type MockChild = EventEmitter & {
+  kill: (signal?: string) => void;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: string | null;
+  stderr: EventEmitter;
+};
 
 // Typed on the mock rather than its implementation so `.mock.calls[0][2].env` is typed
 // without declaring parameters the fake child never reads.
@@ -10,6 +16,10 @@ const spawnMock = vi.fn<(command: string, args: string[], options: SpawnOptions)
   const child = new EventEmitter() as MockChild;
   child.kill = vi.fn();
   child.killed = false;
+  // Node's real ChildProcess sets these to non-null only once the process has actually
+  // exited — killed is a red herring, set true as soon as a signal is *sent*, not received.
+  child.exitCode = null;
+  child.signalCode = null;
   // The daemon's stderr is piped and forwarded to devLog, so the fake child needs one.
   child.stderr = new EventEmitter();
   return child;
@@ -275,5 +285,58 @@ describe("startExplorerDaemon browser fallback config", () => {
     child.stderr.emit("data", Buffer.from("\n"));
 
     expect(devLogMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("stopExplorerDaemon", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    spawnMock.mockClear();
+    resolveMock.mockReset().mockImplementation((specifier: string) =>
+      specifier.startsWith("playwright-core") ? "/fake/playwright-core/package.json" : "/fake/open-websearch/package.json"
+    );
+    existsSyncMock.mockReset().mockReturnValue(false);
+    fetchMock.mockReset().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // KI-6: child.killed is set to true as soon as SIGTERM is *sent*, not once the process has
+  // actually exited — so `if (!child.killed)` was always false and SIGKILL could never fire.
+  it("escalates to SIGKILL after the grace period when the process ignored SIGTERM", async () => {
+    const { startExplorerDaemon, stopExplorerDaemon } = await import("./webSearchDaemon");
+    await startExplorerDaemon();
+    const child = spawnMock.mock.results[0].value as MockChild;
+
+    stopExplorerDaemon();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    // Still alive — SIGTERM was sent but the process hasn't exited (unlike child.killed,
+    // which the old, buggy check relied on and which is already true at this point).
+    child.exitCode = null;
+    child.signalCode = null;
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("does not escalate when the process already exited from SIGTERM", async () => {
+    const { startExplorerDaemon, stopExplorerDaemon } = await import("./webSearchDaemon");
+    await startExplorerDaemon();
+    const child = spawnMock.mock.results[0].value as MockChild;
+
+    stopExplorerDaemon();
+    // The process exited in response to SIGTERM before the grace period elapsed.
+    child.exitCode = null;
+    child.signalCode = "SIGTERM";
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
   });
 });

--- a/electron/main/ai/webSearchDaemon.ts
+++ b/electron/main/ai/webSearchDaemon.ts
@@ -193,7 +193,11 @@ export function stopExplorerDaemon(): void {
   daemonReady = null;
   child.kill("SIGTERM");
   setTimeout(() => {
-    if (!child.killed) child.kill("SIGKILL");
+    // child.killed is set to true as soon as a signal is successfully *sent*, not when the
+    // process actually exits — checking it here meant this branch could never run, since
+    // SIGTERM above already set it. exitCode/signalCode are both null only while the process
+    // is still alive, so this is the check that actually reflects whether SIGTERM worked.
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
   }, STOP_GRACE_PERIOD_MS);
 }
 


### PR DESCRIPTION
## Summary
- `stopExplorerDaemon` (`ai/webSearchDaemon.ts:195-197`) checked `if (!child.killed)` before escalating to `SIGKILL`. Node sets `ChildProcess.killed` to `true` as soon as a signal is *successfully sent*, not when the process actually exits — and `child.kill("SIGTERM")` right above already set it. The `SIGKILL` branch could therefore never execute.
- A daemon that ignores or is wedged past `SIGTERM` (and any headless browser it spawned) survived app quit indefinitely — the grace period was doing nothing.
- Fix: check `child.exitCode === null && child.signalCode === null` instead, which are the fields that actually stay non-null only once the process has exited.

Finding KI-6 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1290 tests passed (2 new: escalates to SIGKILL when the process is still alive after the grace period; does not escalate when it already exited from SIGTERM)
- [x] E2E: launched the app fresh in a sandboxed userData dir — the daemon starts for real (a real Chrome-backed Playwright client resolved), clean boot, no errors. The 3-second SIGTERM-then-SIGKILL race against a hypothetically hung process isn't practically observable against the real daemon binary in an e2e pass — the fake-timer unit tests are the correct verification tool for this specific timing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)