### PR TITLE
Check res.ok before parsing the daemon response body (KI-14)

### DIFF
--- a/electron/main/ai/webSearchDaemon.test.ts
+++ b/electron/main/ai/webSearchDaemon.test.ts
@@ -109,7 +109,7 @@ describe("callDaemon", () => {
   it("resolves normally when the daemon responds before the timeout", async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.endsWith("/health")) return Promise.resolve({ ok: true });
-      return Promise.resolve({ json: async () => ({ status: "ok", data: { hello: "world" } }) });
+      return Promise.resolve({ ok: true, json: async () => ({ status: "ok", data: { hello: "world" } }) });
     });
 
     const { startExplorerDaemon, callDaemon } = await import("./webSearchDaemon");
@@ -118,6 +118,40 @@ describe("callDaemon", () => {
     await expect(callDaemon("/fetch-web", { url: "https://example.com" }, 5000)).resolves.toEqual({
       hello: "world",
     });
+  });
+
+  // KI-14: res.ok was never checked and res.json() ran unconditionally — a 5xx that returns
+  // HTML or an empty body threw a raw "Unexpected token < in JSON" SyntaxError instead of
+  // reporting the actual failed request.
+  it("reports the status and body on a non-ok response instead of throwing a raw JSON parse error", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/health")) return Promise.resolve({ ok: true });
+      return Promise.resolve({ ok: false, status: 502, text: async () => "<html>Bad Gateway</html>" });
+    });
+
+    const { startExplorerDaemon, callDaemon } = await import("./webSearchDaemon");
+    await startExplorerDaemon();
+
+    await expect(callDaemon("/fetch-web", { url: "https://example.com" }, 5000)).rejects.toThrow(
+      /status 502.*Bad Gateway/s
+    );
+  });
+
+  it("reports a clear error when an ok response isn't valid JSON", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/health")) return Promise.resolve({ ok: true });
+      return Promise.resolve({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError("Unexpected token < in JSON at position 0");
+        },
+      });
+    });
+
+    const { startExplorerDaemon, callDaemon } = await import("./webSearchDaemon");
+    await startExplorerDaemon();
+
+    await expect(callDaemon("/fetch-web", { url: "https://example.com" }, 5000)).rejects.toThrow(/non-JSON response/);
   });
 });
 

--- a/electron/main/ai/webSearchDaemon.ts
+++ b/electron/main/ai/webSearchDaemon.ts
@@ -261,7 +261,20 @@ export async function callDaemon<T>(
   } finally {
     clearTimeout(timer);
   }
-  const envelope = (await res.json()) as DaemonEnvelope<T>;
+  // res.ok was never checked and res.json() ran unconditionally — a 5xx that returns HTML
+  // or an empty body threw a raw "Unexpected token < in JSON" SyntaxError instead of the
+  // envelope's own error message, surfacing to Explorer's tools and the knowledge base's
+  // "Add from URL" as a parsing bug rather than a failed request.
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Request to ${endpoint} failed with status ${res.status}${text ? `: ${text}` : ""}`);
+  }
+  let envelope: DaemonEnvelope<T>;
+  try {
+    envelope = (await res.json()) as DaemonEnvelope<T>;
+  } catch {
+    throw new Error(`Request to ${endpoint} returned a non-JSON response despite status ${res.status}`);
+  }
   if (envelope.status === "error" || envelope.data === null) {
     throw new Error(envelope.error?.message ?? `Request to ${endpoint} failed with no error detail`);
   }


### PR DESCRIPTION
## Summary
- `callDaemon`'s `const envelope = (await res.json()) as DaemonEnvelope<T>` ran unconditionally — `res.ok` was never consulted, and the `json()` call sat outside the `try` that wraps the fetch.
- A daemon 5xx that returns HTML or an empty body threw a raw `SyntaxError` ("Unexpected token < in JSON") instead of the envelope's own error message. That propagated to Explorer's web-search tools and the knowledge base's "Add from URL", where it read as a parsing bug rather than a failed request.
- Fix: check `res.ok` first (reporting status and response body on failure) and wrap `res.json()` so a response that claims success (`ok: true`) but isn't valid JSON gets its own clear message too.

Finding KI-14 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1315 tests passed (2 new: a non-ok response reports status+body instead of a raw JSON parse error; an ok response with malformed JSON reports a clear "non-JSON response" message)
- [x] E2E: launched the app fresh in a sandboxed userData dir — the real daemon's happy path (health check + normal responses) still works, clean boot, no errors in `debug.log`. The 5xx/malformed-body failure path isn't practically reproducible against the real daemon binary; the unit tests are the correct tool for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)