### PR TITLE
Add a Download section to the README with direct v0.1.0 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ apps, and Google account.
 
 <img src="public/openorbit.webp" alt="OpenOrbit orbit UI screenshot">
 
+## Download
+
+Builds are unsigned — expect a Gatekeeper prompt on macOS (right-click → Open) or a
+SmartScreen warning on Windows the first time you run one.
+
+| Platform | Download |
+| --- | --- |
+| macOS (Apple Silicon) | [OpenOrbit-0.1.0-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-arm64.dmg) |
+| macOS (Intel) | [OpenOrbit-0.1.0-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-x64.dmg) |
+| Windows | [OpenOrbit.Setup.0.1.0.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit.Setup.0.1.0.exe) |
+| Linux | [OpenOrbit-0.1.0.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0.AppImage) |
+
+These links are for **v0.1.0** specifically — the filenames carry the version, so they'll
+change on the next release. [Releases](https://github.com/maneja81/OpenOrbit/releases)
+always has the current set.
+
 ## How it works
 
 Instead of one chatbot, you get a roster of agents visualized as nodes orbiting a central


### PR DESCRIPTION
## Summary
- Added a `## Download` table linking directly to each of the four v0.1.0 release assets (macOS arm64/x64 `.dmg`, Windows `.exe`, Linux `.AppImage`), plus a note that these are versioned filenames and will change next release — `Releases` stays the canonical always-current link.
- Flagged upfront that builds are unsigned, so the Gatekeeper/SmartScreen prompt on first run isn't a surprise.

## Verification
Before adding the links, downloaded the actual `v0.1.0` macOS arm64 `.dmg` from the release, cleared the quarantine flag, and drove it with Playwright against a sandboxed `--user-data-dir` (never touched the real userData). Settings, database, and the search daemon all initialized normally, `app.getPath("userData")` resolved to the sandbox path, and the onboarding screen rendered — identical to the dev build. Screenshot confirms the packaged build is genuinely working, not just present.

## Test plan
- N/A — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)