### PR TITLE
Fix chat log overlapping the orbit orchestrator node

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -582,7 +582,7 @@ svg#oc {
 
 #chat-log {
   min-height: 36px;
-  max-height: 40vh;
+  max-height: 28vh;
   overflow-y: auto;
   padding: 10px 20px 4px;
   display: flex;
@@ -2881,7 +2881,7 @@ svg#oc {
    centre-anchored and pointer-events: none, so it neither overlaps nor blocks these columns.
 
    bottom: 96px is the chat's *resting* height (#bar: a one-line input card plus its 12/22
-   padding). It is deliberately not the chat's maximum: #chat-log grows to 40vh, and sizing
+   padding). It is deliberately not the chat's maximum: #chat-log grows to 28vh, and sizing
    these columns for that would shorten them by ~430px permanently to avoid an overlap that
    only exists while the backlog is long. The overlap is handled by z-order instead — #chat
    is z-index 30 against these columns' 15, so a grown chat paints over the bottom of a

--- a/src/hooks/useOrbitScene.ts
+++ b/src/hooks/useOrbitScene.ts
@@ -95,7 +95,7 @@ export function useOrbitScene({
   const sizesRef = useRef({ orchestratorHalf: 70, innerRadius: 210, outerRadius: 210 + BAND_GAP });
 
   function getCenter(container: HTMLDivElement) {
-    return { x: container.clientWidth / 2, y: container.clientHeight * 0.41 };
+    return { x: container.clientWidth / 2, y: container.clientHeight * 0.385 };
   }
 
   function updateSizes(container: HTMLDivElement, orchestratorEl: HTMLDivElement) {


### PR DESCRIPTION
## What changed
Lowers `#chat-log`'s max-height from 40vh to 28vh and raises the orbit scene's vertical center from 41% to 38.5% of container height, so the ORBIT orchestrator node and lower-ring agent orbs stay clear of the chat panel at 900px+ window heights. Combined effect: ~136px of clearance instead of ~5px.

## Root cause
At a 900px window, the chat top (40vh) sat ~5px below the orchestrator's bottom edge; the fade gradient on the chat panel made this read as a full overlap, and the lower orbit ring was obscured entirely once the chat backlog grew.

## Testing
- Unit/integration: 1363 passed (127 test files)
- E2E: not configured in this repo
- Manual: visually confirmed in the running app that the ORBIT node and agent orbs stay clear of the chat log with 5+ messages sent, at 900px+ window height

## Notes
28vh is a deliberate UX tradeoff — long chat replies scroll sooner than before. No named constant exists yet for the orbit center fraction; if one is added later, 0.385 becomes a second source of truth to keep in sync.