### PR TITLE
Update changelog for PRs #96-#101, fix stale status claims in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to OpenOrbit are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A Help button in the bottom-right dock** opens the OpenOrbit GitHub wiki in the
+  default browser. The bottom chrome dock is now split in two — Info and the app
+  version stay bottom-left, Help and Settings move to a new bottom-right dock — and
+  the tour-replay button switches from a question-mark icon to a route icon to free
+  `?` for Help.
+  ([#97](https://github.com/maneja81/OpenOrbit/pull/97))
+- **The app checks for a new release at launch** and badges the existing About icon
+  rather than adding a new toast/banner system. The previous build-time-only check
+  could only ever compare a build against itself, so it could never detect a release
+  published after the build ran. No auto-download or install — the project isn't
+  code-signed, so `electron-updater`'s silent-install path can't run on macOS, and a
+  Windows/Linux-only version would give a different experience per platform; this
+  only tells the user a release exists.
+  ([#98](https://github.com/maneja81/OpenOrbit/pull/98))
+- **Orbit now acknowledges config changes in chat.** Adding a knowledge file,
+  enabling location, or connecting a connector attached to an agent produces one
+  coalesced message (e.g. "I've got report.pdf. How can I help?"), shown immediately
+  if Settings is closed or once on close if several changes were made together.
+  ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+- **A dedicated `@` agent-mention menu in the chat input**, separate from the
+  existing `/` command menu. Typing `@` (or clicking the new "Agents" toolbar chip)
+  opens a menu of every enabled agent, grouped under "System" (the four built-in
+  agents) and "Custom" (user-created ones); selecting one inserts a plain-name
+  mention.
+  ([#101](https://github.com/maneja81/OpenOrbit/pull/101))
+- A Download section in the README linking directly to each v0.1.0 release asset
+  (macOS arm64/x64 `.dmg`, Windows `.exe`, Linux `.AppImage`), noting these are
+  versioned filenames that change next release, and flagging that builds are
+  unsigned so the Gatekeeper/SmartScreen prompt on first run isn't a surprise.
+  ([#96](https://github.com/maneja81/OpenOrbit/pull/96))
+
+### Changed
+
+- The orchestrator's internal reasoning now explicitly decomposes multi-part user
+  messages, checks which specialist/resource actually covers each part, and is
+  honest about the one-handoff-per-message architectural limit instead of implying
+  a same-turn multi-specialist chain it can't execute. Atlas no longer offers to
+  search "outside the knowledge base" since it has no web tools to back that up.
+  A pre-existing routing defect — the orchestrator can pick the wrong specialist
+  based on which one ran the previous turn — is not fixed by this change and is
+  tracked as follow-up.
+  ([#100](https://github.com/maneja81/OpenOrbit/pull/100))
+
+### Fixed
+
+- **Errors in MCP Servers, Connectors and HTTP Tools settings never cleared.** The
+  panels' data hooks live for the app's lifetime, and 8 methods across
+  `useMcpServers`/`useConnectors`/`useHttpTools` set `error` on failure but
+  bypassed the hooks' shared `run()` helper that clears it on entry — so a stale
+  failure could survive a tab switch or a full Settings close/reopen, outliving
+  the mutation that caused it.
+  ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+
 ## [0.1.0] — 2026-08-03
 
 The first release. Installers for macOS, Windows and Linux are attached to
@@ -356,4 +413,5 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...develop
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Use live code evidence before planning or editing. Make the smallest safe change
 
 OpenOrbit — a desktop app that runs a team of AI agents locally, with a central orchestrator delegating to specialist sub-agents, each with its own tools and access to the user's files, apps, and Google account.
 
-**Status:** implemented and under active development on `develop-ai`. ~290 source files across an Electron main process, a preload bridge, and a React renderer. The source tree is currently untracked in git (only `README.md`, `LICENSE`, `.gitignore`, and this file are committed) — `README.md` still describes the project as "idea phase" and is stale.
+**Status:** released (v0.1.0) and under active development on `develop`. ~290 source files across an Electron main process, a preload bridge, and a React renderer.
 
 Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`: Cipher (`configAgent`), Atlas (`knowledgeAgent`), Explorer (`explorerAgent`), Chrono (`taskAgent`). The orchestrator ("Orbit") is singular, not an `agents` row, and is configured from its own prompt file plus settings.
 
@@ -105,7 +105,7 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 
 ## Worktrees
 
-- ⚠ **Branch every new worktree from `develop`.** `develop` is the default working branch and carries the entire app. `main` sits at `ca1f8d8` — a README-only "idea phase" commit with no `src/`, no `electron/`, no `package.json`. A worktree cut from `main` (or from whatever HEAD happened to be) reads as an *empty project*, and has now misled three separate sessions into concluding the feature they were sent to fix doesn't exist.
+- ⚠ **Branch every new worktree from `develop`.** `develop` is the default working branch and is always ahead of `main` — `main` only moves at a release cut or hotfix, so a worktree cut from `main` (or from whatever HEAD happened to be) is missing whatever has merged into `develop` since the last release, reading as stale or feature-incomplete. This has now misled four separate sessions, including one that skipped `main`'s old idea-phase commit entirely and instead branched from a `main`-based release-sync merge that was itself several PRs behind `develop`.
 
   ```bash
   git worktree add -b <branch> .claude/worktrees/<name> develop


### PR DESCRIPTION
## What changed
Adds an `[Unreleased]` section to `CHANGELOG.md` covering six PRs merged since the v0.1.0 release (#96–#101: README download links, the Help-button dock split, launch-time release checking, sticky-settings-error fix + in-chat config acknowledgments, orchestrator decomposition tightening, and the `@` agent-mention menu). #95, a release-sync merge with no user-facing content, is intentionally omitted. Also corrects two stale claims in `CLAUDE.md`: the app is released and worked on branch `develop` (not `develop-ai`/untracked), and `main` no longer sits at the old idea-phase commit — it was fast-forwarded to `develop`'s tip at the v0.1.0 release.

## Root cause
Documentation drift — `CHANGELOG.md` wasn't updated as PRs merged post-release, and `CLAUDE.md`'s status line and worktree-warning both described a pre-release repo state.

## Testing
- Unit/integration: 1363/1363 passed (127 files)
- E2E: not configured for this repo
- Manual: verified no README currently says "idea phase" on either `main` or `develop`; cross-checked each new changelog entry and CLAUDE.md claim against live commits/diffs (`git show`, `git log`) before writing it

## Notes
- Companion wiki updates (Help button, `@` mention menu, config acks, update-check badge, `updateCheck` IPC handler) were pushed separately to the `OpenOrbit.wiki` repo — not part of this PR's diff since the wiki is a separate git repository.
- This worktree had originally been branched from a stale `main`-derived commit, six commits behind `develop` — reset to `develop`'s tip before making these changes (no unique work was lost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)