### PR TITLE
Add Phase 2 E2E coverage: MCP Servers tab and Models tab

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -110,6 +110,56 @@ export async function typeIntoNth(
   );
 }
 
+// For rows with no aria-label/id at all (e.g. ApiKeyField, whose <span>{label}</span> is only
+// ever visible text) — finds a `rowSelector` element whose text starts with `labelText` and types
+// into its first `input`/`textarea`.
+export async function typeIntoLabeledRow(
+  page: Page,
+  rowSelector: string,
+  labelText: string,
+  value: string
+): Promise<void> {
+  await page.evaluate(
+    ({ rowSelector, labelText, value }) => {
+      const rows = [...document.querySelectorAll(rowSelector)];
+      const row = rows.find((r) => r.textContent?.trim().startsWith(labelText));
+      if (!row) throw new Error(`typeIntoLabeledRow: no "${rowSelector}" starting with "${labelText}"`);
+      const el = row.querySelector("input, textarea") as HTMLInputElement | HTMLTextAreaElement | null;
+      if (!el) throw new Error(`typeIntoLabeledRow: no input/textarea inside row "${labelText}"`);
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { rowSelector, labelText, value }
+  );
+}
+
+// Companion to typeIntoLabeledRow — clicks a button by text inside the row starting with
+// `labelText`, e.g. ApiKeyField's per-provider "Remove" button.
+export async function clickInLabeledRow(
+  page: Page,
+  rowSelector: string,
+  labelText: string,
+  buttonText: string
+): Promise<void> {
+  const found = await page.evaluate(
+    ({ rowSelector, labelText, buttonText }) => {
+      const rows = [...document.querySelectorAll(rowSelector)];
+      const row = rows.find((r) => r.textContent?.trim().startsWith(labelText));
+      if (!row) return false;
+      const buttons = [...row.querySelectorAll("button")];
+      const btn = buttons.find((b) => b.textContent?.trim() === buttonText);
+      if (!btn) return false;
+      btn.click();
+      return true;
+    },
+    { rowSelector, labelText, buttonText }
+  );
+  if (!found) throw new Error(`clickInLabeledRow: no "${buttonText}" button in row "${labelText}"`);
+}
+
 // Blurs whatever currently holds focus — Settings text/number fields commit onBlur, not per
 // keystroke, so a test must blur after typing (which focuses the field, see typeIntoField above)
 // before the write lands.

--- a/e2e/mcp-servers-tab.spec.ts
+++ b/e2e/mcp-servers-tab.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoNth,
+  confirmTypeToDelete,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// mcp:create/update/delete/toggle are pure local DB writes with no command validation (see
+// electron/main/ai/mcp.ts's createMcpServer) — a fake command is safe to use throughout. Only
+// mcp:test's failure path is exercised: a real successful connect needs an actual MCP-protocol
+// server process on the other end (MCPServerStdio's real JSON-RPC handshake), which this harness
+// doesn't provision — see 0-cowork/plans/active/e2e-full-coverage.md Phase 2.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — MCP Servers tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "MCP Servers");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates, edits, toggles, and deletes a server with a fake command", async () => {
+    await clickByText(page, "Add MCP Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "E2E Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 1, "does-not-exist-xyz");
+    await typeIntoNth(page, ".mcp-add-form", "input", 2, "--flag value");
+    await typeIntoNth(page, ".mcp-add-form", "textarea", 0, "API_KEY=test-value");
+    await clickByText(page, "Save", ".mcp-add-form");
+
+    const server = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, command, args, enabled FROM mcp_servers WHERE name = ?").get("E2E Server") as
+          | { id: string; command: string; args: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(server, "server never appeared in the sandbox DB").toBeDefined();
+    expect(server!.command).toBe("does-not-exist-xyz");
+    expect(JSON.parse(server!.args)).toEqual(["--flag", "value"]);
+    expect(server!.enabled).toBe(1);
+
+    // Expand the row and edit the command.
+    await clickByText(page, "E2E Server");
+    await typeIntoNth(page, ".agent-accordion-body", "input", 1, "still-does-not-exist");
+    await clickByText(page, "Save changes", ".agent-accordion-body");
+
+    const updated = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT command FROM mcp_servers WHERE id = ?").get(server!.id) as
+          | { command: string }
+          | undefined;
+        return r && r.command === "still-does-not-exist" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(updated?.command).toBe("still-does-not-exist");
+
+    // Toggle disabled.
+    await clickSelector(page, '[aria-label="Toggle E2E Server"]');
+    const disabled = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM mcp_servers WHERE id = ?").get(server!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabled?.enabled).toBe(0);
+
+    // Delete (type-to-confirm).
+    await clickSelector(page, '[aria-label="Remove E2E Server"]');
+    await confirmTypeToDelete(page);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM mcp_servers WHERE id = ?").get(server!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+
+  test("Test connection surfaces an error for a command that can't spawn", async () => {
+    await clickByText(page, "Add MCP Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "E2E Bad Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 1, "definitely-not-a-real-binary-xyz");
+    await clickByText(page, "Test connection", ".mcp-add-form");
+
+    await page.waitForSelector(".settings-error", { timeout: 15_000 });
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText.length).toBeGreaterThan(0);
+
+    // Test connection never writes to the DB — confirm the row doesn't exist.
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT id FROM mcp_servers WHERE name = ?").get("E2E Bad Server");
+      expect(row).toBeUndefined();
+    } finally {
+      db.close();
+    }
+
+    await clickByText(page, "Cancel", ".mcp-add-form");
+  });
+
+  // Registry search is a live HTTPS call to registry.modelcontextprotocol.io (searchMcpRegistry in
+  // electron/main/ai/mcp.ts) — the roadmap doc filed MCP Servers under Phase 2 as "local", which
+  // this test corrects: search genuinely depends on an external service being reachable. Assertions
+  // stay lenient about *what* comes back (a registry-side hiccup shouldn't fail the suite) but not
+  // about *whether the call completed cleanly* (a thrown error is a real regression to catch).
+  test("registry search reaches the live MCP registry and installs a result", async () => {
+    await clickByText(page, "Add MCP Server");
+    await clickByText(page, "Browse Registry", ".mcp-add-form");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "filesystem");
+    await clickByText(page, "Search", ".mcp-add-form");
+
+    await page.waitForFunction(
+      () => document.querySelector(".settings-hint, .settings-empty, .settings-error") !== null,
+      { timeout: 15_000 }
+    );
+
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText, "registry search reported an error").toBe("");
+
+    const hasInstallButton = await page.evaluate(
+      () => [...document.querySelectorAll(".settings-folder-row button")].some((b) => b.textContent?.trim() === "Install")
+    );
+    if (!hasInstallButton) {
+      test.info().annotations.push({ type: "note", description: "registry returned no installable results for this query" });
+      return;
+    }
+
+    await clickByText(page, "Install");
+    const installed = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM mcp_servers WHERE command LIKE ? OR command LIKE ?").get(
+          "%npx%",
+          "%node%"
+        ) as { id: string; enabled: number } | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(installed, "installed server never appeared in the sandbox DB").toBeDefined();
+    // Installed servers land disabled by design (mcp.ts's handleInstall comment) — a
+    // registry-sourced command shouldn't silently start running before it's reviewed.
+    expect(installed?.enabled).toBe(0);
+  });
+});

--- a/e2e/models-tab.spec.ts
+++ b/e2e/models-tab.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  typeIntoLabeledRow,
+  clickInLabeledRow,
+  typeIntoField,
+  blurActive,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Only non-Test-button actions — settings:testChat/testVoice (the "Test" buttons beside the Chat
+// provider and Voice rows) are explicitly out of scope here, deferred to Phase 4 alongside the
+// live-provider chat flow. See 0-cowork/plans/active/e2e-full-coverage.md.
+
+const provider = resolveE2EProvider();
+// A non-chat provider to exercise the plain providers:save path — onboarding always selects
+// E2E_PROVIDER as Chat, so any other AI_PROVIDERS entry works here as long as it isn't that one.
+const OTHER_PROVIDER_LABEL = provider.id === "openai" ? "OpenRouter" : "OpenAI";
+
+test.describe("Settings — Models tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Models");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readProviderRow(id: string): { api_url: string; keylen: number } | undefined {
+    const db = openDb(userData);
+    try {
+      return db.prepare("SELECT api_url, length(api_key) AS keylen FROM providers WHERE id = ?").get(id) as
+        | { api_url: string; keylen: number }
+        | undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("saves, then clears, a non-chat provider's API key and URL", async () => {
+    await typeIntoLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API key`, "sk-e2e-test-key");
+    await blurActive(page);
+
+    const saved = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row && row.keylen > 0 ? row : undefined;
+    });
+    expect(saved?.keylen).toBeGreaterThan(0);
+
+    await typeIntoLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API URL`, "https://example.com/v1");
+    await blurActive(page);
+    const withUrl = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row?.api_url === "https://example.com/v1" ? row : undefined;
+    });
+    expect(withUrl?.api_url).toBe("https://example.com/v1");
+
+    await clickInLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API key`, "Remove");
+    const cleared = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row && row.keylen === 0 ? row : undefined;
+    });
+    expect(cleared?.keylen).toBe(0);
+  });
+
+  test("switches the Chat provider slot and updates the Chat model", async () => {
+    const targetLabel = OTHER_PROVIDER_LABEL;
+    const targetId = targetLabel === "OpenRouter" ? "openrouter" : "openai";
+
+    await pickCombobox(page, "Chat provider", targetLabel);
+
+    // selectChatProvider writes via setSetting, bypassing settings:update, then self-broadcasts —
+    // poll the DB rather than the UI so the assertion doesn't depend on catching that broadcast.
+    const switched = await pollUntil(() => readSetting("chatProviderId") as string | undefined);
+    expect(switched).toBe(targetId);
+
+    await typeIntoField(page, 'input[aria-label="Chat model"]', "test-model-id");
+    await blurActive(page);
+    const model = await pollUntil(() => readSetting("orchestratorModel") as string | undefined);
+    expect(model).toBe("test-model-id");
+  });
+
+  test("edits transcription, TTS model, and TTS voice fields", async () => {
+    await typeIntoField(page, 'input[aria-label="Transcription model"]', "test-transcription-model");
+    await blurActive(page);
+    expect(await pollUntil(() => readSetting("voiceTranscriptionModel") as string | undefined)).toBe(
+      "test-transcription-model"
+    );
+
+    await typeIntoField(page, 'input[aria-label="Speech (TTS) model"]', "test-tts-model");
+    await blurActive(page);
+    expect(await pollUntil(() => readSetting("voiceTtsModel") as string | undefined)).toBe("test-tts-model");
+
+    const currentVoice = readSetting("voiceTtsVoice") as string;
+    const otherVoice = currentVoice === "alloy" ? "echo" : "alloy";
+    await pickCombobox(page, "Speech (TTS) voice", otherVoice);
+    expect(await pollUntil(() => readSetting("voiceTtsVoice") as string | undefined)).toBe(otherVoice);
+  });
+});


### PR DESCRIPTION
## What changed
Adds Playwright E2E coverage for the MCP Servers tab (add/edit/toggle/delete with a fake command, Test connection's failure path, and live registry search → install) and the Models tab's non-Test-button actions (provider key/URL save+clear, Chat provider slot switch, Chat/transcription/TTS model fields, TTS voice) — Phase 2 of the `e2e-full-coverage` roadmap.

## Root cause
N/A — new test coverage, not a fix.

## Testing
- Unit/integration: 127 files / 1363 tests passing, eslint 0, `tsc -b` 0 (root + `e2e/tsconfig.json`)
- E2E: 22/22 passing (all Phase 0/1/2 specs together), run against the built app
- Manual: n/a — driven entirely through the real Electron app via Playwright, sandboxed `--user-data-dir` per spec

## Notes
- MCP server create/update/delete/toggle use a fake, nonexistent command — `createMcpServer`/`updateMcpServer` do no command validation and never spawn anything, so this is safe local DB coverage with no subprocess involved.
- `mcp:test`'s real success path needs an actual MCP-protocol-speaking subprocess (`MCPServerStdio`'s live JSON-RPC handshake) — no harmless stand-in binary satisfies that, so only the failure path (bad command → error surfaced) is covered. Flagging as a known gap rather than silently skipping it.
- Registry search hits the live `registry.modelcontextprotocol.io` endpoint end-to-end (search → install → DB row, landing disabled by design). The roadmap doc filed all of MCP Servers as "local" — that undersold this one action, which is a genuine live-network dependency; corrected in the spec's comments rather than left wrong.
- Chat provider switch is asserted via DB poll, not the UI — `selectChatProvider` bypasses `settings:update` and self-broadcasts instead, so polling the DB sidesteps the timing question entirely.
- Both "Test" buttons (Chat, Voice — `settings:testChat`/`settings:testVoice`) are untouched, per the roadmap's explicit Phase 4 deferral.