### PR TITLE
Fix OAuth credentials with no expires_in treated as never-expiring (KI-10)

### DIFF
--- a/electron/main/connectors/gmailConnector.test.ts
+++ b/electron/main/connectors/gmailConnector.test.ts
@@ -44,9 +44,22 @@ describe("ensureFreshCredentials", () => {
     vi.useRealTimers();
   });
 
-  it("returns the credentials unchanged when there's no expiry recorded", async () => {
+  // KI-10: a missing expiresAt used to mean "never expires" — a token response omitting
+  // expires_in converted into a credential that never refreshed again. Now treated as
+  // expired (refresh before use), the safe direction for "unknown".
+  it("refreshes when there's no expiry recorded, rather than treating it as valid forever", async () => {
+    refreshAccessTokenMock.mockResolvedValue({ accessToken: "at-2", expiresAt: Date.now() + 3600_000 });
+    const credentials = { accessToken: "at-1", refreshToken: "rt-1" };
+
+    const fresh = await ensureFreshCredentials(credentials);
+
+    expect(fresh.accessToken).toBe("at-2");
+    expect(refreshAccessTokenMock).toHaveBeenCalled();
+  });
+
+  it("throws instead of refreshing when there's no expiry recorded and no refresh token", async () => {
     const credentials = { accessToken: "at-1" };
-    expect(await ensureFreshCredentials(credentials)).toBe(credentials);
+    await expect(ensureFreshCredentials(credentials)).rejects.toThrow(/reconnect Gmail/);
     expect(refreshAccessTokenMock).not.toHaveBeenCalled();
   });
 
@@ -105,7 +118,7 @@ describe("testGmailConnection", () => {
       ok: true,
       json: async () => ({ emailAddress: "user@gmail.com" }),
     });
-    const result = await testGmailConnection({ accessToken: "at-1" });
+    const result = await testGmailConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: "user@gmail.com" });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/profile"),
@@ -119,7 +132,9 @@ describe("testGmailConnection", () => {
       status: 401,
       text: async () => "Unauthorized",
     });
-    await expect(testGmailConnection({ accessToken: "at-bad" })).rejects.toThrow(/401/);
+    await expect(testGmailConnection({ accessToken: "at-bad", expiresAt: Date.now() + 3600_000 })).rejects.toThrow(
+      /401/
+    );
   });
 
   it("uses a refreshed token when the stored credentials are expired", async () => {

--- a/electron/main/connectors/googleCalendarConnector.test.ts
+++ b/electron/main/connectors/googleCalendarConnector.test.ts
@@ -35,7 +35,7 @@ describe("testCalendarConnection", () => {
       ok: true,
       json: async () => ({ items: [{ id: "user@gmail.com" }] }),
     });
-    const result = await testCalendarConnection({ accessToken: "at-1" });
+    const result = await testCalendarConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: "user@gmail.com" });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/calendarList"),
@@ -48,7 +48,7 @@ describe("testCalendarConnection", () => {
       ok: true,
       json: async () => ({ items: [] }),
     });
-    const result = await testCalendarConnection({ accessToken: "at-1" });
+    const result = await testCalendarConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: undefined });
   });
 
@@ -58,7 +58,7 @@ describe("testCalendarConnection", () => {
       status: 401,
       text: async () => "Unauthorized",
     });
-    await expect(testCalendarConnection({ accessToken: "at-bad" })).rejects.toThrow(/401/);
+    await expect(testCalendarConnection({ accessToken: "at-bad", expiresAt: Date.now() + 3600_000 })).rejects.toThrow(/401/);
   });
 
   it("uses a refreshed token when the stored credentials are expired", async () => {

--- a/electron/main/connectors/googleContactsConnector.test.ts
+++ b/electron/main/connectors/googleContactsConnector.test.ts
@@ -35,7 +35,7 @@ describe("testContactsConnection", () => {
       ok: true,
       json: async () => ({ emailAddresses: [{ value: "user@gmail.com" }] }),
     });
-    const result = await testContactsConnection({ accessToken: "at-1" });
+    const result = await testContactsConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: "user@gmail.com" });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/people/me"),
@@ -48,7 +48,7 @@ describe("testContactsConnection", () => {
       ok: true,
       json: async () => ({ names: [{ displayName: "Jane Doe" }] }),
     });
-    const result = await testContactsConnection({ accessToken: "at-1" });
+    const result = await testContactsConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: "Jane Doe" });
   });
 
@@ -58,7 +58,7 @@ describe("testContactsConnection", () => {
       status: 403,
       text: async () => "Forbidden",
     });
-    await expect(testContactsConnection({ accessToken: "at-bad" })).rejects.toThrow(/403/);
+    await expect(testContactsConnection({ accessToken: "at-bad", expiresAt: Date.now() + 3600_000 })).rejects.toThrow(/403/);
   });
 
   it("uses a refreshed token when the stored credentials are expired", async () => {

--- a/electron/main/connectors/googleDriveConnector.test.ts
+++ b/electron/main/connectors/googleDriveConnector.test.ts
@@ -35,7 +35,7 @@ describe("testDriveConnection", () => {
       ok: true,
       json: async () => ({ user: { emailAddress: "user@gmail.com" } }),
     });
-    const result = await testDriveConnection({ accessToken: "at-1" });
+    const result = await testDriveConnection({ accessToken: "at-1", expiresAt: Date.now() + 3600_000 });
     expect(result).toEqual({ label: "user@gmail.com" });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/about"),
@@ -49,7 +49,7 @@ describe("testDriveConnection", () => {
       status: 403,
       text: async () => "Forbidden",
     });
-    await expect(testDriveConnection({ accessToken: "at-bad" })).rejects.toThrow(/403/);
+    await expect(testDriveConnection({ accessToken: "at-bad", expiresAt: Date.now() + 3600_000 })).rejects.toThrow(/403/);
   });
 
   it("uses a refreshed token when the stored credentials are expired", async () => {

--- a/electron/main/connectors/googleOAuth.test.ts
+++ b/electron/main/connectors/googleOAuth.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const saveConnectorCredentialsMock = vi.hoisted(() => vi.fn());
+const getDecryptedSettingsMock = vi.hoisted(() => vi.fn(() => ({})));
+vi.mock("../db/connectorsStore", () => ({
+  saveConnectorCredentials: saveConnectorCredentialsMock,
+  getDecryptedSettings: getDecryptedSettingsMock,
+}));
+
+const refreshAccessTokenMock = vi.hoisted(() => vi.fn());
+vi.mock("./oauthFlow", () => ({ refreshAccessToken: refreshAccessTokenMock }));
+
+vi.mock("../devLog", () => ({ devLog: vi.fn() }));
+
+import { makeEnsureFreshCredentials } from "./googleOAuth";
+import type { ConnectorCredentials } from "../db/connectorsStore";
+
+const buildConfig = () => ({ authorizeUrl: "", tokenUrl: "", scopes: [], clientId: "x" });
+
+beforeEach(() => {
+  saveConnectorCredentialsMock.mockReset();
+  getDecryptedSettingsMock.mockReset().mockReturnValue({});
+  refreshAccessTokenMock.mockReset();
+});
+
+describe("makeEnsureFreshCredentials", () => {
+  it("returns the credentials unchanged when not yet expired", async () => {
+    const ensureFreshCredentials = makeEnsureFreshCredentials("gmail", "gmail", buildConfig, "Gmail");
+    const credentials: ConnectorCredentials = {
+      accessToken: "tok",
+      refreshToken: "refresh",
+      expiresAt: Date.now() + 10 * 60_000,
+      scope: "s",
+    };
+
+    const result = await ensureFreshCredentials(credentials);
+
+    expect(result).toEqual(credentials);
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when the token is actually expired", async () => {
+    refreshAccessTokenMock.mockResolvedValue({ accessToken: "new-tok", expiresAt: Date.now() + 3600_000 });
+    const ensureFreshCredentials = makeEnsureFreshCredentials("gmail", "gmail", buildConfig, "Gmail");
+    const credentials: ConnectorCredentials = {
+      accessToken: "old-tok",
+      refreshToken: "refresh",
+      expiresAt: Date.now() - 1000,
+      scope: "s",
+    };
+
+    const result = await ensureFreshCredentials(credentials);
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(result.accessToken).toBe("new-tok");
+    expect(saveConnectorCredentialsMock).toHaveBeenCalledTimes(1);
+  });
+
+  // KI-10: expiresAt === undefined used to make isExpired false, so a token response missing
+  // expires_in converted into a credential that refreshes only once, ever, and then fails
+  // every subsequent call with a 401 until the user manually reconnects.
+  it("treats a missing expiresAt as expired rather than valid forever", async () => {
+    refreshAccessTokenMock.mockResolvedValue({ accessToken: "new-tok", expiresAt: undefined });
+    const ensureFreshCredentials = makeEnsureFreshCredentials("gmail", "gmail", buildConfig, "Gmail");
+    const credentials: ConnectorCredentials = {
+      accessToken: "old-tok",
+      refreshToken: "refresh",
+      expiresAt: undefined,
+      scope: "s",
+    };
+
+    const result = await ensureFreshCredentials(credentials);
+
+    expect(refreshAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(result.accessToken).toBe("new-tok");
+  });
+
+  it("throws when expired with no refresh token available", async () => {
+    const ensureFreshCredentials = makeEnsureFreshCredentials("gmail", "gmail", buildConfig, "Gmail");
+    const credentials: ConnectorCredentials = {
+      accessToken: "old-tok",
+      refreshToken: undefined,
+      expiresAt: Date.now() - 1000,
+      scope: "s",
+    };
+
+    await expect(ensureFreshCredentials(credentials)).rejects.toThrow(/reconnect Gmail/);
+    expect(refreshAccessTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/main/connectors/googleOAuth.ts
+++ b/electron/main/connectors/googleOAuth.ts
@@ -61,8 +61,16 @@ export function makeEnsureFreshCredentials(
   return async function ensureFreshCredentials(
     credentials: ConnectorCredentials
   ): Promise<ConnectorCredentials> {
+    // A missing expiresAt used to mean "never expires" — but a token response that omits
+    // expires_in (oauthFlow.ts's exchangeCodeForTokens/refreshAccessToken both map that case
+    // to undefined) converts into a credential that never refreshes again, failing every
+    // subsequent call with a 401 until the user manually reconnects. Google always returns
+    // expires_in today, so this doesn't fire in practice, but runOAuthFlow is documented as
+    // generic and reusable by any connector — treating "unknown" as "expired" is the safe
+    // direction: an unnecessary refresh costs one extra request, a missed one costs a silent
+    // 401 loop.
     const isExpired =
-      credentials.expiresAt !== undefined && Date.now() > credentials.expiresAt - EXPIRY_SAFETY_MARGIN_MS;
+      credentials.expiresAt === undefined || Date.now() > credentials.expiresAt - EXPIRY_SAFETY_MARGIN_MS;
     if (!isExpired) return credentials;
     if (!credentials.refreshToken) {
       throw new Error(


### PR DESCRIPTION
## Summary
- `isExpired` in `makeEnsureFreshCredentials` was `credentials.expiresAt !== undefined && Date.now() > credentials.expiresAt - MARGIN`. Both token paths (`oauthFlow.ts`'s `exchangeCodeForTokens` and `refreshAccessToken`) map a response missing `expires_in` to `expiresAt: undefined` — which made `isExpired` `false` forever.
- Google always returns `expires_in` today, so this is latent rather than active. But `runOAuthFlow` is documented as generic and reusable by any connector, and `refreshAccessToken` has the identical gap — one refresh response without `expires_in` converts a working credential into one that never refreshes again, failing every subsequent call with a 401 until the user manually reconnects.
- Fix: treat a missing `expiresAt` as expired (refresh before use) rather than valid forever — the safe direction, since an unnecessary refresh costs one extra request and a missed one costs a silent 401 loop.

Finding KI-10 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1297 tests passed. New `googleOAuth.test.ts` (4 tests: not-yet-expired passthrough, refresh on real expiry, missing-`expiresAt` now treated as expired, throws with no refresh token). Also fixed four connector test fixtures (gmail/calendar/contacts/drive) that passed a bare access token with neither `expiresAt` nor `refreshToken` and relied on the old bug to reach their actual target (the profile/list API call) without going through the refresh-or-throw path — they now carry a valid `expiresAt` so they still test what they're named for.
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`. A full live-OAuth exercise needs a real connected Google account, which I didn't set up without explicit user consent — unit coverage plus the boot check is the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)