### PR TITLE
Run the protocol check in testTool even when private hosts are allowed (KI-12)

### DIFF
--- a/electron/main/ai/httpTools.ts
+++ b/electron/main/ai/httpTools.ts
@@ -10,7 +10,7 @@ import {
   type HttpToolParam,
   type HttpToolRow,
 } from "../db/httpToolsStore";
-import { safeFetch } from "../net/urlSafety";
+import { assertHttpProtocol, safeFetch } from "../net/urlSafety";
 import { buildHttpRequest, toolParamsSchema, type HttpToolArgValue } from "./httpToolRequest";
 import { requiresApproval, type ApprovalPolicy } from "./approvalPolicy";
 import { readAppSetting } from "../appSettings";
@@ -32,21 +32,6 @@ export interface HttpToolResponse {
   contentType: string | null;
   body: string;
   truncated: boolean;
-}
-
-/** Non-http(s) schemes are refused even when a collection opts into private hosts —
- * "allow private addresses" widens which *hosts* are reachable, never which protocols
- * (file:, data: etc. are not HTTP tools in any configuration). */
-function assertHttpProtocol(url: string): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error(`"${url}" is not a valid URL`);
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`Refusing to call a non-http(s) URL: "${url}"`);
-  }
 }
 
 async function executeHttpTool(

--- a/electron/main/ipc/httpTools.test.ts
+++ b/electron/main/ipc/httpTools.test.ts
@@ -22,7 +22,12 @@ vi.mock("../db/httpToolsStore", () => ({
 
 const buildHttpRequestMock = vi.hoisted(() => vi.fn());
 vi.mock("../ai/httpToolRequest", () => ({ buildHttpRequest: buildHttpRequestMock }));
-vi.mock("../net/urlSafety", () => ({ assertPublicHttpUrl: vi.fn(), safeFetch: vi.fn() }));
+const assertHttpProtocolMock = vi.hoisted(() => vi.fn());
+vi.mock("../net/urlSafety", () => ({
+  assertPublicHttpUrl: vi.fn(),
+  assertHttpProtocol: assertHttpProtocolMock,
+  safeFetch: vi.fn(async () => ({ ok: true, status: 200, statusText: "OK", text: async () => "{}" })),
+}));
 
 import { ipcMain } from "electron";
 import { registerHttpToolHandlers } from "./httpTools";
@@ -52,6 +57,7 @@ describe("httpTools:testTool argument names", () => {
   beforeEach(() => {
     vi.mocked(ipcMain.handle).mockClear();
     buildHttpRequestMock.mockReset();
+    assertHttpProtocolMock.mockReset();
     buildHttpRequestMock.mockReturnValue({
       url: "https://api.example.com/things/1",
       method: "GET",
@@ -89,6 +95,27 @@ describe("httpTools:testTool argument names", () => {
       allowPrivateHosts: false,
     });
     expect(buildHttpRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  // KI-12: allowPrivateHosts widens which *hosts* are reachable, never which protocols —
+  // this branch previously skipped assertPublicHttpUrl (correctly, since private hosts are
+  // allowed) but also assertHttpProtocol, unlike ai/httpTools.ts's equivalent branch.
+  it("still runs the protocol check when private hosts are allowed", async () => {
+    await testTool({ ...VALID, allowPrivateHosts: true });
+    expect(assertHttpProtocolMock).toHaveBeenCalledWith("https://api.example.com/things/1");
+  });
+
+  it("does not run the protocol check when private hosts are not allowed (safeFetch covers it)", async () => {
+    await testTool({ ...VALID, allowPrivateHosts: false });
+    expect(assertHttpProtocolMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a rejected protocol as a returned error rather than a thrown one", async () => {
+    assertHttpProtocolMock.mockImplementation(() => {
+      throw new Error('Refusing to call a non-http(s) URL: "file:///etc/passwd"');
+    });
+    const result = await testTool({ ...VALID, allowPrivateHosts: true });
+    expect(result).toEqual({ ok: false, error: expect.stringContaining("Refusing to call a non-http(s) URL") });
   });
 
   it("still accepts an input carrying only the required key", async () => {

--- a/electron/main/ipc/httpTools.ts
+++ b/electron/main/ipc/httpTools.ts
@@ -18,7 +18,7 @@ import {
   type HttpToolPatch,
 } from "../db/httpToolsStore";
 import { buildHttpRequest } from "../ai/httpToolRequest";
-import { safeFetch } from "../net/urlSafety";
+import { assertHttpProtocol, safeFetch } from "../net/urlSafety";
 
 export type { HttpToolCollectionRow, HttpToolRow, HttpToolParam } from "../db/httpToolsStore";
 
@@ -239,10 +239,17 @@ export function registerHttpToolHandlers() {
           signal: AbortSignal.timeout(15_000),
         };
         // safeFetch re-validates every redirect hop, so a 302 to private space is caught
-        // even though the initial URL passed assertPublicHttpUrl.
-        const response = input.allowPrivateHosts
-          ? await fetch(request.url, fetchInit)
-          : await safeFetch(request.url, fetchInit);
+        // even though the initial URL passed assertPublicHttpUrl. When private hosts are
+        // allowed, assertHttpProtocol still runs — "allow private addresses" widens which
+        // hosts are reachable, never which protocols — mirroring ai/httpTools.ts, which
+        // this branch previously did not (KI-12).
+        let response: Response;
+        if (input.allowPrivateHosts) {
+          assertHttpProtocol(request.url);
+          response = await fetch(request.url, fetchInit);
+        } else {
+          response = await safeFetch(request.url, fetchInit);
+        }
         const body = await response.text();
         return {
           ok: response.ok,

--- a/electron/main/net/urlSafety.test.ts
+++ b/electron/main/net/urlSafety.test.ts
@@ -8,7 +8,25 @@ vi.mock("node:dns", () => ({
 }));
 
 import dns from "node:dns";
-import { assertPublicHttpUrl, safeFetch } from "./urlSafety";
+import { assertHttpProtocol, assertPublicHttpUrl, safeFetch } from "./urlSafety";
+
+describe("assertHttpProtocol", () => {
+  it("accepts http(s) URLs regardless of host", () => {
+    expect(() => assertHttpProtocol("https://example.com/")).not.toThrow();
+    expect(() => assertHttpProtocol("http://127.0.0.1:8080/")).not.toThrow();
+  });
+
+  it.each(["file:///etc/passwd", "ftp://example.com", "javascript:alert(1)"])(
+    "rejects a non-http(s) URL: %s",
+    (url) => {
+      expect(() => assertHttpProtocol(url)).toThrow(/non-http/);
+    }
+  );
+
+  it("rejects an invalid URL string", () => {
+    expect(() => assertHttpProtocol("not a url")).toThrow(/not a valid URL/);
+  });
+});
 
 describe("assertPublicHttpUrl", () => {
   afterEach(() => {

--- a/electron/main/net/urlSafety.ts
+++ b/electron/main/net/urlSafety.ts
@@ -62,6 +62,24 @@ function isBlockedHost(host: string): boolean {
   return false;
 }
 
+/** Non-http(s) schemes are refused even when a collection opts into private hosts —
+ * "allow private addresses" widens which *hosts* are reachable, never which protocols
+ * (file:, data: etc. are not HTTP tools in any configuration). Shared by both HTTP-tool
+ * call sites (ai/httpTools.ts's agent-facing execute, ipc/httpTools.ts's testTool) so the
+ * two paths can't drift the way they did before KI-12 — testTool skipped this entirely
+ * when allowPrivateHosts was true. */
+export function assertHttpProtocol(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`"${url}" is not a valid URL`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Refusing to call a non-http(s) URL: "${url}"`);
+  }
+}
+
 /** Validates a URL is safe to fetch from the knowledgebase "Add from URL"/discovery/sitemap flows:
  * http(s) only, and neither the literal hostname nor any of its DNS-resolved addresses
  * point at loopback/private/link-local space. The resolved-address check defends against


### PR DESCRIPTION
## Summary
- `httpTools:testTool`'s `allowPrivateHosts` branch called `fetch()` directly with no validation at all: `if (!input.allowPrivateHosts) { await assertPublicHttpUrl(request.url); }` — when `allowPrivateHosts` was true, nothing ran.
- The agent-facing equivalent (`ai/httpTools.ts`) gets this right: it calls `assertHttpProtocol(request.url)` on the same branch, since "allow private addresses" widens which *hosts* are reachable, never which *protocols* (`file:`, `data:` etc. are not HTTP tools in any configuration).
- `fetch()` currently rejects non-http(s) schemes itself, so the practical impact today is an opaque error rather than a real bypass — but the two paths had already drifted, and the guard the codebase deliberately wrote for one didn't cover the other.
- Fix: moved `assertHttpProtocol` into `net/urlSafety.ts` (shared by both call sites, rather than `ipc/` importing across the `ai/` boundary) and call it from `testTool`'s `allowPrivateHosts` branch too.

Finding KI-12 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1313 tests passed (8 new: `assertHttpProtocol` direct unit coverage in `urlSafety.test.ts`; `testTool` runs the check when `allowPrivateHosts` is true, skips it when false (safeFetch covers that path), and surfaces a rejected protocol as a returned `{ok:false}` rather than a thrown error, matching the existing error-shape contract)
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)