### PR TITLE
Add error listener to the spawned search daemon (KI-7)

### DIFF
--- a/electron/main/ai/webSearchDaemon.test.ts
+++ b/electron/main/ai/webSearchDaemon.test.ts
@@ -286,6 +286,20 @@ describe("startExplorerDaemon browser fallback config", () => {
 
     expect(devLogMock).not.toHaveBeenCalled();
   });
+
+  // KI-7: an EventEmitter throws an uncaught exception when an 'error' event fires with no
+  // listener. A ChildProcess that fails to spawn (ENOENT, EACCES, EAGAIN) emits exactly that,
+  // so an unspawnable daemon crashed the main process instead of degrading gracefully.
+  it("does not throw when the spawned process emits an error", async () => {
+    const { startExplorerDaemon } = await import("./webSearchDaemon");
+    // startExplorerDaemon's own promise is unaffected by this — it awaits waitForHealthy,
+    // which the fetch mock in this suite already resolves as healthy regardless.
+    await startExplorerDaemon();
+
+    const child = spawnMock.mock.results[0].value as MockChild;
+    expect(() => child.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+    expect(devLogMock).toHaveBeenCalledWith(expect.stringContaining("spawn ENOENT"));
+  });
 });
 
 describe("stopExplorerDaemon", () => {

--- a/electron/main/ai/webSearchDaemon.ts
+++ b/electron/main/ai/webSearchDaemon.ts
@@ -160,6 +160,12 @@ export function startExplorerDaemon(): Promise<void> {
       // fallback that quietly stopped resolving looked identical to one that was working.
       stdio: ["ignore", "ignore", "pipe"],
     });
+    // A ChildProcess that fails to spawn (ENOENT, EACCES, EAGAIN under process pressure)
+    // emits 'error', and Node throws an uncaught exception for an 'error' event with no
+    // listener. Without this, an unspawnable daemon crashed the main process instead of
+    // degrading to the "log and carry on" behavior the surrounding comments describe —
+    // waitForHealthy below still times out and surfaces normally.
+    child.on("error", (e) => devLog(`[open-websearch] failed to spawn: ${e.message}`));
     child.stderr?.on("data", (chunk: Buffer) => {
       // One chunk routinely carries many lines, and devLog writes synchronously — so every line
       // kept here is an appendFileSync on the main process thread. A single failed Bing request


### PR DESCRIPTION
## Summary
- `spawn()` in `startExplorerDaemon` was followed only by a `child.stderr.on("data", ...)` handler — no `child.on("error", ...)` was registered.
- A `ChildProcess` that fails to spawn (ENOENT, EACCES, EAGAIN under process pressure) emits an `'error'` event, and Node throws an uncaught exception for an `'error'` event with no listener.
- An unspawnable daemon therefore crashed the main process, instead of degrading to the "log and carry on" behavior the surrounding comments already describe.
- Fix: `child.on("error", (e) => devLog(...))`. `waitForHealthy` still times out and surfaces normally in that case — this only stops the crash.

Finding KI-7 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1291 tests passed (1 new: emitting `'error'` on the spawned child no longer throws, and is logged)
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)