### PR TITLE
Await an in-flight scheduled task before quitting (KI-15)

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -27,7 +27,7 @@ import { registerUserInfoHandlers } from "./ipc/userInfo";
 import { registerAppInfoHandlers } from "./ipc/appInfo";
 import { ensureAppDirectories, migrateLegacyUserData } from "./appDirs";
 import { startExplorerDaemon, stopExplorerDaemon } from "./ai/webSearchDaemon";
-import { startTaskScheduler, stopTaskScheduler } from "./tasks/scheduler";
+import { startTaskScheduler, stopTaskScheduler, waitForInFlightPoll } from "./tasks/scheduler";
 
 function applyContentSecurityPolicy() {
   const policy = contentSecurityPolicy(is.dev);
@@ -152,7 +152,24 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
 });
 
-app.on("before-quit", () => {
+// A task already mid-run when the user quits (an LLM call, possibly using MCP tools) was
+// previously abandoned outright — stopTaskScheduler only clears the poll interval, it
+// never waited for an in-flight run, so its `finally { await closeMcpServers(mcpServers) }`
+// (tasks/scheduler.ts) could be skipped entirely, orphaning MCP subprocesses. Capped so a
+// stuck task can't block quitting indefinitely.
+const QUIT_TASK_WAIT_TIMEOUT_MS = 10_000;
+let readyToQuit = false;
+
+app.on("before-quit", (event) => {
   stopExplorerDaemon();
   stopTaskScheduler();
+  if (readyToQuit) return;
+  event.preventDefault();
+  Promise.race([
+    waitForInFlightPoll(),
+    new Promise((resolve) => setTimeout(resolve, QUIT_TASK_WAIT_TIMEOUT_MS)),
+  ]).finally(() => {
+    readyToQuit = true;
+    app.quit();
+  });
 });

--- a/electron/main/tasks/scheduler.test.ts
+++ b/electron/main/tasks/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const runMock = vi.hoisted(() => vi.fn());
 vi.mock("@openai/agents", () => ({ run: runMock }));
@@ -12,7 +12,29 @@ vi.mock("../ai/agents", () => ({
 const closeMcpServersMock = vi.hoisted(() => vi.fn());
 vi.mock("../ai/mcp", () => ({ closeMcpServers: closeMcpServersMock }));
 
-import { computeNextRunAt, renderTaskPrompt, runPromptTask } from "./scheduler";
+const getDueTasksMock = vi.hoisted(() => vi.fn<(nowIso: string) => import("../db/tasksStore").TaskRow[]>(() => []));
+const recordTaskRunMock = vi.hoisted(() => vi.fn());
+vi.mock("../db/tasksStore", () => ({ getDueTasks: getDueTasksMock, recordTaskRun: recordTaskRunMock }));
+
+vi.mock("electron", () => {
+  class MockNotification {
+    static isSupported = () => true;
+    show = vi.fn();
+  }
+  return {
+    Notification: MockNotification,
+    BrowserWindow: { getAllWindows: () => [] },
+  };
+});
+
+import {
+  computeNextRunAt,
+  renderTaskPrompt,
+  runPromptTask,
+  startTaskScheduler,
+  stopTaskScheduler,
+  waitForInFlightPoll,
+} from "./scheduler";
 import type { TaskRow } from "../db/tasksStore";
 
 function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
@@ -107,5 +129,55 @@ describe("computeNextRunAt", () => {
 
   it("computes from the passed-in time, not wall-clock now", () => {
     expect(computeNextRunAt("2020-01-01T00:00:00.000Z", 3_600_000)).toBe("2020-01-01T01:00:00.000Z");
+  });
+});
+
+// KI-15: stopTaskScheduler only ever cleared the poll interval — it never waited for a task
+// already mid-run, so app quit could abandon it before runPromptTask's
+// `finally { await closeMcpServers(mcpServers) }` ran, orphaning MCP subprocesses.
+describe("waitForInFlightPoll", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getDueTasksMock.mockReset().mockReturnValue([]);
+    recordTaskRunMock.mockReset();
+  });
+
+  afterEach(() => {
+    stopTaskScheduler();
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when no poll is in flight", async () => {
+    await expect(waitForInFlightPoll()).resolves.toBeUndefined();
+  });
+
+  it("resolves only once the in-flight poll actually finishes", async () => {
+    let releaseRun: (value: { finalOutput: string; interruptions: never[] }) => void = () => {};
+    const runGate = new Promise((resolve) => {
+      releaseRun = resolve as typeof releaseRun;
+    });
+    // A prompt task's run() call is the awaited step in processDueTask (via runPromptTask),
+    // unlike a plain reminder's recordTaskRun, which isn't awaited — gating here is what
+    // actually keeps the poll in flight.
+    getDueTasksMock.mockReturnValue([makeTask({ prompt: "do the thing" })]);
+    buildOrchestratorMock.mockResolvedValue({ agent: { name: "Orbit" }, mcpServers: [], allAgents: [] });
+    runMock.mockReturnValue(runGate);
+
+    startTaskScheduler();
+    await vi.advanceTimersByTimeAsync(30_000); // POLL_INTERVAL_MS — fires the first tick
+
+    let resolved = false;
+    const waited = waitForInFlightPoll().then(() => {
+      resolved = true;
+    });
+
+    // Still pending — run()'s promise hasn't settled yet.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseRun({ finalOutput: "done", interruptions: [] });
+    await waited;
+    expect(resolved).toBe(true);
   });
 });

--- a/electron/main/tasks/scheduler.ts
+++ b/electron/main/tasks/scheduler.ts
@@ -135,6 +135,9 @@ async function processDueTask(task: TaskRow): Promise<void> {
 }
 
 let pollInFlight = false;
+// Tracked separately from the boolean above so app quit can await the actual in-flight
+// run rather than just checking whether one exists — see waitForInFlightPoll below.
+let inFlightPoll: Promise<void> | null = null;
 
 async function pollOnce(): Promise<void> {
   // A prompt task can take longer than POLL_INTERVAL_MS to run (an LLM call, especially
@@ -160,7 +163,9 @@ async function pollOnce(): Promise<void> {
 export function startTaskScheduler(): void {
   if (timer) return;
   timer = setInterval(() => {
-    void pollOnce();
+    inFlightPoll = pollOnce().finally(() => {
+      inFlightPoll = null;
+    });
   }, POLL_INTERVAL_MS);
 }
 
@@ -169,4 +174,14 @@ export function stopTaskScheduler(): void {
   if (!timer) return;
   clearInterval(timer);
   timer = null;
+}
+
+/** Resolves once any poll in flight at the moment of the call finishes, or immediately if
+ * none is running. stopTaskScheduler only clears the interval — a task already mid-run
+ * (an LLM call, possibly using MCP tools) was previously abandoned when the process exited,
+ * so runPromptTask's `finally { await closeMcpServers(mcpServers) }` might never complete
+ * and MCP subprocesses were orphaned rather than closed. Exported so main/index.ts's
+ * before-quit handler can await it (with its own timeout) before actually quitting. */
+export function waitForInFlightPoll(): Promise<void> {
+  return inFlightPoll ?? Promise.resolve();
 }


### PR DESCRIPTION
## Summary
- `stopTaskScheduler()` (`tasks/scheduler.ts:146-150`) only cleared the poll interval — it never awaited a task already mid-run. `runPromptTask`'s `finally { await closeMcpServers(mcpServers) }` could be skipped entirely when the app quit mid-task, orphaning MCP subprocesses. Compounds KI-6: between the two, app quit could leave the search daemon, a headless browser, and one or more MCP subprocesses running.
- Fix: `scheduler.ts` now tracks the actual in-flight poll promise (`waitForInFlightPoll`), separate from the existing `pollInFlight` boolean guard. `main/index.ts`'s `before-quit` handler calls `event.preventDefault()`, awaits it (capped at 10s so a stuck task can't block quitting indefinitely), then calls `app.quit()` again — guarded by a `readyToQuit` flag so the handler doesn't loop.

Finding KI-15 from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 122 files / 1317 tests passed (2 new: `waitForInFlightPoll` resolves immediately with nothing running; resolves only once an in-flight prompt-task run actually completes, not before)
- [x] E2E: launched the app fresh in a sandboxed userData dir, then quit it through the driver — clean boot, clean single quit (no hang, no repeat-quit loop from the new `preventDefault`/re-quit logic), no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)