### PR TITLE
Prepare v0.1.0: dated changelog, release-accurate README, branching rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to OpenOrbit are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] — Unreleased
+## [0.1.0] — 2026-08-03
 
-Everything below is the work leading up to the first release. Nothing has been
-tagged yet, so there are no packaged downloads — running OpenOrbit means
-[building from source](README.md#build-and-run). The pipeline for it is in
-place: pushing a `v*` tag builds installers for all three platforms and
-attaches them to a GitHub Release.
+The first release. Installers for macOS, Windows and Linux are attached to
+the [GitHub Release](https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0)
+for this tag — see [Build and run](README.md#build-and-run) if you'd rather
+build from source.
 
 ### Added
 
@@ -357,4 +356,4 @@ attaches them to a GitHub Release.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[0.1.0]: https://github.com/maneja81/OpenOrbit/commits/develop
+[0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,12 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 
 - **`node_modules` and `dist-electron/` are per-worktree** and untracked — a fresh worktree needs its own install (see the Electron caveat below). `0-cowork/`, `MEMORY.md` and `.env` are gitignored and exist **only in the main checkout** at `/Users/mohitaneja/Projects/OpenOrbit`; write shared plans, fixes and memory to that absolute path or the workspace silently forks.
 
+## Branching & Releases
+
+- **`develop` is where all work happens — feature PRs, fixes, chores, docs — every time, no exceptions.** `main` tracks the released, stable line and moves only at a release cut (fast-forwarded to `develop`'s tip) or for a hotfix.
+- **Hotfixing a released version:** branch off `main` (not `develop`), fix, verify gate, PR *into `main`*. Once merged, **immediately** bring the same fix into `develop` too (cherry-pick the hotfix commit, or merge `main` into `develop` — whichever is cleaner for that fix) so the next release cut from `develop` doesn't silently regress it. A hotfix that only lands on `main` is a fix that vanishes the next time `main` is fast-forwarded to `develop`.
+- **Cutting a release:** finalize the CHANGELOG entry on `develop` first (dated header, corrected compare-link) via the normal PR flow, fast-forward `main` to `develop`'s new tip, then tag `vX.Y.Z` on `main`. `package.json`'s `version` field must match the tag exactly — `.github/workflows/release.yml` checks this and fails the build otherwise. The release workflow triggers on any `v*` tag push regardless of branch, but tagging from `main` keeps the tagged commit and the stable branch pointer identical.
+
 ## Verify Gate
 
 - **Run all four, every time, before reporting work done** — a green vitest run alone is not validation:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ apps, and Google account.
 > **This is a personal side project — built evenings and weekends, around a full-time job.
 > No support, no roadmap commitments, no guarantees.**
 >
-> The app is built and works. There are no packaged downloads yet, so running it means
-> [building from source](#build-and-run). Dates aren't promised.
+> The app works. Grab a packaged build from the
+> [latest release](https://github.com/maneja81/OpenOrbit/releases/latest), or
+> [build from source](#build-and-run). Dates aren't promised.
 
 <img src="public/openorbit.webp" alt="OpenOrbit orbit UI screenshot">
 
@@ -79,8 +80,10 @@ YAML, TOML, SQL and a range of source files.
 
 ## Build and run
 
-There are no prebuilt binaries yet. You'll need [Node.js](https://nodejs.org) `^20.19.0`
-or `>=22.12.0` (what Vite 7 and electron-vite 5 require) and Git.
+Packaged builds for macOS, Windows and Linux are on the
+[releases page](https://github.com/maneja81/OpenOrbit/releases). To build from source
+you'll need [Node.js](https://nodejs.org) `^20.19.0` or `>=22.12.0` (what Vite 7 and
+electron-vite 5 require) and Git.
 
 ```bash
 git clone -b develop https://github.com/maneja81/OpenOrbit.git
@@ -101,8 +104,10 @@ npm run lint      # eslint
 On first run you'll be asked to name the orchestrator, introduce yourself, and enter an
 API key. Nothing else is required — there are no environment variables to set.
 
-`npm run package` uses electron-builder's defaults with no configuration file, so treat it
-as a starting point rather than a finished cross-platform pipeline.
+`npm run package` builds for your current platform only, using the `build` config in
+`package.json` (macOS `.dmg`, Windows `.exe` via NSIS, Linux `.AppImage`). Cross-platform
+builds happen in CI — see `.github/workflows/release.yml`, which builds all three and
+attaches them to a GitHub Release on every `v*` tag.
 
 ## Bring your own key
 


### PR DESCRIPTION
## Summary
Final prep before cutting the v0.1.0 tag, per our discussion:

- **CHANGELOG.md**: `[0.1.0] — Unreleased` → `[0.1.0] — 2026-08-03`, and the intro paragraph/bottom compare-link now point at the `v0.1.0` GitHub Release instead of saying nothing's tagged yet.
- **README.md**: the top banner and "Build and run" section both claimed there were no packaged downloads — both now point at the release. Also fixed an unrelated stale line: `npm run package` uses a real `build` config in `package.json` (macOS `.dmg`, Windows NSIS `.exe`, Linux `.AppImage`), not electron-builder's bare defaults as previously stated.
- **CLAUDE.md**: added a `## Branching & Releases` section — `develop` is where all work happens; `main` tracks stable and only moves at a release cut (fast-forward) or a hotfix; a hotfix landed on `main` must be brought back into `develop` immediately (cherry-pick or merge) or it's silently lost the next time `main` is fast-forwarded to `develop`'s tip.

## Next steps (not in this PR)
1. Merge this into `develop`.
2. Fast-forward `main` to `develop`'s new tip.
3. Tag `v0.1.0` on `main` and push the tag — triggers `.github/workflows/release.yml` (builds macOS/Windows/Linux, attaches installers to a GitHub Release).

## Test plan
- N/A — documentation only. `npx eslint electron src scripts` — 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)