### PR TITLE
Check for new releases at launch and badge the About icon

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,21 +1,13 @@
 import { resolve } from "node:path";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
-import { resolveReleaseInfo } from "./scripts/releaseInfo";
+import { resolveCommit } from "./scripts/releaseInfo";
 
-// Resolved once per build, never at runtime, so the shipped app makes no release-check
-// network call and needs no GitHub token. resolveReleaseInfo never rejects — an offline
-// build falls back to 0.0.0 rather than failing (see scripts/releaseInfo.ts).
-const release = await resolveReleaseInfo();
-
-/** JSON.stringify is required, not cosmetic: release notes are arbitrary markdown carrying
- * quotes and newlines, which would produce broken JS if substituted raw. */
-export const releaseDefines: Record<string, string> = {
-  __APP_RELEASE_VERSION__: JSON.stringify(release.version),
-  __APP_RELEASE_DATE__: JSON.stringify(release.releaseDate),
-  __APP_RELEASE_NOTES__: JSON.stringify(release.releaseNotes),
-  __APP_RELEASE_URL__: JSON.stringify(release.releaseUrl),
-  __APP_COMMIT__: JSON.stringify(release.commit),
+// The packaged app has no .git dir of its own, so the building machine's commit can only
+// ever be captured here, at build time — resolveCommit() returns "" without a .git dir
+// (see scripts/releaseInfo.ts) rather than throwing, so an archive-only build still works.
+export const buildDefines: Record<string, string> = {
+  __APP_COMMIT__: JSON.stringify(resolveCommit()),
 };
 
 export default defineConfig({
@@ -51,7 +43,7 @@ export default defineConfig({
   },
   renderer: {
     root: ".",
-    define: releaseDefines,
+    define: buildDefines,
     build: {
       outDir: "dist-electron/renderer",
       rollupOptions: {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -24,6 +24,7 @@ import { registerKnowledgeBaseHandlers } from "./ipc/knowledgeBase";
 import { registerTaskHandlers } from "./ipc/tasks";
 import { registerUserInfoHandlers } from "./ipc/userInfo";
 import { registerAppInfoHandlers } from "./ipc/appInfo";
+import { registerUpdateCheckHandlers } from "./ipc/updateCheck";
 import { ensureAppDirectories, migrateLegacyUserData } from "./appDirs";
 import { startExplorerDaemon, stopExplorerDaemon } from "./ai/webSearchDaemon";
 import { startTaskScheduler, stopTaskScheduler, waitForInFlightPoll } from "./tasks/scheduler";
@@ -132,6 +133,7 @@ app.whenReady().then(() => {
   registerTaskHandlers();
   registerUserInfoHandlers();
   registerAppInfoHandlers();
+  registerUpdateCheckHandlers();
   // Fire-and-forget: Explorer's tools await getExplorerDaemonPort() themselves, so a
   // slow/failed daemon start doesn't block app launch — it just fails that tool call later.
   // The .catch is required, not optional: Node's default disposition for an unhandled

--- a/electron/main/ipc/updateCheck.ts
+++ b/electron/main/ipc/updateCheck.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a newer release has been published, checked live once per launch — the build-time
+ * check this replaced could only ever compare a build against itself (see
+ * scripts/releaseInfo.ts). No auto-download or install: the project isn't code-signed yet, so
+ * electron-updater's silent-install path (Squirrel.Mac in particular) can't run on macOS,
+ * and shipping it Windows/Linux-only would give a different experience per platform. This
+ * only tells the user a release exists; About links out to it.
+ */
+
+import { ipcMain } from "electron";
+import { resolveReleaseInfo, type ReleaseInfo } from "../../../scripts/releaseInfo";
+
+export function registerUpdateCheckHandlers() {
+  ipcMain.handle("app:latestRelease", async (): Promise<ReleaseInfo> => {
+    // resolveReleaseInfo() never throws (see scripts/releaseInfo.ts) — an offline or rate
+    // limited launch resolves to the "0.0.0" sentinel rather than rejecting the handler.
+    const { version, releaseDate, releaseNotes, releaseUrl } = await resolveReleaseInfo();
+    return { version, releaseDate, releaseNotes, releaseUrl };
+  });
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -13,6 +13,7 @@ import type { ConnectorCatalogEntry } from "../main/ipc/connectors";
 import type { HttpToolCollectionRow, HttpToolRow, HttpToolParam } from "../main/ipc/httpTools";
 import type { TaskCreateInput, TaskRow, TaskUpdatePatch } from "../main/ipc/tasks";
 import type { AppInfo, AppStorageInfo, AppStats } from "../main/ipc/appInfo";
+import type { ReleaseInfo } from "../../scripts/releaseInfo";
 
 function subscribe(channel: string, callback: () => void): () => void {
   const listener = () => callback();
@@ -380,6 +381,9 @@ const agentsAPI = {
     stats: (): Promise<AppStats> => ipcRenderer.invoke("app:stats"),
     /** Resolves with the cache size remaining after the clear, so the UI can update in place. */
     clearCache: (): Promise<number> => ipcRenderer.invoke("app:clearCache"),
+    /** Live, once per call — unlike everything else here this hits the network. Never
+     * rejects; see ipc/updateCheck.ts. */
+    latestRelease: (): Promise<ReleaseInfo> => ipcRenderer.invoke("app:latestRelease"),
   },
 
   // Forwards renderer-side debug logs into the same userData/debug.log the main process

--- a/scripts/releaseInfo.ts
+++ b/scripts/releaseInfo.ts
@@ -1,18 +1,27 @@
 /**
- * Resolves the app's release metadata once, at build time, for injection into the renderer
- * (see electron.vite.config.ts). Runs against the public release repo, so the request is
- * unauthenticated and no token is ever bundled into the app — only the resolved values are.
+ * Resolves the app's release metadata. Runs against the public release repo, so the request
+ * is unauthenticated and no token is ever bundled into the app — only the resolved values
+ * are.
  *
- * Hard requirement: this must never throw and never reject. An offline `npm run build` has
- * to succeed, so every failure path resolves to FALLBACK_RELEASE_INFO instead. `0.0.0` is
- * the deliberate "no release tag found" sentinel; the About screen hides the row on it.
+ * Two callers, deliberately different in what they need from here:
+ *  - `electron.vite.config.ts` calls `resolveCommit()` alone, at build time, to bake the
+ *    building machine's git commit into the shipped app — the packaged app has no .git dir
+ *    of its own, so this is the only point the commit is ever knowable.
+ *  - `electron/main/ipc/updateCheck.ts` calls `resolveReleaseInfo()` at runtime, once per
+ *    launch, to check whether a newer release has been published since this build — that has
+ *    to happen live or it can never detect a release that shipped after the build ran.
+ *
+ * Hard requirement either way: this must never throw and never reject. An offline
+ * `npm run build` has to succeed, and a launch with no network has to proceed. Every failure
+ * path resolves to FALLBACK_RELEASE_INFO instead. `0.0.0` is the deliberate "no release tag
+ * found" sentinel; consumers hide the row on it.
  */
 
 import { execFileSync } from "node:child_process";
 
 const GITHUB_API = "https://api.github.com";
 const ACCEPT_HEADER = "application/vnd.github+json";
-const DEFAULT_REPO = "maneja81/OpenOrbit";
+export const DEFAULT_REPO = "maneja81/OpenOrbit";
 
 // Bounds the worst case for `npm run dev` on a slow or captive network — without it, a
 // hanging request would stall every build behind it.

--- a/src/components/molecules/AppControls.tsx
+++ b/src/components/molecules/AppControls.tsx
@@ -7,7 +7,13 @@ interface AppControlsProps {
   onOpenSettings: () => void;
   onStartTour: () => void;
   onOpenAbout: () => void;
+  /** This build's own version (app:info.packageVersion) — not the latest published release,
+   * which used to be shown here by mistake (see AgentsApp.tsx / AboutTab.tsx). */
   version: string;
+  /** True when a newer release than `version` has been published. Surfaced as a dot on
+   * #aboutbtn rather than a separate control — About already has the release details and the
+   * link out, and this app has no toast/banner system to put a fuller notice in. */
+  updateAvailable: boolean;
 }
 
 /** Bottom-left (#ctrls) and bottom-right (#ctrls-right) chrome docks. Both sit over #chat,
@@ -21,20 +27,32 @@ function openWiki() {
   void window.agentsAPI.fs.openExternal(APP_LINKS.wiki);
 }
 
-export default function AppControls({ onOpenSettings, onStartTour, onOpenAbout, version }: AppControlsProps) {
+export default function AppControls({
+  onOpenSettings,
+  onStartTour,
+  onOpenAbout,
+  version,
+  updateAvailable,
+}: AppControlsProps) {
   return (
     <>
       <div id="ctrls">
         {/* #aboutbtn is a tour target (see lib/tourSteps.ts) — the id must stay stable. */}
-        <IconButton id="aboutbtn" aria-label="About this app" title="About" onClick={onOpenAbout}>
+        <IconButton
+          id="aboutbtn"
+          aria-label={updateAvailable ? "About this app — update available" : "About this app"}
+          title={updateAvailable ? "About (update available)" : "About"}
+          onClick={onOpenAbout}
+        >
           <TablerIcon name="ti-info-circle" />
+          {updateAvailable && <span className="update-dot" aria-hidden="true" />}
         </IconButton>
         <IconButton id="helpbtn" aria-label="Open the OpenOrbit wiki" title="Help" onClick={openWiki}>
           <TablerIcon name="ti-question-mark" />
         </IconButton>
-        {/* "0.0.0" is the deliberate no-release-found sentinel (see scripts/releaseInfo.ts) —
-            hide it rather than show a meaningless version number. */}
-        {version !== "0.0.0" && <span id="app-version">v{version}</span>}
+        {/* Empty until the app:info round trip in AgentsApp.tsx resolves — hide rather than
+            show a blank "v". */}
+        {version && <span id="app-version">v{version}</span>}
       </div>
       <div id="ctrls-right">
         <IconButton id="tourbtn" aria-label="Replay tour" title="Replay tour" onClick={onStartTour}>

--- a/src/components/organisms/AboutTab.test.tsx
+++ b/src/components/organisms/AboutTab.test.tsx
@@ -17,6 +17,7 @@ function stubBridge() {
       get: vi.fn(async () => ({ packageVersion: "1.0.0", electron: "43.0.0", node: "22.0.0", platform: "darwin" })),
       storage: vi.fn(async () => ({ cacheBytes: 1024, dbBytes: 2048, knowledgeBytes: 512 })),
       stats: vi.fn(async () => ({ messages: 3, agents: 4 })),
+      latestRelease: vi.fn(async () => ({ version: "0.0.0", releaseDate: "", releaseNotes: "", releaseUrl: "" })),
       clearCache,
     },
     fs: { openExternal, revealInFolder },

--- a/src/components/organisms/AboutTab.tsx
+++ b/src/components/organisms/AboutTab.tsx
@@ -18,15 +18,13 @@ interface AboutTabProps {
   sessionElapsedMs: number;
 }
 
-/** Every value below is empty on a build made offline or before the first release was
- * published, so each consumer hides its row rather than showing a blank. */
-const RELEASE = {
-  version: __APP_RELEASE_VERSION__,
-  date: __APP_RELEASE_DATE__,
-  notes: __APP_RELEASE_NOTES__,
-  url: __APP_RELEASE_URL__,
-  commit: __APP_COMMIT__,
-};
+/** __APP_COMMIT__ is the only piece of release metadata still resolved at build time — the
+ * building machine's git commit, which the packaged app has no other way to know (see
+ * scripts/releaseInfo.ts). Everything else about "what's the latest release" is fetched live,
+ * below — a build-time value could only ever compare a build against itself. */
+const BUILD_COMMIT = __APP_COMMIT__;
+
+const EMPTY_RELEASE: ReleaseInfo = { version: "0.0.0", releaseDate: "", releaseNotes: "", releaseUrl: "" };
 
 function Row({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
@@ -45,6 +43,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
   const [info, setInfo] = useState<AppInfo | null>(null);
   const [storage, setStorage] = useState<AppStorageInfo | null>(null);
   const [stats, setStats] = useState<AppStats | null>(null);
+  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
   const [error, setError] = useState<string | null>(null);
   const [openLicense, setOpenLicense] = useState<string | null>(null);
   const [clearing, setClearing] = useState(false);
@@ -57,14 +56,18 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
       window.agentsAPI.appInfo.get(),
       window.agentsAPI.appInfo.storage(),
       window.agentsAPI.appInfo.stats(),
+      window.agentsAPI.appInfo.latestRelease(),
     ])
-      .then(([nextInfo, nextStorage, nextStats]) => {
+      .then(([nextInfo, nextStorage, nextStats, nextRelease]) => {
         if (cancelled) return;
         setInfo(nextInfo);
         setStorage(nextStorage);
         setStats(nextStats);
+        setRelease(nextRelease);
       })
       .catch((e) => {
+        // latestRelease() itself never rejects (see ipc/updateCheck.ts) — this only fires on
+        // an IPC-level failure, same as the three calls it joined before it.
         if (!cancelled) setError(formatHumanizedError(humanizeError(e)));
       });
     return () => {
@@ -102,7 +105,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
   const copyDiagnostics = useCallback(async () => {
     if (!info) return;
     const lines = [
-      `${info.name} ${info.packageVersion}${RELEASE.commit ? ` (build ${RELEASE.commit})` : ""}`,
+      `${info.name} ${info.packageVersion}${BUILD_COMMIT ? ` (build ${BUILD_COMMIT})` : ""}`,
       `Electron ${info.electronVersion} / Node ${info.nodeVersion} / Chrome ${info.chromeVersion}`,
       `${formatPlatformName(info.platform)} ${info.osVersion} (${info.arch}) — kernel ${info.osRelease}`,
     ];
@@ -135,8 +138,8 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
     setOpenLicense((prev) => (prev === key ? null : key));
   }, []);
 
-  const releaseDate = formatReleaseDate(RELEASE.date);
-  const updateAvailable = info ? isUpdateAvailable(RELEASE.version, info.packageVersion) : false;
+  const releaseDate = formatReleaseDate(release.releaseDate);
+  const updateAvailable = info ? isUpdateAvailable(release.version, info.packageVersion) : false;
   const pending = bridgeReady && !info && !error;
 
   return (
@@ -158,18 +161,18 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
               <Row label="Version" hint="This build">
                 <span className="about-value">{info?.packageVersion ?? "…"}</span>
               </Row>
-              {RELEASE.version !== "0.0.0" && (
+              {release.version !== "0.0.0" && (
                 <Row label="Latest release">
                   <span className="about-value">
-                    {RELEASE.version}
+                    {release.version}
                     {releaseDate && <small> · {releaseDate}</small>}
                     {updateAvailable && <span className="about-badge">Update available</span>}
                   </span>
                 </Row>
               )}
-              {RELEASE.commit && (
+              {BUILD_COMMIT && (
                 <Row label="Build">
-                  <span className="about-value about-value-mono">{RELEASE.commit}</span>
+                  <span className="about-value about-value-mono">{BUILD_COMMIT}</span>
                 </Row>
               )}
               {info && (
@@ -229,13 +232,13 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
           </SettingsAccordion>
         )}
 
-        {RELEASE.notes && (
+        {release.releaseNotes && (
           <SettingsAccordion
             icon="ti-sparkles"
-            title={`What's new in ${RELEASE.version}`}
+            title={`What's new in ${release.version}`}
             headerActions={
-              RELEASE.url ? (
-                <button className="settings-action-btn-sm" onClick={() => openLink(RELEASE.url)}>
+              release.releaseUrl ? (
+                <button className="settings-action-btn-sm" onClick={() => openLink(release.releaseUrl)}>
                   <span>View on GitHub</span>
                   <TablerIcon name="ti-external-link" />
                 </button>
@@ -243,7 +246,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
             }
           >
             <div className="about-notes">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{RELEASE.notes}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{release.releaseNotes}</ReactMarkdown>
             </div>
           </SettingsAccordion>
         )}

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -31,6 +31,7 @@ import { useBackgroundMusic } from "@/hooks/useBackgroundMusic";
 import { useSystemStats } from "@/hooks/useSystemStats";
 import { useTokenUsage } from "@/hooks/useTokenUsage";
 import { hasAgentsAPI } from "@/lib/agentsApi";
+import { isUpdateAvailable } from "@/lib/semver";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { AgentId, StepEvent, matchAgentSlashCommand } from "@/lib/agents";
@@ -222,6 +223,31 @@ export default function AgentsApp() {
     const start = Date.now();
     const interval = setInterval(() => setSessionElapsedMs(Date.now() - start), 60_000);
     return () => clearInterval(interval);
+  }, []);
+
+  // Checked once, on launch, against this build's own version — not the reverse of the old
+  // build-time check (see AboutTab.tsx / semver.ts), which could only ever compare a build
+  // against itself and so could never actually detect a release published afterward. No
+  // auto-download here, only the badge on #aboutbtn (AppControls.tsx) — see ipc/updateCheck.ts
+  // for why.
+  const [appVersion, setAppVersion] = useState("");
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  useEffect(() => {
+    if (!hasAgentsAPI()) return;
+    let cancelled = false;
+    Promise.all([window.agentsAPI.appInfo.get(), window.agentsAPI.appInfo.latestRelease()])
+      .then(([info, release]) => {
+        if (cancelled) return;
+        setAppVersion(info.packageVersion);
+        setUpdateAvailable(isUpdateAvailable(release.version, info.packageVersion));
+      })
+      .catch(() => {
+        // Version display and the update badge are both cosmetic — nothing here should
+        // interrupt launch or surface an error the user can't act on.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // A time-of-day greeting by the user's own name reads as more "alive" than a static
@@ -819,7 +845,8 @@ export default function AgentsApp() {
         entering={entering}
         locationEnabled={settings.locationEnabled}
         cognitiveState={cognitiveState}
-        version={__APP_RELEASE_VERSION__}
+        version={appVersion}
+        updateAvailable={updateAvailable}
         sessionStats={sessionStats}
       >
         <ErrorBoundary fallbackTitle="The chat failed to load">

--- a/src/components/organisms/OrbitScene.tsx
+++ b/src/components/organisms/OrbitScene.tsx
@@ -39,6 +39,7 @@ interface OrbitSceneProps {
   cognitiveState: string;
   sessionStats: string;
   version: string;
+  updateAvailable: boolean;
   children?: ReactNode;
 }
 
@@ -68,6 +69,7 @@ export default function OrbitScene({
   cognitiveState,
   sessionStats,
   version,
+  updateAvailable,
   children,
 }: OrbitSceneProps) {
   const activeLineD = activeAgent ? lineGeometry[activeAgent] : undefined;
@@ -118,6 +120,7 @@ export default function OrbitScene({
         onStartTour={onStartTour}
         onOpenAbout={onOpenAbout}
         version={version}
+        updateAvailable={updateAvailable}
       />
       <div id="widgets-left" className={entering ? "entering" : undefined}>
         <TokenUsageWidget steps={steps} />

--- a/src/globals.css
+++ b/src/globals.css
@@ -1582,6 +1582,7 @@ svg#oc {
 #tourbtn,
 #aboutbtn,
 #helpbtn {
+  position: relative;
   width: 34px;
   height: 34px;
   border-radius: 50%;
@@ -1593,6 +1594,21 @@ svg#oc {
   justify-content: center;
   transition: all 0.2s;
   padding: 7px;
+}
+
+/* A newer release than this build has been published (AppControls.tsx). Positioned against
+   #aboutbtn's own `position: relative` above rather than a wrapping element, so it tracks the
+   icon exactly. */
+.update-dot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #50a0ff;
+  border: 1.5px solid #00060f;
+  box-shadow: 0 0 4px rgba(80, 160, 255, 0.8);
 }
 
 #setbtn:hover {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,13 +1,9 @@
 /// <reference types="vite/client" />
 
-/** Build-time release metadata, substituted by the `define` block in electron.vite.config.ts
- * (mirrored into vite.config.ts for `dev:web`). Resolved from the OpenOrbit repo's latest
- * release when the build runs; every one of these is "" — and the version "0.0.0" — when no
- * release exists or the build was offline, so consumers must handle the empty case. */
-declare const __APP_RELEASE_VERSION__: string;
-declare const __APP_RELEASE_DATE__: string;
-declare const __APP_RELEASE_NOTES__: string;
-declare const __APP_RELEASE_URL__: string;
+/** The building machine's git commit, substituted by the `define` block in
+ * electron.vite.config.ts (mirrored into vite.config.ts for `dev:web`). "" when the build ran
+ * without a .git dir — the packaged app has none of its own, so this is the only point the
+ * commit is ever knowable (see scripts/releaseInfo.ts). */
 declare const __APP_COMMIT__: string;
 
 /** Build-time overrides for the About screen's outbound links (src/lib/appLinks.ts).
@@ -364,6 +360,16 @@ interface AppStats {
   messageCount: number;
 }
 
+/** Mirrors ReleaseInfo in scripts/releaseInfo.ts — the renderer does not import that module,
+ * so `tsc` will NOT catch editing only one side. "0.0.0" is the deliberate "no release found"
+ * sentinel; every field is "" alongside it. */
+interface ReleaseInfo {
+  version: string;
+  releaseDate: string;
+  releaseNotes: string;
+  releaseUrl: string;
+}
+
 interface Window {
   agentsAPI: {
     ping: () => Promise<string>;
@@ -576,6 +582,10 @@ interface Window {
       storage: () => Promise<AppStorageInfo>;
       stats: () => Promise<AppStats>;
       clearCache: () => Promise<number>;
+      /** Live, once per call — unlike everything else on this namespace this hits the
+       * network (unauthenticated GitHub API). Never rejects; a failed/offline check resolves
+       * to the "0.0.0" sentinel like every other releaseInfo consumer. */
+      latestRelease: () => Promise<ReleaseInfo>;
     };
     dev: {
       log: (...args: unknown[]) => void;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
-import { releaseDefines } from "./electron.vite.config";
+import { buildDefines } from "./electron.vite.config";
 
 export default defineConfig({
   plugins: [react()],
-  // Same constants the Electron renderer build injects. `npm run dev:web` renders the same
-  // components, so without these every __APP_*__ reference is an undefined global there.
-  define: releaseDefines,
+  // Same constant the Electron renderer build injects. `npm run dev:web` renders the same
+  // components, so without it __APP_COMMIT__ is an undefined global there.
+  define: buildDefines,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,17 +7,12 @@ export default defineConfig({
       "@": resolve(__dirname, "./src"),
     },
   },
-  // The renderer reads these as build-time globals (see releaseDefines in
+  // The renderer reads this as a build-time global (see buildDefines in
   // electron.vite.config.ts), so anything importing AboutTab throws ReferenceError without
-  // them. Fixed literals rather than the real `resolveReleaseInfo()` on purpose: that call
-  // hits git/network per run, and a test asserting on whatever version happens to be
-  // checked out is a test that changes meaning between machines. A non-"0.0.0" version is
-  // chosen so the version row renders — AboutTab hides it on the offline-build fallback.
+  // it. A fixed literal rather than the real `resolveCommit()` on purpose: that shells out to
+  // git per run, and a test asserting on whatever commit happens to be checked out is a test
+  // that changes meaning between machines.
   define: {
-    __APP_RELEASE_VERSION__: JSON.stringify("1.2.3"),
-    __APP_RELEASE_DATE__: JSON.stringify("2026-08-01T00:00:00Z"),
-    __APP_RELEASE_NOTES__: JSON.stringify("Test release notes."),
-    __APP_RELEASE_URL__: JSON.stringify("https://example.com/releases/1.2.3"),
     __APP_COMMIT__: JSON.stringify("0000000"),
   },
   test: {


### PR DESCRIPTION
## Summary
- The build-time release check (`releaseDefines` in `electron.vite.config.ts`) could only ever compare a build against itself, so it could never actually detect a release published after the build ran.
- Adds a runtime check on launch (`app:latestRelease` — `electron/main/ipc/updateCheck.ts`, reusing `scripts/releaseInfo.ts`'s existing `resolveReleaseInfo`) and surfaces it as a dot on the existing About icon (`#aboutbtn`) rather than adding a new toast/banner system, which doesn't exist anywhere in this app.
- No auto-download or install: the project isn't code-signed, so `electron-updater`'s silent-install path (Squirrel.Mac in particular) can't run on macOS, and shipping it Windows/Linux-only would give a different experience per platform. This only tells the user a release exists — About already had the release notes + GitHub link, now fed live data.
- Along the way: fixes `#app-version` next to the About icon, which was showing the *latest release's* version (a build-time constant) instead of the running build's own version.
- `__APP_COMMIT__` (the building machine's git commit) stays build-time-only — the packaged app has no `.git` dir of its own, so that's the only point it's ever knowable. Only the release-comparison fields moved to runtime.

Design discussion + evidence: `0-cowork/plans/done/update-notification.md`.

## Test plan
- [x] `npx eslint src electron` — exit 0
- [x] `npx tsc -b` — exit 0
- [x] `npm run build` — exit 0
- [x] `npm test` — 123 files / 1332 tests passed
- [ ] Live Electron run — not done, `run-openorbit` is currently broken on this machine's Node 26; badge placement/styling has not been eyeballed in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)