### PR TITLE
Add Phase 3 E2E coverage: Knowledge base URL discovery and About tab

### DIFF
--- a/e2e/about-tab.spec.ts
+++ b/e2e/about-tab.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, openSettingsTab } from "./helpers";
+
+// The update check (window.agentsAPI.appInfo.latestRelease()) runs automatically on mount, no
+// button to click — a real unauthenticated call to api.github.com/repos/<repo>/releases/latest
+// (scripts/releaseInfo.ts). It never throws: offline, timeout, rate-limited, or genuinely no
+// releases published all collapse to the same "0.0.0" fallback, so this spec can't assume a
+// release exists — only that the tab renders without an error, and conditionally checks the
+// release row's shape when one is present. See 0-cowork/plans/active/e2e-full-coverage.md Phase 3.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — About tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("loads without an error and shows build identity", async () => {
+    await openSettingsTab(page, "About");
+
+    // "Version" (this build) always renders once appInfo.get() resolves — a stable signal the
+    // panel loaded, independent of whether the live release check itself found anything.
+    await page.waitForFunction(
+      () => document.querySelector(".about-value")?.textContent && document.querySelector(".about-value")?.textContent !== "…",
+      { timeout: 15_000 }
+    );
+
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText, "About tab reported an error").toBe("");
+  });
+
+  test("shows a well-formed version when the live release check finds one", async () => {
+    const releaseVersion = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll(".row")];
+      const row = rows.find((r) => r.querySelector(".row-label")?.textContent?.startsWith("Latest release"));
+      return row?.querySelector(".about-value")?.textContent?.trim() ?? null;
+    });
+
+    if (releaseVersion === null) {
+      test.info().annotations.push({
+        type: "note",
+        description: "no 'Latest release' row rendered — GitHub API returned no release (rate-limited, offline, or none published)",
+      });
+      return;
+    }
+    // Loose shape check only — the actual version string is live data this test doesn't control.
+    expect(releaseVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -171,13 +171,19 @@ export async function openCombobox(page: Page, ariaLabel: string): Promise<void>
   await clickSelector(page, `[aria-haspopup="listbox"][aria-label="${ariaLabel}"]`);
 }
 
-// Combobox options select on mousedown (not click) — e.preventDefault() there is deliberate,
-// keeping the search input focused instead of blurring it — so a synthetic .click() (which never
-// fires mousedown) is a silent no-op against them.
+// Combobox/SlashCommandMenu options select on mousedown (not click) — e.preventDefault() there is
+// deliberate, keeping the search input focused instead of blurring it — so a synthetic .click()
+// (which never fires mousedown) is a silent no-op against them. Matches an option whose *own*
+// label text (`.combobox-option`'s full text, or a SlashCommandMenu item's `.slash-menu-label`
+// specifically) equals optionText — SlashCommandMenu concatenates label+sublabel into one
+// textContent with no separator, so a plain full-text match misses every item that has one.
 export async function selectComboboxOption(page: Page, optionText: string): Promise<void> {
   const found = await page.evaluate((t) => {
     const els = [...document.querySelectorAll('[role="listbox"] [role="option"]')];
-    const el = els.find((e) => e.textContent?.trim() === t);
+    const el = els.find((e) => {
+      const label = e.querySelector(".slash-menu-label");
+      return (label ? label.textContent?.trim() : e.textContent?.trim()) === t;
+    });
     if (!el) return false;
     el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     return true;

--- a/e2e/knowledge-url-discovery.spec.ts
+++ b/e2e/knowledge-url-discovery.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  clickSelector,
+  clickByText,
+  selectComboboxOption,
+  typeIntoNth,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// discoverLinks is a real fetch — POSTed to the local open-websearch daemon (started at app
+// launch, electron/main/index.ts) which does the actual outbound HTTP fetch + link extraction of
+// the URL given. example.com is used deliberately: a static IANA page with no outbound links, no
+// JS rendering and no cookie gate, so the daemon's fast request-only path handles it and the
+// discovered-links assertions are stable (both link sections empty). See
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 3.
+
+const provider = resolveE2EProvider();
+const SEED_URL = "https://example.com";
+
+test.describe("Knowledge base — Add from URL", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("discovers links for a real URL and adds the seed page as a knowledge file", async () => {
+    await clickSelector(page, '[aria-label="Add to knowledge base"]');
+    await selectComboboxOption(page, "URL");
+    await page.waitForSelector('[role="dialog"][aria-label="Add from URL"]', { timeout: 10_000 });
+
+    await typeIntoNth(page, ".au-field", "input", 0, SEED_URL);
+    await clickByText(page, "Fetch page", ".km-body");
+
+    // The daemon fetch is a real network round trip — give it real time, and tolerate the
+    // daemon's own startup health-check window right after a fresh onboarding.
+    await page.waitForSelector(".au-section", { timeout: 30_000 });
+
+    const errorText = await page.evaluate(() => document.querySelector(".widget-error")?.textContent ?? "");
+    expect(errorText, "discoverLinks reported an error for a known-good URL").toBe("");
+
+    // Seed URL's own checkbox is pre-checked by default — confirm with that selection.
+    await clickByText(page, "Add 1 selected", ".km-body");
+
+    // handleConfirm is fire-and-forget (see AddUrlModal.tsx) — poll the DB rather than the click.
+    // addUrl() re-fetches through the daemon a second time (it doesn't reuse discoverLinks'
+    // result), so this is a second real network round trip on top of the one above. The daemon
+    // normalizes the seed URL (trailing slash added), so match with LIKE rather than exact equal.
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, title, source_url FROM knowledge_files WHERE source_url LIKE ?").get(`${SEED_URL}%`) as
+          | { id: string; title: string; source_url: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    }, 30_000);
+    expect(row, "discovered URL was never added as a knowledge file").toBeDefined();
+    expect(row!.title).toBe("Example Domain");
+  });
+});


### PR DESCRIPTION
## What changed
Adds Playwright E2E coverage for the knowledge-base Add-from-URL flow (link discovery + add, both real fetches through the `open-websearch` daemon subprocess) and the About tab's automatic update check (a real unauthenticated call to `api.github.com`) — Phase 3 of the `e2e-full-coverage` roadmap.

## Root cause
N/A — new test coverage, not a fix.

## Testing
- Unit/integration: 127 files / 1363 tests passing, eslint 0, `tsc -b` 0 (root + `e2e/tsconfig.json`)
- E2E: 25/25 passing (all specs through Phase 3), run against the built app
- Manual: n/a — driven entirely through the real Electron app via Playwright, sandboxed `--user-data-dir` per spec

## Notes
- Add-from-URL is reached via the Knowledge widget's own "+" menu on the main screen — there's no Settings-tab path to it, `FilesAppsTab` only has folder/document add.
- Seed URL is `https://example.com` — static, link-free, no JS rendering, so both discovered-link sections come back empty and the daemon's fast request-only path handles it without needing its headless-browser fallback. No offline/mock mode exists for this flow; it's a genuine live-network dependency both for discovery and for the follow-up add (which re-fetches independently).
- About tab has no manual "check for updates" trigger — the release check runs automatically on mount and is designed to never reject (offline/timeout/rate-limited/no-releases-published all collapse to the same fallback). The spec only asserts the tab renders cleanly and conditionally checks the release row's shape when one is actually present, since it can't assume the app's own GitHub repo has a published release to compare against live.
- `selectComboboxOption` (shared helper) now matches an option's `.slash-menu-label` specifically when present, rather than its full concatenated text — needed to select "URL" from a `SlashCommandMenu`-based menu, which renders label+sublabel as one run of text with no separator. Existing Combobox call sites are unaffected (no `.slash-menu-label` child, falls back to full-text match as before).