### PR TITLE
Restrict renderer permission handler to an allowlist (KI-13)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -109,13 +109,17 @@ app.whenReady().then(() => {
   registerSystemStatsHandlers();
   startSystemStatsBroadcast();
   registerLocationHandlers();
-  // Location now comes from a main-process IP lookup (electron/main/ipc/location.ts),
-  // not Chromium's navigator.geolocation, so no permission type needs gating here anymore
-  // — this just keeps Electron's implicit-allow default explicit for everything else
-  // (e.g. microphone, used by voice input).
-  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
-    callback(true);
+  // Location now comes from a main-process IP lookup (electron/main/ipc/location.ts), not
+  // Chromium's navigator.geolocation. The app needs exactly one Chromium permission —
+  // "media", for voice input's microphone access — so this is an allowlist rather than
+  // Electron's implicit-allow default: a permission the app doesn't use (notifications,
+  // clipboard-read, midi, and anything Chromium adds in a future major) is denied, not
+  // granted for free. Denial is the cheap direction of error here — a wrong denial is
+  // immediately visible in voice input, whereas a wrong grant is invisible.
+  session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    callback(permission === "media");
   });
+  session.defaultSession.setPermissionCheckHandler((_webContents, permission) => permission === "media");
   registerSettingsHandlers();
   registerChatHistoryHandlers();
   registerMemoryHandlers();


### PR DESCRIPTION
## Summary
- `session.defaultSession.setPermissionRequestHandler((_wc, _permission, callback) => callback(true))` granted every permission type without inspecting which one was asked for. `setPermissionCheckHandler` wasn't registered at all — Electron's default there is also allow.
- The app needs exactly one permission — microphone, for voice input. Everything else (notifications, clipboard-read, midi, and anything Chromium adds in a future major) was granted for free. The renderer is well confined otherwise (contextIsolation, sandbox, `default-src 'none'` CSP), so this was defence-in-depth rather than an open hole — but it's the one place a new Chromium capability would arrive pre-approved.
- Fix: both handlers now allowlist `permission === "media"`. Denial is the cheap direction of error here — the app requests only one permission, so a wrong denial is immediately visible in voice input, whereas a wrong grant is invisible.

Finding KI-13 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1313 tests passed (no unit harness exists for `main/index.ts`'s bootstrap wiring; verified live below instead)
- [x] E2E: launched the app fresh in a sandboxed userData dir and probed the real permission handler via `navigator.permissions.query` — `microphone` reports `"granted"`, `notifications` reports `"denied"`. Confirms the allowlist behaves exactly as intended in the running app, not just in isolated logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)