### PR TITLE
Add Phase 1 E2E coverage: Agents, HTTP Tools, General, Privacy & Safety, App Sounds, Tasks

### DIFF
--- a/e2e/agents-tab.spec.ts
+++ b/e2e/agents-tab.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoField,
+  blurActive,
+  confirmTypeToDelete,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Settings → Agents: create/edit/enable/export/import/delete a custom agent. Built-in agents
+// (Cipher/Atlas/Explorer/Chrono/the orchestrator) are excluded from destructive coverage — only
+// a custom agent this spec creates itself is ever deleted.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Agents tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Agents");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates, edits, toggles, and deletes a custom agent", async () => {
+    await clickByText(page, "New");
+    await typeIntoField(page, ".add-agent-form input", "E2E Scout");
+    await clickByText(page, "Add Agent");
+
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM agents WHERE name = ?").get("E2E Scout") as
+          | { id: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(row, "created agent never appeared in the sandbox DB").toBeDefined();
+    expect(row!.enabled).toBe(1);
+
+    // Expand the new agent's accordion and edit its tagline — commits onBlur, not per keystroke.
+    await clickByText(page, "E2E Scout");
+    await typeIntoField(page, '.agent-accordion-body input[placeholder="e.g. App configuration"]', "Testing tagline");
+    await blurActive(page);
+
+    const updated = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT tagline FROM agents WHERE id = ?").get(row!.id) as
+          | { tagline: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(updated?.tagline).toBe("Testing tagline");
+
+    // Toggle disabled.
+    await clickSelector(page, `[aria-label="Toggle E2E Scout"]`);
+    const disabled = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM agents WHERE id = ?").get(row!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabled?.enabled).toBe(0);
+
+    // Delete requires typing DELETE to confirm.
+    await clickByText(page, "Delete");
+    await confirmTypeToDelete(page);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM agents WHERE id = ?").get(row!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+
+  test("exports and imports an agent through a stubbed native file dialog", async () => {
+    // Playwright cannot click through a native OS dialog — stub Electron's dialog module in the
+    // main process before triggering the click. It's the same module-level `dialog` singleton
+    // agent.ts imports, so patching it here is visible to the IPC handler.
+    const exportPath = path.join(userData, "exported-agent.json");
+    await app.evaluate(
+      async ({ dialog }, exportPath) => {
+        dialog.showSaveDialog = (async () => ({ canceled: false, filePath: exportPath })) as typeof dialog.showSaveDialog;
+      },
+      exportPath
+    );
+
+    await clickByText(page, "New");
+    await typeIntoField(page, ".add-agent-form input", "E2E Export Me");
+    await clickByText(page, "Add Agent");
+    await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id FROM agents WHERE name = ?").get("E2E Export Me") as
+          | { id: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+
+    await clickByText(page, "E2E Export Me");
+    await clickByText(page, "Export");
+
+    const exported = await pollUntil(() => (fs.existsSync(exportPath) ? { ok: true } : undefined));
+    expect(exported?.ok, "export never wrote the stubbed file path").toBe(true);
+    const payload = JSON.parse(fs.readFileSync(exportPath, "utf-8"));
+    expect(payload.name).toBe("E2E Export Me");
+
+    // Import it back under a new name to prove the round trip lands a fresh agent row.
+    payload.name = "E2E Imported Agent";
+    const importPath = path.join(userData, "import-agent.json");
+    fs.writeFileSync(importPath, JSON.stringify(payload), "utf-8");
+
+    await app.evaluate(
+      async ({ dialog }, importPath) => {
+        dialog.showOpenDialog = (async () => ({
+          canceled: false,
+          filePaths: [importPath],
+        })) as typeof dialog.showOpenDialog;
+      },
+      importPath
+    );
+
+    await clickByText(page, "Import Agent");
+
+    const imported = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id FROM agents WHERE name = ?").get("E2E Imported Agent") as
+          | { id: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(imported, "imported agent never appeared in the sandbox DB").toBeDefined();
+  });
+});

--- a/e2e/app-sounds-tab.spec.ts
+++ b/e2e/app-sounds-tab.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickSelector,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — App Sounds tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "App Sounds");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("switches a sound variant", async () => {
+    await pickCombobox(page, "Message sent variant", "Variant 2");
+    const value = await pollUntil(() => readSetting("soundVariantSend") as number | undefined);
+    expect(value).toBe(2);
+  });
+
+  test("preview button does not throw", async () => {
+    // Audio.play() in a headless/CI Electron environment commonly rejects (autoplay policy, no
+    // output device) — previewSound() swallows that (.catch(() => {})), so the only thing worth
+    // asserting is that the click itself doesn't surface a renderer error.
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+    await clickSelector(page, '[aria-label="Preview Message sent"]');
+    await page.waitForTimeout(300);
+    expect(errors).toEqual([]);
+  });
+});

--- a/e2e/general-tab.spec.ts
+++ b/e2e/general-tab.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  typeIntoField,
+  blurActive,
+  clickSelector,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — General tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "General");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("commits the name field on blur", async () => {
+    await typeIntoField(page, 'input[aria-label="What should I call you?"]', "Renamed Tester");
+    await blurActive(page);
+
+    const value = await pollUntil(() => readSetting("userName") as string | undefined);
+    expect(value).toBe("Renamed Tester");
+  });
+
+  test("toggles voice input and sound effects", async () => {
+    await clickSelector(page, '[aria-label="Toggle voice input"]');
+    const voiceInput = await pollUntil(() => readSetting("voiceInputEnabled") as boolean | undefined);
+    expect(voiceInput).toBe(false);
+
+    await clickSelector(page, '[aria-label="Toggle sound effects"]');
+    const soundFx = await pollUntil(() => readSetting("soundFxEnabled") as boolean | undefined);
+    expect(soundFx).toBe(false);
+  });
+
+  test("rejects an out-of-range agent run timeout and keeps the stored value", async () => {
+    const before = readSetting("agentRunTimeoutSeconds");
+
+    await typeIntoField(page, 'input[aria-label="Agent run timeout (seconds)"]', "0");
+    await blurActive(page);
+
+    // NumberField validates client-side before ever calling onCommit — an out-of-bounds value
+    // never reaches settings:update, so the stored value must be unchanged.
+    await page.waitForTimeout(300);
+    expect(readSetting("agentRunTimeoutSeconds")).toBe(before);
+  });
+
+  test("accepts an in-range agent run timeout", async () => {
+    await typeIntoField(page, 'input[aria-label="Agent run timeout (seconds)"]', "45");
+    await blurActive(page);
+
+    const value = await pollUntil(() => readSetting("agentRunTimeoutSeconds") as number | undefined);
+    expect(value).toBe(45);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,244 @@
+import { type ElectronApplication, type Page, _electron as electron } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import type { E2EProviderConfig } from "./providerConfig";
+
+// Shared launch/click/type/DB conventions, extracted from onboarding.spec.ts once a second spec
+// needed them (see 0-cowork/plans/active/e2e-full-coverage.md's reuse audit — premature extraction
+// for a single caller was deliberately deferred until Phase 1 gave it a second one).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const APP_DIR = path.resolve(__dirname, "..");
+
+export const ELECTRON_BIN =
+  process.platform === "darwin"
+    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(APP_DIR, "node_modules/electron/dist/electron");
+
+export function dbPath(userData: string): string {
+  return path.join(userData, "database/agents.db");
+}
+
+// Same realpath-comparison as driver.mjs's isInsideSandbox — macOS symlinks /tmp to /private/tmp,
+// so a plain startsWith would read a perfectly good sandbox as an escape.
+function isInsideSandbox(resolved: string, sandboxReal: string): boolean {
+  const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : path.resolve(resolved);
+  return real === sandboxReal || real.startsWith(sandboxReal + path.sep);
+}
+
+// React-controlled inputs ignore a plain `.value =` assignment — it has to go through the
+// prototype setter and dispatch a real input event, or onChange never fires.
+export async function typeIntoField(page: Page, selector: string, value: string): Promise<void> {
+  await page.evaluate(
+    ({ selector, value }) => {
+      const el = document.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | null;
+      if (!el) throw new Error(`field not found: ${selector}`);
+      // Settings' TextField/NumberField commit onBlur, not onChange — a later blurActive() only
+      // fires that handler if this element actually holds DOM focus, which a bare value-setter +
+      // dispatch does not give it.
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { selector, value }
+  );
+}
+
+// Locator clicks time out on "element is not stable" against this app's continuous framer-motion
+// animation — DOM click via evaluate sidesteps the actionability check entirely.
+export async function clickSelector(page: Page, selector: string): Promise<void> {
+  const found = await page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, selector);
+  if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
+}
+
+export async function clickByText(page: Page, text: string, scopeSelector?: string): Promise<void> {
+  const found = await page.evaluate(
+    ({ t, scopeSelector }) => {
+      const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+      if (!root) return false;
+      const els = [...root.querySelectorAll('button, a, [role="button"], [role="radio"], [role="option"]')];
+      const el = els.find((e) => e.textContent?.trim() === t);
+      if (!el) return false;
+      (el as HTMLElement).click();
+      return true;
+    },
+    { t: text, scopeSelector }
+  );
+  if (!found) throw new Error(`clickByText: no element with text "${text}"`);
+}
+
+// For fields with no aria-label/id to target directly — picks the Nth match (document order)
+// of `innerSelector` within `scopeSelector` and types into it.
+export async function typeIntoNth(
+  page: Page,
+  scopeSelector: string,
+  innerSelector: string,
+  index: number,
+  value: string
+): Promise<void> {
+  await page.evaluate(
+    ({ scopeSelector, innerSelector, index, value }) => {
+      const scope = document.querySelector(scopeSelector);
+      if (!scope) throw new Error(`typeIntoNth: no scope matching "${scopeSelector}"`);
+      const els = [...scope.querySelectorAll(innerSelector)] as (HTMLInputElement | HTMLTextAreaElement)[];
+      const el = els[index];
+      if (!el) throw new Error(`typeIntoNth: no element at index ${index} for "${innerSelector}" in "${scopeSelector}"`);
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { scopeSelector, innerSelector, index, value }
+  );
+}
+
+// Blurs whatever currently holds focus — Settings text/number fields commit onBlur, not per
+// keystroke, so a test must blur after typing (which focuses the field, see typeIntoField above)
+// before the write lands.
+export async function blurActive(page: Page): Promise<void> {
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+}
+
+export async function openCombobox(page: Page, ariaLabel: string): Promise<void> {
+  await clickSelector(page, `[aria-haspopup="listbox"][aria-label="${ariaLabel}"]`);
+}
+
+// Combobox options select on mousedown (not click) — e.preventDefault() there is deliberate,
+// keeping the search input focused instead of blurring it — so a synthetic .click() (which never
+// fires mousedown) is a silent no-op against them.
+export async function selectComboboxOption(page: Page, optionText: string): Promise<void> {
+  const found = await page.evaluate((t) => {
+    const els = [...document.querySelectorAll('[role="listbox"] [role="option"]')];
+    const el = els.find((e) => e.textContent?.trim() === t);
+    if (!el) return false;
+    el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    return true;
+  }, optionText);
+  if (!found) throw new Error(`selectComboboxOption: no option with text "${optionText}"`);
+}
+
+export async function pickCombobox(page: Page, ariaLabel: string, optionText: string): Promise<void> {
+  await openCombobox(page, ariaLabel);
+  await selectComboboxOption(page, optionText);
+}
+
+export async function confirmTypeToDelete(page: Page): Promise<void> {
+  await typeIntoField(page, ".delete-confirm-modal input", "DELETE");
+  await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+}
+
+export async function openSettings(page: Page): Promise<void> {
+  await clickSelector(page, "#setbtn");
+}
+
+export async function openSettingsTab(page: Page, label: string): Promise<void> {
+  await openSettings(page);
+  await clickByText(page, label, ".settings-sidebar");
+}
+
+export function launchSandboxedApp(): { userData: string } {
+  const userData = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "orbit-e2e-"));
+  return { userData };
+}
+
+export async function launchApp(userData: string): Promise<{ app: ElectronApplication; page: Page }> {
+  if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
+    throw new Error("no build — run `npm run build` first (main is dist-electron/main/index.js)");
+  }
+  const app = await electron.launch({
+    executablePath: ELECTRON_BIN,
+    args: [APP_DIR, `--user-data-dir=${userData}`],
+    timeout: 60_000,
+  });
+  const page = await app.firstWindow();
+  await page.waitForLoadState("domcontentloaded");
+  await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
+
+  // Non-negotiable: abort before any interaction if isolation didn't take, or the test writes
+  // into the developer's real ~/Library/Application Support/OpenOrbit database.
+  const resolvedUserData = await app.evaluate(({ app }) => app.getPath("userData"));
+  const sandboxReal = fs.realpathSync(userData);
+  if (!isInsideSandbox(resolvedUserData, sandboxReal)) {
+    await app.close();
+    throw new Error(`ABORT: userData resolved to ${resolvedUserData}, expected under ${sandboxReal}`);
+  }
+  return { app, page };
+}
+
+// Drives the same onboarding flow onboarding.spec.ts exercises directly, purely as a means to
+// reach the main screen — every Electron build gates on `settings.onboardingDone`
+// (AgentsApp.tsx's showOnboarding), so any spec that needs Settings open has to clear it first.
+export async function completeOnboarding(page: Page, provider: E2EProviderConfig): Promise<void> {
+  await typeIntoField(page, 'input[aria-label="Give me a name?"]', "TestOrbit");
+  await page.keyboard.press("Enter");
+
+  await typeIntoField(page, 'input[aria-label="What should I call you?"]', "E2E Tester");
+  await page.keyboard.press("Enter");
+
+  // profession is an optional *text* step — no Skip button, just an always-enabled Next.
+  await clickSelector(page, '[aria-label="Next"]');
+
+  // responseStyle, technicalLevel, stuckStyle — optional *chip* steps, each with its own Skip.
+  for (let i = 0; i < 3; i++) {
+    await clickSelector(page, '[aria-label="Skip"]');
+  }
+
+  await clickByText(page, provider.label);
+
+  // apiUrl step is prefilled from the provider's registry entry — accept the default.
+  await page.keyboard.press("Enter");
+
+  await typeIntoField(page, 'input[aria-label="Enter your API key"]', provider.apiKey);
+  await page.keyboard.press("Enter");
+
+  // model step is prefilled — accept the default.
+  await page.keyboard.press("Enter");
+
+  // handleOnboardingComplete fires providers.selectChat fire-and-forget, so the main screen can
+  // render before the write lands — wait for the orbit UI (settings button) rather than a fixed
+  // delay.
+  await page.waitForSelector("#setbtn", { timeout: 15_000 });
+}
+
+// global.d.ts deliberately types window.agentsAPI as `unknown` — every other spec drives the UI
+// rather than the bridge. The handful of specs that must call it directly (no UI exists to seed
+// a task; header decryption has no visible affordance) go through this narrow, local-only shape
+// instead of casting inline at each call site.
+export interface AgentsApiForE2E {
+  tasks: {
+    create: (input: { title: string }) => Promise<{ id: string; title: string }>;
+  };
+  httpTools: {
+    getCollectionHeaders: (id: string) => Promise<Record<string, string>>;
+  };
+}
+
+export function openDb(userData: string): Database.Database {
+  return new Database(dbPath(userData), { readonly: true, fileMustExist: false });
+}
+
+export async function pollUntil<T>(fn: () => T | undefined, timeoutMs = 5_000): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  let result: T | undefined;
+  while (Date.now() < deadline) {
+    try {
+      result = fn();
+    } catch {
+      // table may not exist yet on the very first poll — keep waiting.
+    }
+    if (result !== undefined) return result;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return result;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -61,19 +61,26 @@ export async function clickSelector(page: Page, selector: string): Promise<void>
   if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
 }
 
+// Retries briefly: a preceding action (e.g. a create submit) can resolve before React's list
+// re-render commits, and the target text isn't in the DOM yet on the very next evaluate.
 export async function clickByText(page: Page, text: string, scopeSelector?: string): Promise<void> {
-  const found = await page.evaluate(
-    ({ t, scopeSelector }) => {
-      const root = scopeSelector ? document.querySelector(scopeSelector) : document;
-      if (!root) return false;
-      const els = [...root.querySelectorAll('button, a, [role="button"], [role="radio"], [role="option"]')];
-      const el = els.find((e) => e.textContent?.trim() === t);
-      if (!el) return false;
-      (el as HTMLElement).click();
-      return true;
-    },
-    { t: text, scopeSelector }
-  );
+  const deadline = Date.now() + 3_000;
+  let found = false;
+  while (!found && Date.now() < deadline) {
+    found = await page.evaluate(
+      ({ t, scopeSelector }) => {
+        const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+        if (!root) return false;
+        const els = [...root.querySelectorAll('button, a, [role="button"], [role="radio"], [role="option"]')];
+        const el = els.find((e) => e.textContent?.trim() === t);
+        if (!el) return false;
+        (el as HTMLElement).click();
+        return true;
+      },
+      { t: text, scopeSelector }
+    );
+    if (!found) await new Promise((r) => setTimeout(r, 100));
+  }
   if (!found) throw new Error(`clickByText: no element with text "${text}"`);
 }
 

--- a/e2e/http-tools-tab.spec.ts
+++ b/e2e/http-tools-tab.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoNth,
+  openDb,
+  pollUntil,
+  type AgentsApiForE2E,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — HTTP Tools tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "HTTP Tools");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates a collection with encrypted headers, adds an endpoint, toggles both, deletes both", async () => {
+    await clickByText(page, "Add API");
+    await typeIntoNth(page, ".http-collection-form", "input", 0, "E2E API");
+    await typeIntoNth(page, ".http-collection-form", "input", 1, "Test collection");
+    await typeIntoNth(page, ".http-collection-form", "input", 2, "https://example.com");
+    await typeIntoNth(page, ".http-collection-form", "textarea", 0, "Authorization=Bearer secret-token");
+    await clickByText(page, "Add API", ".http-collection-form");
+
+    const collection = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, headers FROM http_tool_collections WHERE name = ?").get("E2E API") as
+          | { id: string; headers: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(collection, "collection never appeared in the sandbox DB").toBeDefined();
+    // Headers are encrypted at rest — the raw column must not contain the plaintext token.
+    expect(collection!.headers).not.toContain("secret-token");
+
+    const decrypted = await page.evaluate(
+      (id) => (window.agentsAPI as unknown as AgentsApiForE2E).httpTools.getCollectionHeaders(id),
+      collection!.id
+    );
+    expect(decrypted).toEqual({ Authorization: "Bearer secret-token" });
+
+    // Expand the collection row, add an endpoint.
+    await clickByText(page, "E2E API — no endpoints yet");
+    await clickByText(page, "Add endpoint");
+    await typeIntoNth(page, ".http-tool-form", "input", 0, "Get Widget");
+    await typeIntoNth(page, ".http-tool-form", "input", 1, "Fetch a widget");
+    await typeIntoNth(page, ".http-tool-form", "input", 2, "/widget");
+    await clickByText(page, "Add endpoint", ".http-tool-form");
+
+    const tool = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM http_tools WHERE name = ?").get("Get Widget") as
+          | { id: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(tool, "endpoint never appeared in the sandbox DB").toBeDefined();
+    expect(tool!.enabled).toBe(1);
+
+    // Toggle the endpoint off.
+    await clickSelector(page, '[aria-label="Toggle Get Widget"]');
+    const disabledTool = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM http_tools WHERE id = ?").get(tool!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabledTool?.enabled).toBe(0);
+
+    // Delete the endpoint (type-to-confirm), then the collection.
+    await clickSelector(page, '[aria-label="Remove Get Widget"]');
+    await typeIntoNth(page, ".delete-confirm-modal", "input", 0, "DELETE");
+    await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+
+    const toolGone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM http_tools WHERE id = ?").get(tool!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(toolGone?.deleted).toBe(true);
+
+    await clickSelector(page, '[aria-label="Remove E2E API"]');
+    await typeIntoNth(page, ".delete-confirm-modal", "input", 0, "DELETE");
+    await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+
+    const collectionGone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM http_tool_collections WHERE id = ?").get(collection!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(collectionGone?.deleted).toBe(true);
+  });
+});

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,76 +1,16 @@
-import { test, expect, _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, openDb, pollUntil } from "./helpers";
 
 // Drives the real Electron app through onboarding, selecting whichever provider E2E_PROVIDER
 // resolves to (see providerConfig.ts), and asserts the credential landed in the sandbox DB.
 // See .claude/skills/run-openorbit/driver.mjs for the manual-REPL version of the same
-// sandbox/click/DB-read conventions this spec reuses.
+// sandbox/click/DB-read conventions this spec reuses (now shared with the rest of e2e/ via
+// helpers.ts).
 
 // Resolved at module load, not inside a test/hook: a bad or unconfigured E2E_PROVIDER should
 // fail the whole suite immediately, not surface as a confusing mid-test failure.
 const provider = resolveE2EProvider();
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const APP_DIR = path.resolve(__dirname, "..");
-
-const ELECTRON_BIN =
-  process.platform === "darwin"
-    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
-    : path.join(APP_DIR, "node_modules/electron/dist/electron");
-
-function dbPath(userData: string): string {
-  return path.join(userData, "database/agents.db");
-}
-
-// Same realpath-comparison as driver.mjs's isInsideSandbox — macOS symlinks /tmp to /private/tmp,
-// so a plain startsWith would read a perfectly good sandbox as an escape.
-function isInsideSandbox(resolved: string, sandboxReal: string): boolean {
-  const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : path.resolve(resolved);
-  return real === sandboxReal || real.startsWith(sandboxReal + path.sep);
-}
-
-// React-controlled inputs ignore a plain `.value =` assignment — it has to go through the
-// prototype setter and dispatch a real input event, or onChange never fires.
-async function typeIntoField(page: Page, selector: string, value: string): Promise<void> {
-  await page.evaluate(
-    ({ selector, value }) => {
-      const el = document.querySelector(selector) as HTMLInputElement | null;
-      if (!el) throw new Error(`field not found: ${selector}`);
-      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
-      setter.call(el, value);
-      el.dispatchEvent(new Event("input", { bubbles: true }));
-    },
-    { selector, value }
-  );
-}
-
-// Locator clicks time out on "element is not stable" against this app's continuous framer-motion
-// animation — DOM click via evaluate sidesteps the actionability check entirely.
-async function clickSelector(page: Page, selector: string): Promise<void> {
-  const found = await page.evaluate((s) => {
-    const el = document.querySelector(s);
-    if (!el) return false;
-    (el as HTMLElement).click();
-    return true;
-  }, selector);
-  if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
-}
-
-async function clickByText(page: Page, text: string): Promise<void> {
-  const found = await page.evaluate((t) => {
-    const els = [...document.querySelectorAll('button, a, [role="button"], [role="radio"]')];
-    const el = els.find((e) => e.textContent?.trim() === t);
-    if (!el) return false;
-    (el as HTMLElement).click();
-    return true;
-  }, text);
-  if (!found) throw new Error(`clickByText: no element with text "${text}"`);
-}
 
 test.describe(`onboarding — ${provider.label}`, () => {
   let app: ElectronApplication;
@@ -78,29 +18,8 @@ test.describe(`onboarding — ${provider.label}`, () => {
   let userData: string;
 
   test.beforeAll(async () => {
-    if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
-      throw new Error("no build — run `npm run build` first (main is dist-electron/main/index.js)");
-    }
-
-    userData = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "orbit-e2e-"));
-
-    app = await electron.launch({
-      executablePath: ELECTRON_BIN,
-      args: [APP_DIR, `--user-data-dir=${userData}`],
-      timeout: 60_000,
-    });
-    page = await app.firstWindow();
-    await page.waitForLoadState("domcontentloaded");
-    await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
-
-    // Non-negotiable: abort before any interaction if isolation didn't take, or the test writes
-    // into the developer's real ~/Library/Application Support/OpenOrbit database.
-    const resolvedUserData = await app.evaluate(({ app }) => app.getPath("userData"));
-    const sandboxReal = fs.realpathSync(userData);
-    if (!isInsideSandbox(resolvedUserData, sandboxReal)) {
-      await app.close();
-      throw new Error(`ABORT: userData resolved to ${resolvedUserData}, expected under ${sandboxReal}`);
-    }
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
   });
 
   test.afterAll(async () => {
@@ -108,55 +27,26 @@ test.describe(`onboarding — ${provider.label}`, () => {
   });
 
   test(`completes onboarding selecting ${provider.label} and persists the provider`, async () => {
-    await typeIntoField(page, 'input[aria-label="Give me a name?"]', "TestOrbit");
-    await page.keyboard.press("Enter");
-
-    await typeIntoField(page, 'input[aria-label="What should I call you?"]', "E2E Tester");
-    await page.keyboard.press("Enter");
-
-    // profession is an optional *text* step — no Skip button, just an always-enabled Next.
-    await clickSelector(page, '[aria-label="Next"]');
-
-    // responseStyle, technicalLevel, stuckStyle — optional *chip* steps, each with its own Skip.
-    for (let i = 0; i < 3; i++) {
-      await clickSelector(page, '[aria-label="Skip"]');
-    }
-
-    await clickByText(page, provider.label);
-
-    // apiUrl step is prefilled from the provider's registry entry — accept the default.
-    await page.keyboard.press("Enter");
-
-    await typeIntoField(page, 'input[aria-label="Enter your API key"]', provider.apiKey);
-    await page.keyboard.press("Enter");
-
-    // model step is prefilled — accept the default.
-    await page.keyboard.press("Enter");
+    await completeOnboarding(page, provider);
 
     // handleOnboardingComplete fires providers.selectChat fire-and-forget (not awaited by the UI),
     // so the DB write can land after the click resolves. Poll rather than assert immediately.
-    const deadline = Date.now() + 5_000;
-    let row: { id: string; api_url: string; keylen: number } | undefined;
-    while (Date.now() < deadline) {
-      const db = new Database(dbPath(userData), { readonly: true, fileMustExist: false });
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
       try {
-        row = db
+        return db
           .prepare("SELECT id, api_url, length(api_key) AS keylen FROM providers WHERE id = ?")
-          .get(provider.id) as typeof row;
-      } catch {
-        // table may not exist yet on the very first poll — keep waiting.
+          .get(provider.id) as { id: string; api_url: string; keylen: number } | undefined;
       } finally {
         db.close();
       }
-      if (row) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
+    });
 
     expect(row, `${provider.id} provider row never appeared in the sandbox DB`).toBeDefined();
     expect(row!.keylen).toBeGreaterThan(0);
     expect(row!.api_url).not.toBe("");
 
-    const settingsDb = new Database(dbPath(userData), { readonly: true });
+    const settingsDb = openDb(userData);
     const chatProviderRow = settingsDb
       .prepare("SELECT setting_value FROM settings WHERE setting_name = ?")
       .get("appSettings.chatProviderId") as { setting_value: string } | undefined;

--- a/e2e/privacy-safety-tab.spec.ts
+++ b/e2e/privacy-safety-tab.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickSelector,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Privacy & Safety tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Privacy & Safety");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("toggles the three approval methods", async () => {
+    await clickSelector(page, '[aria-label="Ask before POST requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalPost") as boolean | undefined)).toBe(false);
+
+    await clickSelector(page, '[aria-label="Ask before PUT / PATCH requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalPutPatch") as boolean | undefined)).toBe(false);
+
+    await clickSelector(page, '[aria-label="Ask before DELETE requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalDelete") as boolean | undefined)).toBe(false);
+  });
+
+  test("switches the approval display method", async () => {
+    await pickCombobox(page, "How to ask for approval", "Card in the chat");
+    const value = await pollUntil(() => readSetting("toolApprovalDisplay") as string | undefined);
+    expect(value).toBe("inline");
+  });
+
+  test("toggles location access and remote image loading", async () => {
+    await clickSelector(page, '[aria-label="Toggle location access"]');
+    expect(await pollUntil(() => readSetting("locationEnabled") as boolean | undefined)).toBe(true);
+
+    await clickSelector(page, '[aria-label="Toggle automatic remote image loading"]');
+    expect(await pollUntil(() => readSetting("remoteImagesAutoLoad") as boolean | undefined)).toBe(true);
+  });
+});

--- a/e2e/tasks-widget.spec.ts
+++ b/e2e/tasks-widget.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  clickSelector,
+  openDb,
+  pollUntil,
+  type AgentsApiForE2E,
+} from "./helpers";
+
+// There is no UI to create a task (electron/main/ai/tools/taskAgentTools.ts's createTaskTool is
+// the only real entry point, invoked mid-conversation by the agent, and the scheduler creates
+// recurring ones) — see 0-cowork/plans/active/e2e-full-coverage.md. Seeding here goes straight
+// through the same window.agentsAPI.tasks.create() contract the agent tool calls, so it still
+// exercises the real IPC validation (assertTaskFields) and DB write; only Complete/Delete are
+// driven through the actual TasksWidget UI.
+
+const provider = resolveE2EProvider();
+
+// TasksWidget only re-fetches on the "tasks:update" broadcast (electron/main/ipc/agent.ts's
+// broadcastTasksUpdate) — the same path Chrono's tools and the scheduler rely on for writes that
+// bypass the tasks:* IPC handlers, which is exactly what this seed does too (see the comment
+// below). Without firing it ourselves, a task created this way never appears in the widget.
+async function broadcastTasksUpdate(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ BrowserWindow }) => {
+    for (const win of BrowserWindow.getAllWindows()) win.webContents.send("tasks:update");
+  });
+}
+
+test.describe("Tasks widget", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("tasks:create rejects a blank title", async () => {
+    const error = await page.evaluate(async () => {
+      try {
+        await (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "" });
+        return null;
+      } catch (err) {
+        return String(err);
+      }
+    });
+    expect(error).toContain("non-empty title");
+  });
+
+  test("completes a task through the widget", async () => {
+    const created = await page.evaluate(
+      () => (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "E2E Complete Me" })
+    );
+    await broadcastTasksUpdate(app);
+    await page.waitForSelector(`[aria-label="Complete ${created.title}"]`, { timeout: 10_000 });
+
+    await clickSelector(page, `[aria-label="Complete ${created.title}"]`);
+
+    const done = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT status FROM tasks WHERE id = ?").get(created.id) as
+          | { status: string }
+          | undefined;
+        return r && r.status === "done" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(done?.status).toBe("done");
+  });
+
+  test("deletes a task through the widget", async () => {
+    const created = await page.evaluate(
+      () => (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "E2E Delete Me" })
+    );
+    await broadcastTasksUpdate(app);
+    await page.waitForSelector(`[aria-label="Delete ${created.title}"]`, { timeout: 10_000 });
+
+    await clickSelector(page, `[aria-label="Delete ${created.title}"]`);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM tasks WHERE id = ?").get(created.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed
Adds Playwright E2E coverage for six local-only settings surfaces and the tasks widget — Phase 1 of the `e2e-full-coverage` roadmap: Agents (create/edit/toggle/delete/export/import), HTTP Tools (collection + endpoint CRUD, encrypted-header round trip), General (name/toggles/numeric bounds), Privacy & Safety, App Sounds, and Tasks (complete/delete, plus direct-IPC creation since no UI exists for it). Extracts the sandboxed-launch/click/type/DB helpers `onboarding.spec.ts` proved out into shared `e2e/helpers.ts` now that a second consumer exists, and refactors `onboarding.spec.ts` onto it with no behavior change.

## Root cause
N/A — new test coverage, not a fix.

## Testing
- Unit/integration: 127 files / 1363 tests passing, eslint 0, `tsc -b` 0 (root + `e2e/tsconfig.json` separately, since it's not part of the root project references)
- E2E: 16/16 passing (onboarding + 6 new specs), run twice against the built app to rule out flake
- Manual: n/a — driven entirely through the real Electron app via Playwright, sandboxed `--user-data-dir` per spec

## Notes
- Agent export/import exercised via a stubbed `dialog.showSaveDialog`/`showOpenDialog` in the main process (`app.evaluate`) — Playwright can't click a native OS file picker.
- Combobox options select on `mousedown`, not `click` (keeps the search input focused) — `helpers.ts` dispatches the right event.
- Settings text/number fields commit on blur, not per keystroke — `typeIntoField` now focuses the element so a later blur actually fires the field's own handler.
- Task creation has no UI (only the agent's `createTaskTool` or the scheduler write it) — seeded via `window.agentsAPI.tasks.create()` directly, then the app's own `tasks:update` broadcast is fired manually so the widget picks it up, matching how Chrono/scheduler-created tasks already surface.
- Phases 2–6 of the roadmap (MCP/Models, Knowledge/About live network, real AI chat, Connectors OAuth, Danger Zone reset) are explicitly out of scope for this PR.