### PR TITLE
Handle daemon startup rejection at the call site (KI-9)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -132,7 +132,10 @@ app.whenReady().then(() => {
   registerAppInfoHandlers();
   // Fire-and-forget: Explorer's tools await getExplorerDaemonPort() themselves, so a
   // slow/failed daemon start doesn't block app launch — it just fails that tool call later.
-  void startExplorerDaemon();
+  // The .catch is required, not optional: Node's default disposition for an unhandled
+  // rejection is to terminate the process, so a health-check timeout here (see KI-8) could
+  // take the whole app down at launch on a path this comment already says is non-blocking.
+  startExplorerDaemon().catch((e) => devLog(`[startExplorerDaemon] failed to start: ${e instanceof Error ? e.message : String(e)}`));
   startTaskScheduler();
   createWindow();
 


### PR DESCRIPTION
## Summary
- `main/index.ts:135` called `void startExplorerDaemon();`, discarding the promise with no rejection handler.
- Combined with a health-check timeout (KI-8), this produces an unhandled promise rejection during app startup. Node's default disposition for an unhandled rejection since v15 is to terminate the process — so a slow or unavailable search daemon could take the whole app down at launch, on a path the surrounding comment already describes as deliberately non-blocking.
- Fix: `startExplorerDaemon().catch((e) => devLog(...))` — the fire-and-forget intent was always there, it just needed the `.catch` to actually be one.

Finding KI-9 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 121 files / 1292 tests passed (no behavior to unit-test here — `main/index.ts` is the bootstrap file with no existing test harness; verification is the build/e2e below)
- [x] E2E: launched the app fresh in a sandboxed userData dir through the exact modified line — clean boot, no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)