### PR TITLE
Harden the OAuth callback response and token-endpoint errors (KI-20, KI-21)

### DIFF
--- a/electron/main/connectors/oauthFlow.test.ts
+++ b/electron/main/connectors/oauthFlow.test.ts
@@ -122,7 +122,113 @@ describe("runOAuthFlow", () => {
       })
     ).rejects.toThrow(/security check/);
   });
+
+  // KI-20: the callback used to write the 200/success HTML before validating state/code, so
+  // a failed check rejected the flow in the app while the browser still showed success.
+  // Also asserts the security headers on the response the browser actually receives, since
+  // its URL carries the authorization code.
+  it("tells the browser the callback failed, not succeeded, on a security-check failure", async () => {
+    let callbackFetch: Promise<Response> | undefined;
+    openExternalMock.mockImplementation((authorizeUrl: string) => {
+      const parsed = new URL(authorizeUrl);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const callbackUrl = new URL(redirectUri);
+      callbackUrl.searchParams.set("code", "auth-code-1");
+      callbackUrl.searchParams.set("state", "wrong-state");
+      callbackFetch = fetch(callbackUrl.toString());
+    });
+
+    await expect(
+      runOAuthFlow({
+        authorizeUrl: "https://example.com/authorize",
+        tokenUrl: "http://127.0.0.1:1/token",
+        scopes: ["scope-a"],
+        clientId: "client-123",
+      })
+    ).rejects.toThrow(/security check/);
+
+    const callbackResponse = await callbackFetch!;
+    const body = await callbackResponse.text();
+    expect(body).toContain("went wrong");
+    expect(callbackResponse.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(callbackResponse.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("tells the browser the callback succeeded, with the same security headers, on a valid callback", async () => {
+    let callbackFetch: Promise<Response> | undefined;
+    tokenServer = await startFakeTokenServer({ access_token: "at-1", expires_in: 3600 });
+    openExternalMock.mockImplementation((authorizeUrl: string) => {
+      const parsed = new URL(authorizeUrl);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const state = parsed.searchParams.get("state")!;
+      const callbackUrl = new URL(redirectUri);
+      callbackUrl.searchParams.set("code", "auth-code-1");
+      callbackUrl.searchParams.set("state", state);
+      callbackFetch = fetch(callbackUrl.toString());
+    });
+
+    await runOAuthFlow({
+      authorizeUrl: "https://example.com/authorize",
+      tokenUrl: tokenServer.url,
+      scopes: ["scope-a"],
+      clientId: "client-123",
+    });
+
+    const callbackResponse = await callbackFetch!;
+    const body = await callbackResponse.text();
+    expect(body).toContain("close this window");
+    expect(body).not.toContain("went wrong");
+    expect(callbackResponse.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(callbackResponse.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  // KI-21: same reasoning as refreshAccessToken's equivalent test — the token endpoint's raw
+  // error body must not reach the thrown Error, since this path is agent-reachable.
+  it("throws only the status, not the raw response body, on a failed code exchange", async () => {
+    const errorServer = await startFakeErrorTokenServer(400, "client_secret=super-secret-value&leaked=true");
+    openExternalMock.mockImplementation((authorizeUrl: string) => {
+      const parsed = new URL(authorizeUrl);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const state = parsed.searchParams.get("state")!;
+      const callbackUrl = new URL(redirectUri);
+      callbackUrl.searchParams.set("code", "auth-code-1");
+      callbackUrl.searchParams.set("state", state);
+      fetch(callbackUrl.toString());
+    });
+
+    try {
+      const error = await runOAuthFlow({
+        authorizeUrl: "https://example.com/authorize",
+        tokenUrl: errorServer.url,
+        scopes: ["scope-a"],
+        clientId: "client-123",
+      }).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Token exchange failed (400).");
+      expect((error as Error).message).not.toContain("super-secret-value");
+    } finally {
+      await errorServer.close();
+    }
+  });
 });
+
+/** A fake token endpoint that always answers with `status` and `body` — for exercising the
+ * error path, where the real endpoint's raw response must not reach the thrown Error. */
+function startFakeErrorTokenServer(status: number, body: string): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server: Server = createServer((_req, res) => {
+      res.writeHead(status, { "Content-Type": "text/plain" });
+      res.end(body);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}/token`,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
 
 describe("refreshAccessToken", () => {
   it("exchanges a refresh token for a fresh access token", async () => {
@@ -137,6 +243,25 @@ describe("refreshAccessToken", () => {
       expect(tokenServer.requests[0].get("refresh_token")).toBe("rt-1");
     } finally {
       await tokenServer.close();
+    }
+  });
+
+  // KI-21: the raw response body used to be embedded in the thrown message. connect_connector
+  // (ai/agents.ts) is agent-callable, so that message reaches the model's context — a
+  // provider's error body can echo request parameters, which isn't something that needs to
+  // reach an LLM.
+  it("throws only the status, not the raw response body, on a failed refresh", async () => {
+    const errorServer = await startFakeErrorTokenServer(400, "client_secret=super-secret-value&leaked=true");
+    try {
+      const error = await refreshAccessToken(
+        { authorizeUrl: "https://example.com/authorize", tokenUrl: errorServer.url, scopes: [], clientId: "client-123" },
+        "rt-1"
+      ).catch((e: Error) => e);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("Token refresh failed (400).");
+      expect((error as Error).message).not.toContain("super-secret-value");
+    } finally {
+      await errorServer.close();
     }
   });
 });

--- a/electron/main/connectors/oauthFlow.ts
+++ b/electron/main/connectors/oauthFlow.ts
@@ -65,23 +65,46 @@ export function runOAuthFlow(config: OAuthConfig): Promise<OAuthTokenResponse> {
       const code = url.searchParams.get("code");
       const errorParam = url.searchParams.get("error");
 
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<html><body>You can close this window and return to the app.</body></html>");
+      // The response headers/body used to be written before any of the validation below —
+      // the browser told the user "success" regardless of what the app was about to decide.
+      // A failed state check rejected the flow while the browser kept showing the success
+      // page, so the two surfaces disagreed. Validating first and varying the body lets the
+      // browser say what actually happened. The URL here carries the authorization code, so
+      // no-referrer/no-store keep it out of a Referer header on any onward navigation and
+      // out of any cache along the way.
+      const respond = (ok: boolean) => {
+        res.writeHead(200, {
+          "Content-Type": "text/html",
+          "Referrer-Policy": "no-referrer",
+          "Cache-Control": "no-store",
+        });
+        res.end(
+          ok
+            ? "<html><body>You can close this window and return to the app.</body></html>"
+            : "<html><body>Something went wrong — you can close this window and return to the app to see the error.</body></html>"
+        );
+      };
 
-      if (settled) return;
+      if (settled) {
+        respond(false);
+        return;
+      }
       settled = true;
       clearTimeout(timeout);
       server.close();
 
       if (errorParam) {
+        respond(false);
         reject(new Error(`OAuth authorization was denied or failed: ${errorParam}`));
         return;
       }
       if (returnedState !== state || !code) {
+        respond(false);
         reject(new Error("OAuth callback failed a security check (state mismatch or missing code)."));
         return;
       }
 
+      respond(true);
       exchangeCodeForTokens(config, code, verifier, redirectUri)
         .then(resolve)
         .catch(reject);
@@ -135,7 +158,13 @@ async function exchangeCodeForTokens(
     body,
   });
   if (!response.ok) {
-    throw new Error(`Token exchange failed (${response.status}): ${await response.text()}`);
+    // The full body is logged, not thrown: `connect_connector` (ai/agents.ts) is
+    // agent-callable, so a thrown message reaches the model's context. A provider's raw
+    // error body can echo request parameters, and an auth-endpoint failure body isn't
+    // something that needs to reach an LLM regardless — only the status is.
+    const text = await response.text();
+    devLog(`[oauthFlow] token exchange failed (${response.status}): ${text}`);
+    throw new Error(`Token exchange failed (${response.status}).`);
   }
   const data = (await response.json()) as {
     access_token: string;
@@ -168,7 +197,11 @@ export async function refreshAccessToken(config: OAuthConfig, refreshToken: stri
     body,
   });
   if (!response.ok) {
-    throw new Error(`Token refresh failed (${response.status}): ${await response.text()}`);
+    // Same reasoning as exchangeCodeForTokens above — this runs from ensureFreshCredentials,
+    // reachable from an agent-callable connector tool call, so only the status is thrown.
+    const text = await response.text();
+    devLog(`[oauthFlow] token refresh failed (${response.status}): ${text}`);
+    throw new Error(`Token refresh failed (${response.status}).`);
   }
   const data = (await response.json()) as { access_token: string; expires_in?: number; scope?: string };
   return {


### PR DESCRIPTION
## Summary
Two related findings on the same OAuth flow, shipped together:

- **KI-20**: the callback handler (`oauthFlow.ts:68-83`) wrote the `200`/success HTML at lines 68-69, *before* checking `errorParam` or the state/code match at line 80. The browser showed the success page regardless of outcome — a failed state check rejected the flow in the app while the browser still said "success", so the two surfaces disagreed. Also missing: `Referrer-Policy`/`Cache-Control` on a response whose URL carries the authorization code.
  - Fix: the response is now written *after* validation, with a body that varies by outcome (success vs. "something went wrong"), plus `Referrer-Policy: no-referrer` and `Cache-Control: no-store`.
- **KI-21**: `exchangeCodeForTokens`/`refreshAccessToken` embedded the raw token-endpoint response body in the thrown `Error`. `connect_connector` (`ai/agents.ts:585`) is agent-callable, so that message reaches the model's context — low likelihood of a secret appearing, but a provider's raw error body (which can echo request parameters) isn't something that needs to reach an LLM.
  - Fix: the full body is now logged via `devLog`, and the thrown message carries only the status.

Findings from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 123 files / 1329 tests passed. 4 new tests in `oauthFlow.test.ts` against a real loopback HTTP server (not mocked): the callback response body/headers on both a security-check failure and a valid callback, and that a failed code exchange / refresh throws only the status (not the raw body containing a fake leaked secret) for both `runOAuthFlow` and `refreshAccessToken`.
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`. A full live-OAuth exercise needs a real connected Google account, which I didn't set up without explicit user consent — the unit tests exercise the real HTTP callback server and a real fake token endpoint, not a mocked copy of the logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)