### PR TITLE
Add test coverage and a failure path to secretStorage.ts (KI-17, KI-18)

### DIFF
--- a/electron/main/security/secretStorage.test.ts
+++ b/electron/main/security/secretStorage.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// A minimal in-memory stand-in for the settings table — encryptSecret/decryptSecret only
+// ever read/write the single _encryptionFallbackKey row through these two functions.
+const store = new Map<string, unknown>();
+vi.mock("../db/settingsStore", () => ({
+  getSetting: (name: string, defaultValue: unknown) => (store.has(name) ? store.get(name) : defaultValue),
+  setSetting: (name: string, value: unknown) => {
+    store.set(name, value);
+  },
+}));
+
+import { decryptSecret, encryptSecret } from "./secretStorage";
+
+beforeEach(() => {
+  store.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("encryptSecret / decryptSecret round trip", () => {
+  it("decrypts back to the original plaintext", () => {
+    const encrypted = encryptSecret("sk-super-secret-key");
+    expect(decryptSecret(encrypted)).toBe("sk-super-secret-key");
+  });
+
+  it("round-trips an empty string", () => {
+    expect(decryptSecret(encryptSecret(""))).toBe("");
+  });
+
+  it("generates the encryption key once and reuses it across calls", () => {
+    const first = encryptSecret("a");
+    const second = encryptSecret("b");
+    // Different values (fresh IV each time) but both decrypt correctly under the same key,
+    // proving getEncryptionKey() persisted rather than regenerating per call.
+    expect(first).not.toBe(second);
+    expect(decryptSecret(first)).toBe("a");
+    expect(decryptSecret(second)).toBe("b");
+  });
+
+  it("produces a different ciphertext each time (fresh IV per call)", () => {
+    const a = encryptSecret("same-plaintext");
+    const b = encryptSecret("same-plaintext");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("the nodeCrypto: prefix contract", () => {
+  it("prefixes every encrypted value with nodeCrypto: and three base64 segments", () => {
+    const encrypted = encryptSecret("value");
+    const parts = encrypted.split(":");
+    expect(parts[0]).toBe("nodeCrypto");
+    expect(parts).toHaveLength(4); // nodeCrypto, iv, authTag, ciphertext
+  });
+});
+
+describe("legacy plaintext passthrough", () => {
+  it("returns a value with no nodeCrypto: prefix unchanged", () => {
+    expect(decryptSecret("plain-legacy-value")).toBe("plain-legacy-value");
+  });
+
+  it("does not require getEncryptionKey to have ever been called for a legacy value", () => {
+    // No encryptSecret call happened in this test, so the key setting was never touched —
+    // decryptSecret on a legacy value must not need it.
+    expect(store.has("_encryptionFallbackKey")).toBe(false);
+    expect(decryptSecret("un-encrypted")).toBe("un-encrypted");
+    expect(store.has("_encryptionFallbackKey")).toBe(false);
+  });
+});
+
+// KI-18: a stored value prefixed nodeCrypto: that fails GCM authentication (corrupted,
+// truncated, or encrypted under a key that no longer matches) used to throw node:crypto's
+// raw "Unsupported state or unable to authenticate data" straight out of decryptSecret,
+// with no caller wrapping it.
+describe("decryptSecret failure path", () => {
+  it("throws a clear error instead of a raw crypto exception when the auth tag doesn't match", () => {
+    const encrypted = encryptSecret("value");
+    const [prefix, iv, authTag, data] = encrypted.split(":");
+    // Flip the ciphertext so GCM authentication fails on decrypt.
+    const tampered = [prefix, iv, authTag, Buffer.from(data, "base64").reverse().toString("base64")].join(":");
+
+    expect(() => decryptSecret(tampered)).toThrow(/corrupted or the encryption key has changed/);
+  });
+
+  it("throws the same clear error for a truncated/malformed nodeCrypto: value", () => {
+    expect(() => decryptSecret("nodeCrypto:not-valid-base64-segments")).toThrow(
+      /corrupted or the encryption key has changed/
+    );
+  });
+});

--- a/electron/main/security/secretStorage.ts
+++ b/electron/main/security/secretStorage.ts
@@ -31,9 +31,18 @@ export function encryptSecret(plainText: string): string {
 export function decryptSecret(stored: string): string {
   if (stored.startsWith("nodeCrypto:")) {
     const [, ivB64, authTagB64, dataB64] = stored.split(":");
-    const decipher = crypto.createDecipheriv("aes-256-gcm", getEncryptionKey(), Buffer.from(ivB64, "base64"));
-    decipher.setAuthTag(Buffer.from(authTagB64, "base64"));
-    return Buffer.concat([decipher.update(Buffer.from(dataB64, "base64")), decipher.final()]).toString("utf8");
+    try {
+      const decipher = crypto.createDecipheriv("aes-256-gcm", getEncryptionKey(), Buffer.from(ivB64, "base64"));
+      decipher.setAuthTag(Buffer.from(authTagB64, "base64"));
+      return Buffer.concat([decipher.update(Buffer.from(dataB64, "base64")), decipher.final()]).toString("utf8");
+    } catch {
+      // GCM auth failure (corrupted/truncated value, or a key that no longer matches)
+      // previously threw node:crypto's raw "Unsupported state or unable to authenticate
+      // data" straight out of this function, with no caller wrapping it — surfacing as an
+      // opaque crash rather than something the user could act on (reconnect the account,
+      // re-enter the key).
+      throw new Error("Failed to decrypt stored secret — it may be corrupted or the encryption key has changed.");
+    }
   }
   return stored;
 }


### PR DESCRIPTION
## Summary
Two related findings on the same file, shipped together:

- **KI-17**: `secretStorage.ts` had zero tests — every consumer (`agents.test.ts`, `mcp.test.ts`, `httpTools.test.ts`, `connectorsStore.test.ts`, `providersStore.test.ts`, `settings.test.ts`, `selectProvider.test.ts`) mocks it, so the encrypt/decrypt round trip, the `nodeCrypto:` prefix contract, and the legacy plaintext passthrough were never exercised — even though this module is the only thing standing between the database and every API key, OAuth token, and MCP env var it holds.
- **KI-18**: `decryptSecret` had two gaps. A value not prefixed `nodeCrypto:` is returned verbatim as though it were the plaintext secret — intended for legacy rows, but that also means a truncated/corrupted value is handed to callers as a "valid" secret. And a value that *is* prefixed but fails GCM authentication threw `node:crypto`'s raw `"Unsupported state or unable to authenticate data"` straight out of `decipher.final()`, with no caller wrapping it.
- Fix: wrapped the decrypt path in a try/catch that rethrows a clear message ("corrupted or the encryption key has changed") instead of the opaque crypto exception. The legacy passthrough branch is unchanged — it's documented, intended behavior, and distinguishing "legitimately unencrypted legacy value" from "corrupted encrypted value missing its prefix" isn't decidable from the string alone.

Findings from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 123 files / 1325 tests passed. New `secretStorage.test.ts` (9 tests): round trip, empty-string round trip, key reuse across calls, fresh IV per call, the `nodeCrypto:` prefix shape, legacy passthrough (including that it never touches the encryption-key setting), and two failure-path tests (tampered ciphertext, malformed `nodeCrypto:` value) that only pass because of the KI-18 fix.
- [x] E2E: launched the app fresh in a sandboxed userData dir and wrote a real provider credential through `providers.selectChat` — exercises the actual encryption-key generation and encrypt round trip end to end, not just the unit-level mock. Clean write, no errors in `debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)