### PR TITLE
Fix daemon start leaking child and poisoning daemonReady (KI-8)

### DIFF
--- a/electron/main/ai/webSearchDaemon.test.ts
+++ b/electron/main/ai/webSearchDaemon.test.ts
@@ -302,6 +302,51 @@ describe("startExplorerDaemon browser fallback config", () => {
   });
 });
 
+describe("startExplorerDaemon health-check failure recovery", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    spawnMock.mockClear();
+    resolveMock.mockReset().mockImplementation((specifier: string) =>
+      specifier.startsWith("playwright-core") ? "/fake/playwright-core/package.json" : "/fake/open-websearch/package.json"
+    );
+    existsSyncMock.mockReset().mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // KI-8: daemonProcess/daemonPort/daemonReady were all assigned before waitForHealthy, so a
+  // health-check timeout left every one of them set — `if (daemonReady) return daemonReady`
+  // then handed every future call the same rejection forever, with the orphaned child still
+  // running. This asserts both halves: the failed child is killed, and a fresh call retries
+  // (spawns again) instead of reusing the dead promise.
+  it("kills the orphaned child and lets the next call retry after a health-check timeout", async () => {
+    fetchMock.mockReset().mockResolvedValue({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+    const { startExplorerDaemon } = await import("./webSearchDaemon");
+
+    const firstAttempt = startExplorerDaemon();
+    // Swallow the rejection here so it doesn't count as an unhandled promise rejection while
+    // the timers below advance — the assertion on it happens after.
+    firstAttempt.catch(() => {});
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(firstAttempt).rejects.toThrow(/did not become healthy/);
+
+    const firstChild = spawnMock.mock.results[0].value as MockChild;
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+    // Second call must spawn a new child rather than returning the same dead promise.
+    fetchMock.mockReset().mockResolvedValue({ ok: true });
+    const secondAttempt = startExplorerDaemon();
+    await vi.advanceTimersByTimeAsync(300);
+    await expect(secondAttempt).resolves.toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("stopExplorerDaemon", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/electron/main/ai/webSearchDaemon.ts
+++ b/electron/main/ai/webSearchDaemon.ts
@@ -184,7 +184,19 @@ export function startExplorerDaemon(): Promise<void> {
     });
     daemonProcess = child;
     daemonPort = port;
-    await waitForHealthy(port);
+    try {
+      await waitForHealthy(port);
+    } catch (e) {
+      // A health-check timeout previously left daemonProcess/daemonPort/daemonReady all set,
+      // so `if (daemonReady) return daemonReady` on the next call returned this same
+      // rejection forever — no retry possible for the rest of the session, and the child kept
+      // running, orphaned. Kill it and null out every field so the next call starts fresh.
+      child.kill("SIGKILL");
+      daemonProcess = null;
+      daemonPort = null;
+      daemonReady = null;
+      throw e;
+    }
   })();
 
   return daemonReady;


### PR DESCRIPTION
## Summary
- `startExplorerDaemon` assigned `daemonProcess`/`daemonPort` before `await waitForHealthy(port)`. If the health check timed out (15s), the promise rejected with the child still running and still referenced, and `daemonReady` was left holding that rejected promise.
- `if (daemonReady) return daemonReady` on the next call then returned the same rejection to every future caller — no retry possible for the rest of the session, and the orphaned daemon process (and any headless browser it spawned) kept running.
- Fix: the health-check failure path now kills the child and nulls `daemonProcess`/`daemonPort`/`daemonReady` before re-throwing, so the next call starts fresh instead of reusing the dead promise.

Finding KI-8 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1292 tests passed (1 new, with fake timers: a health-check timeout kills the orphaned child and lets a subsequent call spawn a fresh attempt rather than reusing the dead promise)
- [x] E2E: launched the app fresh in a sandboxed userData dir — the real daemon starts and becomes healthy normally, clean boot, no errors in `debug.log`. The 15-second health-check-timeout race isn't practically reproducible against the real daemon binary in an e2e pass; the fake-timer unit test is the correct tool for this timing behavior (same reasoning as KI-6's PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)