### PR TITLE
Restrict HTTP tool param names to a safe identifier pattern (KI-11)

### DIFF
--- a/electron/main/ipc/httpTools.test.ts
+++ b/electron/main/ipc/httpTools.test.ts
@@ -108,3 +108,34 @@ describe("httpTools:testTool argument names", () => {
     );
   });
 });
+
+describe("httpTools:createTool param name validation", () => {
+  function createTool(input: unknown): unknown {
+    return handlerFor("httpTools:createTool")(null, input);
+  }
+
+  const BASE_INPUT = { collectionId: "col-1", name: "Get Thing" };
+
+  // KI-11: param.name is later interpolated unescaped into a per-param RegExp
+  // (httpToolRequest.ts's path substitution). A name like ".*" builds a pattern that
+  // swallows every "{{...}}" placeholder in the path; an unbalanced "(" throws a
+  // SyntaxError building the regex. Restricting the name to the same class the {{name}}
+  // placeholder syntax already implies closes both off at creation time.
+  it.each([".*", "id)", "a b", "1id"])("rejects a param name that isn't a valid identifier: %s", (name) => {
+    expect(() =>
+      createTool({
+        ...BASE_INPUT,
+        params: [{ name, description: "", type: "string", location: "path", required: false }],
+      })
+    ).toThrow(/must match/);
+  });
+
+  it.each(["id", "user_id", "_private", "id2"])("accepts a valid identifier param name: %s", (name) => {
+    expect(() =>
+      createTool({
+        ...BASE_INPUT,
+        params: [{ name, description: "", type: "string", location: "path", required: false }],
+      })
+    ).not.toThrow();
+  });
+});

--- a/electron/main/ipc/httpTools.ts
+++ b/electron/main/ipc/httpTools.ts
@@ -24,6 +24,13 @@ export type { HttpToolCollectionRow, HttpToolRow, HttpToolParam } from "../db/ht
 
 const PARAM_TYPES = ["string", "number", "boolean"];
 const PARAM_LOCATIONS = ["path", "query", "header", "body"];
+// Matches the capture class httpToolRequest.ts's own PLACEHOLDER_PATTERN uses for
+// {{name}} — a param name is later interpolated unescaped into a per-param RegExp when
+// substituting path placeholders, so anything outside this class (e.g. ".*", or an
+// unbalanced "(") either swallows every placeholder in the path or throws a SyntaxError
+// building the regex. Enforcing the same class the placeholder syntax already implies
+// closes that off at the one place params are created or edited.
+const PARAM_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function assertPlainObject(value: unknown, message: string): asserts value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -69,6 +76,11 @@ function assertParamsShape(value: unknown, prefix: string): asserts value is Htt
   for (const entry of value) {
     assertPlainObject(entry, `${prefix} each param must be an object`);
     assertNonEmptyString(entry.name, `${prefix} each param needs a non-empty name`);
+    if (!PARAM_NAME_PATTERN.test(entry.name)) {
+      throw new Error(
+        `${prefix} param name "${entry.name}" must match ${PARAM_NAME_PATTERN} (letters, digits, underscore; not starting with a digit)`
+      );
+    }
     // The name becomes a key in the generated zod schema, so a duplicate would silently
     // overwrite the earlier one and drop a parameter the user thinks they declared.
     if (seen.has(entry.name)) {


### PR DESCRIPTION
## Summary
- Path substitution in `httpToolRequest.ts:113-116` built `new RegExp("\\{\\{\\s*" + param.name + "\\s*\\}\\}", "g")` with no escaping. `assertParamsShape` (`ipc/httpTools.ts:64`) only required the name to be a non-empty string — no character class enforced anywhere.
- A parameter named `.*` produced a greedy pattern that swallows every placeholder between the first `{{` and the last `}}`, silently substituting one value across all of them and sending a request to a URL the user never configured. A name containing an unbalanced `(` threw a `SyntaxError` that surfaced as an opaque tool failure.
- Fix: `assertParamsShape` now restricts param names to `^[A-Za-z_][A-Za-z0-9_]*$` — the same capture class `PLACEHOLDER_PATTERN` already uses for `{{name}}` placeholders. Enforced at creation/edit time, so a bad name never reaches the regex construction.

Finding KI-11 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1305 tests passed (8 new: rejects `.*`, `id)`, `a b`, `1id`; accepts `id`, `user_id`, `_private`, `id2`)
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`. Driving the actual HTTP Tools "add parameter" form through the Playwright driver was blocked by onboarding-flow flakiness unrelated to this change; the fix is exercised through the real `httpTools:createTool` IPC handler in the unit tests above, not a mocked copy of the validation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)