### PR TITLE
Add CHANGELOG entry for PR #105 (orbit/chat-log overlap fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure could survive a tab switch or a full Settings close/reopen, outliving
   the mutation that caused it.
   ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+- **The orbit orchestrator node and lower agent orbs could sit under the chat
+  log.** At a 900px window the chat panel's 40vh max-height left the orbit node
+  about 5px of clearance, and the panel's fade gradient made that read as a
+  full overlap once the log grew. The chat log now caps at 28vh and the orbit's
+  vertical center moved from 41% to 38.5% of the container, about 136px of
+  clearance instead of 5px.
+  ([#105](https://github.com/maneja81/OpenOrbit/pull/105))
 
 ## [0.1.0] — 2026-08-03
 


### PR DESCRIPTION
## What changed
Adds a `### Fixed` entry to `CHANGELOG.md`'s `[Unreleased]` section for PR #105 (the orbit orchestrator node/agent orbs sitting under the chat log at 900px+ window heights). The section covered #96-#101 but stopped short of #105.

## Root cause
Documentation drift - the changelog wasn't updated when #105 merged, same pattern #102 already fixed once for #96-#101.

## Testing
- Unit/integration: 1363 passed (127 test files)
- E2E: not configured for this diff (docs-only, no `e2e/` coverage applies)
- Manual: diffed against PR #105's own body and confirmed the entry matches its stated root cause and numbers (40vh->28vh, 41%->38.5%, ~5px->~136px clearance)

## Notes
Companion wiki update (`Developer-Build-Test-and-Verify.md`, documenting the #103 E2E test setup) was pushed directly to the wiki repo - GitHub wikis have no PR surface.