### PR TITLE
Add Phase 4 E2E coverage: core chat flow and slash-command interception

### DIFF
--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, openDb, pollUntil } from "./helpers";
+
+// The only spec in this suite that makes a real, billed AI provider call — see
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 4. Cost is whatever E2E_PROVIDER/.env.test
+// resolves to (see providerConfig.ts) — this spec does not force a specific provider, since the
+// harness has no way to override a run someone else configured. When E2E_PROVIDER=openrouter, the
+// registry's default model for it is a "latest cheap/fast" floating alias
+// (electron/main/ai/providers.ts), which is what onboarding accepts by default; unset or
+// E2E_PROVIDER=openai instead bills against gpt-4.1-mini.
+//
+// agent:runStream has no single IPC promise this test process can await directly — the renderer
+// only surfaces the result as DOM/DB effects (see AgentsApp.tsx's onStreamChunk/onStreamAgent
+// listeners). The messages table (written server-side in agent:runStream's handler, before the
+// IPC promise resolves) is the stable thing to poll — never assert on exact reply text, since a
+// live model's wording isn't something this test controls.
+//
+// A trivial prompt still goes through the orchestrator's own routing hop before any reply, which
+// is a second real model round trip — both the app's own agentRunTimeoutSeconds (default 60s) and
+// Playwright's default test timeout are tight for that under normal network jitter, so both are
+// raised here.
+
+const provider = resolveE2EProvider();
+
+test.describe("Core chat flow", () => {
+  test.setTimeout(120_000);
+
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("sends a message and receives a real routed agent reply", async () => {
+    const before = openDb(userData);
+    const beforeCount = before.prepare("SELECT COUNT(*) AS n FROM messages").get() as { n: number };
+    before.close();
+
+    await typeIntoField(page, "#inp", "Reply with just the word OK, nothing else.");
+    await page.keyboard.press("Enter");
+
+    const assistantRow = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const row = db
+          .prepare("SELECT role, text, trace_id FROM messages WHERE role = 'assistant' ORDER BY id DESC LIMIT 1")
+          .get() as { role: string; text: string; trace_id: string | null } | undefined;
+        return row ? row : undefined;
+      } finally {
+        db.close();
+      }
+    }, 90_000);
+
+    expect(assistantRow, "no assistant reply landed in the sandbox DB").toBeDefined();
+    expect(assistantRow!.text.length).toBeGreaterThan(0);
+    expect(assistantRow!.trace_id).not.toBeNull();
+
+    const after = openDb(userData);
+    const afterCount = after.prepare("SELECT COUNT(*) AS n FROM messages").get() as { n: number };
+    after.close();
+    // At least the user turn and the assistant reply — an orchestrator handoff can add more.
+    expect(afterCount.n).toBeGreaterThanOrEqual(beforeCount.n + 2);
+  });
+});

--- a/e2e/slash-commands.spec.ts
+++ b/e2e/slash-commands.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, clickSelector } from "./helpers";
+
+// AgentsApp.tsx's handleSend intercepts these exact strings BEFORE any provider call (see
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 4) — genuinely zero-cost, local-only. Two
+// commands in the same intercept block are deliberately excluded: /agents-create rewrites the
+// text and falls through to a real orchestrator call, and /<agent-slug> routing is likewise a
+// real call — neither belongs in a zero-cost spec. /add-file and /add-folder open native OS
+// pickers Playwright can't drive, and /tour's resulting DOM wasn't traced for this phase — all
+// three are left uncovered here rather than guessed at.
+
+const provider = resolveE2EProvider();
+
+// Typing a full command opens ChatInputBar's own autocomplete menu (matches the app's other
+// slash-driven surfaces) — Enter while it's open selects the highlighted menu item (completing
+// the text) rather than submitting. Escape closes the menu without touching the typed text, so
+// the next Enter takes the normal send path and handleSend's exact-string intercept fires.
+async function sendSlashCommand(page: Page, command: string): Promise<void> {
+  await typeIntoField(page, "#inp", command);
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Enter");
+}
+
+test.describe("Slash-command interception", () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const { userData } = launchSandboxedApp();
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("/settings opens the Settings modal", async () => {
+    await sendSlashCommand(page, "/settings");
+    await page.waitForSelector('[role="dialog"][aria-label="Settings"]', { timeout: 10_000 });
+    await clickSelector(page, '[aria-label="Close settings"]');
+  });
+
+  test("/chat-history opens the Chat History modal", async () => {
+    await sendSlashCommand(page, "/chat-history");
+    await page.waitForSelector('[role="dialog"][aria-label="Chat History"]', { timeout: 10_000 });
+    await clickSelector(page, '.modal-panel--chat-history [aria-label="Close"]');
+  });
+
+  test("/http-tools opens Settings deep-linked to the HTTP Tools section", async () => {
+    await sendSlashCommand(page, "/http-tools");
+    await page.waitForSelector('[role="dialog"][aria-label="Settings"]', { timeout: 10_000 });
+    const title = await page.evaluate(() => document.querySelector(".settings-detail h1")?.textContent ?? "");
+    expect(title).toBe("HTTP Tools");
+    await clickSelector(page, '[aria-label="Close settings"]');
+  });
+
+  test("/knowledgebase opens the Knowledge modal", async () => {
+    await sendSlashCommand(page, "/knowledgebase");
+    await page.waitForSelector('[role="dialog"][aria-label="Knowledge"]', { timeout: 10_000 });
+    await clickSelector(page, '.km-header [aria-label="Close"]');
+  });
+
+  test("/system-stats appends a local reply with no provider call", async () => {
+    const before = await page.evaluate(() => document.querySelectorAll("#chat-log .turn.assistant").length);
+    await sendSlashCommand(page, "/system-stats");
+    await page.waitForFunction(
+      (n) => document.querySelectorAll("#chat-log .turn.assistant").length > n,
+      before,
+      { timeout: 10_000 }
+    );
+    const lastReply = await page.evaluate(() => {
+      const turns = [...document.querySelectorAll("#chat-log .turn.assistant .mb--assistant")];
+      return turns[turns.length - 1]?.textContent ?? "";
+    });
+    expect(lastReply).toMatch(/CPU:|not available/);
+  });
+
+  test("/usage appends a local reply with no provider call", async () => {
+    const before = await page.evaluate(() => document.querySelectorAll("#chat-log .turn.assistant").length);
+    await sendSlashCommand(page, "/usage");
+    await page.waitForFunction(
+      (n) => document.querySelectorAll("#chat-log .turn.assistant").length > n,
+      before,
+      { timeout: 10_000 }
+    );
+    const lastReply = await page.evaluate(() => {
+      const turns = [...document.querySelectorAll("#chat-log .turn.assistant .mb--assistant")];
+      return turns[turns.length - 1]?.textContent ?? "";
+    });
+    expect(lastReply).toMatch(/Today's usage/);
+  });
+});


### PR DESCRIPTION
## What changed
Adds Playwright E2E coverage for the core chat send/reply flow (the first spec in this suite that makes a real, billed AI provider call) and the six slash commands `handleSend` intercepts locally before any provider call — Phase 4 of the `e2e-full-coverage` roadmap.

## Root cause
N/A — new test coverage, not a fix.

## Testing
- Unit/integration: 127 files / 1363 tests passing, eslint 0, `tsc -b` 0 (root + `e2e/tsconfig.json`)
- E2E: 32/32 passing (all specs through Phase 4), run against the built app with the default provider (OpenAI); also validated once against `E2E_PROVIDER=openrouter` to confirm the cheap-model path works (~5s per chat-flow run)
- Manual: n/a — driven entirely through the real Electron app via Playwright, sandboxed `--user-data-dir` per spec

## Notes
- `chat-flow.spec.ts` polls the `messages` table rather than the DOM or a single IPC promise — `agent:runStream` streams events into React state with no single round trip this test process can await, and the DB row is written server-side before the IPC promise resolves anyway. Never asserts on exact reply text since a live model's wording isn't something this test controls.
- A trivial prompt still goes through the orchestrator's own routing hop first (a second real model round trip), so both Playwright's test timeout (120s) and the DB poll window (90s) are raised well past the app's own 60s `agentRunTimeoutSeconds` default to avoid flaking under normal network jitter.
- Cost is whatever `E2E_PROVIDER`/`.env.test` resolves to for whoever runs the suite — this spec doesn't force a provider. Unset or `E2E_PROVIDER=openai` bills against `gpt-4.1-mini`; `E2E_PROVIDER=openrouter` uses the registry's default "latest cheap/fast" floating alias instead.
- Typing a full slash command opens `ChatInputBar`'s own autocomplete menu, and Enter while it's open selects the highlighted item rather than submitting — `sendSlashCommand` presses Escape first to close the menu without touching the typed text, then Enter takes the normal send path.
- Deliberately excluded from the slash-command spec: `/agents-create` and `/<agent-slug>` live in the same intercept block in `handleSend` but both fall through to a real orchestrator call; `/add-file`/`/add-folder` open native OS pickers Playwright can't drive; `/tour`'s resulting DOM wasn't traced this session.
- This is the only spec in the suite with a real per-run dollar cost. It's not wired into the CI workflow (`.github/workflows/ci.yml` runs unit tests + build only, not `npm run test:e2e`), so it only bills when a developer explicitly runs the E2E suite locally with their own `.env.test`.