### PR TITLE
Batch of minor audit cleanups (KI-19, KI-22, KI-23)

### DIFF
--- a/electron/main/ipc/sitemapDiscovery.ts
+++ b/electron/main/ipc/sitemapDiscovery.ts
@@ -59,7 +59,11 @@ function extractLocs(xml: string, tag: "sitemap" | "url"): string[] {
   return locs;
 }
 
-async function fetchSitemapTree(url: string, depth: number, seen: Set<string>): Promise<string[]> {
+// Recursion is bounded by `seen` against MAX_CHILD_SITEMAPS, not by nesting depth — there is
+// no depth parameter here (there used to be one that was accepted, incremented, and passed
+// on every recursive call, but never actually read: a future reader could reasonably have
+// assumed nesting was capped by depth when it was capped by total fetch count).
+async function fetchSitemapTree(url: string, seen: Set<string>): Promise<string[]> {
   if (seen.has(url) || seen.size >= MAX_CHILD_SITEMAPS) return [];
   seen.add(url);
   const xml = await guardedFetchText(url);
@@ -70,7 +74,7 @@ async function fetchSitemapTree(url: string, depth: number, seen: Set<string>): 
     const results: string[] = [];
     for (const childUrl of childUrls) {
       if (results.length >= MAX_DISCOVERED_LINKS) break;
-      results.push(...(await fetchSitemapTree(childUrl, depth + 1, seen)));
+      results.push(...(await fetchSitemapTree(childUrl, seen)));
     }
     return results;
   }
@@ -90,7 +94,7 @@ export async function fetchSitemapUrls(originUrl: string): Promise<string[] | nu
   } catch {
     return null;
   }
-  const urls = await fetchSitemapTree(`${origin}/sitemap.xml`, 0, new Set());
+  const urls = await fetchSitemapTree(`${origin}/sitemap.xml`, new Set());
   if (urls.length === 0) return null;
   return urls.slice(0, MAX_DISCOVERED_LINKS);
 }

--- a/electron/main/tasks/scheduler.test.ts
+++ b/electron/main/tasks/scheduler.test.ts
@@ -16,10 +16,14 @@ const getDueTasksMock = vi.hoisted(() => vi.fn<(nowIso: string) => import("../db
 const recordTaskRunMock = vi.hoisted(() => vi.fn());
 vi.mock("../db/tasksStore", () => ({ getDueTasks: getDueTasksMock, recordTaskRun: recordTaskRunMock }));
 
+const notificationConstructorMock = vi.hoisted(() => vi.fn());
 vi.mock("electron", () => {
   class MockNotification {
     static isSupported = () => true;
     show = vi.fn();
+    constructor(options: { title: string; body: string }) {
+      notificationConstructorMock(options);
+    }
   }
   return {
     Notification: MockNotification,
@@ -29,6 +33,7 @@ vi.mock("electron", () => {
 
 import {
   computeNextRunAt,
+  notify,
   renderTaskPrompt,
   runPromptTask,
   startTaskScheduler,
@@ -179,5 +184,34 @@ describe("waitForInFlightPoll", () => {
     releaseRun({ finalOutput: "done", interruptions: [] });
     await waited;
     expect(resolved).toBe(true);
+  });
+});
+
+// KI-22: notify() truncated the body but not the title, even though task.title is user- or
+// agent-authored with no length cap of its own — and becomes `${task.title} — failed` on a
+// failure notification, making an already-long title longer still.
+describe("notify", () => {
+  beforeEach(() => {
+    notificationConstructorMock.mockReset();
+  });
+
+  it("truncates a long title the same way it already truncates the body", () => {
+    const longTitle = "x".repeat(500);
+    const longBody = "y".repeat(500);
+
+    notify(longTitle, longBody);
+
+    expect(notificationConstructorMock).toHaveBeenCalledTimes(1);
+    const [{ title, body }] = notificationConstructorMock.mock.calls[0];
+    expect(title.length).toBeLessThan(longTitle.length);
+    expect(body.length).toBeLessThan(longBody.length);
+  });
+
+  it("leaves a short title and body untouched", () => {
+    notify("Reminder", "Time to check in.");
+
+    const [{ title, body }] = notificationConstructorMock.mock.calls[0];
+    expect(title).toBe("Reminder");
+    expect(body).toBe("Time to check in.");
   });
 });

--- a/electron/main/tasks/scheduler.ts
+++ b/electron/main/tasks/scheduler.ts
@@ -20,6 +20,11 @@ const POLL_INTERVAL_MS = 30_000;
 // Truncated in the OS notification body so a long agent reply doesn't overflow the
 // notification UI — the full text is still readable via last_result in the Tasks widget.
 const NOTIFICATION_BODY_MAX_LENGTH = 200;
+// task.title is user- or agent-authored with no length cap of its own (it becomes
+// `${task.title} — failed` on a failure notification below), so it needs the same
+// treatment as the body — otherwise it overflows or gets truncated unpredictably by the
+// OS notification layer, differently per platform.
+const NOTIFICATION_TITLE_MAX_LENGTH = 100;
 
 let timer: NodeJS.Timeout | null = null;
 
@@ -57,12 +62,17 @@ function broadcastTasksUpdate(): void {
   }
 }
 
-function notify(title: string, body: string): void {
+/** Exported for testing the title/body truncation (KI-22) — otherwise only reachable via
+ * processDueTask, which needs the full poll-loop scaffolding to exercise. */
+export function notify(title: string, body: string): void {
   if (!Notification.isSupported()) {
     devLog(`[taskScheduler] Notification not supported on this platform — title="${title}"`);
     return;
   }
-  new Notification({ title, body: body.slice(0, NOTIFICATION_BODY_MAX_LENGTH) }).show();
+  new Notification({
+    title: title.slice(0, NOTIFICATION_TITLE_MAX_LENGTH),
+    body: body.slice(0, NOTIFICATION_BODY_MAX_LENGTH),
+  }).show();
 }
 
 /** Exported for testing — the interruption/auto-reject handling below is the KI-5 fix and is

--- a/src/components/atoms/ChatBubble.test.tsx
+++ b/src/components/atoms/ChatBubble.test.tsx
@@ -182,6 +182,21 @@ describe("ChatBubble", () => {
     expect(container.querySelector(".mb")?.textContent).toContain("click");
   });
 
+  // KI-23: urlTransform={(url) => url} disables react-markdown's own scheme filter, so
+  // safety depends entirely on isSafeHref (anchors, above) and isDisplayable (images, here)
+  // staying in front of every URL-bearing construct react-markdown/remark-gfm can emit. This
+  // is the image half of that invariant — if a future plugin or react-markdown upgrade added
+  // a new URL-bearing node without an equivalent gate, this is the test that would need a
+  // matching case, making the gap visible instead of silent.
+  it("refuses to render a javascript: URL as an image src", () => {
+    const { container } = render(
+      <ChatBubble role="assistant" text="![alt](javascript:alert(1))" avatarLabel="A" />
+    );
+    const img = container.querySelector("img");
+    expect(img).toBeNull();
+    expect(container.querySelector(".chat-image-fallback")).not.toBeNull();
+  });
+
   it("does not render raw HTML from either role", () => {
     // No rehype-raw is configured; this test is what stops someone adding it without
     // thinking about model- or user-supplied markup.


### PR DESCRIPTION
## Summary
Three unrelated minor findings, batched per your direction:

- **KI-19** (dead code): `fetchSitemapTree`'s `depth` parameter (`ipc/sitemapDiscovery.ts:65`) was accepted, incremented, and passed on every recursive call, but never read — recursion is bounded by the `seen` set against `MAX_CHILD_SITEMAPS` instead. Removed the parameter.
- **KI-22** (edge case): `notify()`'s `NOTIFICATION_BODY_MAX_LENGTH` truncated the body but left `task.title` — user- or agent-authored, no length cap, and turned into `` `${task.title} — failed` `` on a failure notification — untouched, overflowing/truncating unpredictably per-platform. Added a matching `NOTIFICATION_TITLE_MAX_LENGTH` slice; exported `notify()` for direct test coverage.
- **KI-23** (production readiness): `ChatBubble.tsx`'s `urlTransform={(url) => url}` disables react-markdown's own scheme filter — safety instead depends on `isSafeHref` (anchors) and `isDisplayable` (images) staying in front of every URL-bearing construct react-markdown/remark-gfm can emit. The anchor case was already tested; added the missing image case so the invariant fails loudly (test breaks) if that element set ever changes, rather than silently.

Findings from the full-codebase audit at `0-cowork/memory/known-issues.md` (gitignored, not in this diff).

## Test plan
- [x] `npx eslint electron src scripts` — 0
- [x] `npx tsc -b --pretty false` — 0
- [x] `npx electron-vite build` — 0
- [x] `npx vitest run` — 123 files / 1332 tests passed. New: `notify()` truncates a long title the same way it already truncates the body, and leaves a short one untouched (2 tests); a `javascript:` image src renders the `.chat-image-fallback`, not an `<img>` (1 test). `sitemapDiscovery.test.ts`'s existing suite (recursion cap, entity decoding, CDATA) still passes unchanged with `depth` removed.
- [x] E2E: launched the app fresh in a sandboxed userData dir — clean boot, no errors in `debug.log`. KI-23 is test-only (no component change); KI-19/22 don't have a UI-observable happy path distinct from what the test suite already covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)