### PR TITLE
Add Phase 5a E2E coverage: Connectors tab disconnect

### DIFF
--- a/e2e/connectors-disconnect.spec.ts
+++ b/e2e/connectors-disconnect.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import Database from "better-sqlite3";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickInLabeledRow,
+  dbPath,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Only `disconnect` is covered — `connect`/`test` need a real, already-authorized Google account
+// and driving the OS's actual system browser through Google's consent screen (runOAuthFlow calls
+// shell.openExternal, entirely outside Playwright's _electron control surface), which this
+// harness deliberately doesn't attempt. See 0-cowork/plans/active/e2e-full-coverage.md Phase 5 —
+// deferred pending a decision on a dedicated test account, possibly with a human-in-the-loop step
+// for the consent screen rather than full automation.
+//
+// There is no UI path to reach a "connected" status without a real OAuth round trip, so this
+// spec seeds one directly into the sandbox DB (same pattern as tasks-widget.spec.ts seeding a
+// task via the IPC bridge directly) — the same shape connect's own saveConnectorCredentials
+// would leave behind (connectorsStore.ts), just without a real token in it.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Connectors tab — disconnect", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+
+    const db = new Database(dbPath(userData));
+    db.prepare(
+      `INSERT INTO connectors (id, type, status, account_label, credentials, updated_at)
+       VALUES ('gmail', 'gmail', 'connected', 'e2e-test@example.com', '{}', datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET status = 'connected', account_label = 'e2e-test@example.com'`
+    ).run();
+    db.close();
+
+    // useConnectors.ts only fetches the catalog once on mount — it has no reason to know a
+    // connector changed unless the main process pushes "connectors:update" (the same broadcast a
+    // real connect/disconnect triggers). A direct DB write like the one above never fires it.
+    await app.evaluate(({ BrowserWindow }) => {
+      for (const win of BrowserWindow.getAllWindows()) win.webContents.send("connectors:update");
+    });
+
+    await openSettingsTab(page, "Connectors");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("disconnects a connected connector and clears its credentials", async () => {
+    // Gmail is a child grouped under the "Google Account" parent (googleAccountConnector.ts) —
+    // its own row has no accordion of its own to expand, only the parent does. 4 Google
+    // connectors total (gmail/calendar/drive/contacts), 1 seeded connected, matching
+    // formatGroupStatus's "N of M connected" text exactly.
+    await page.waitForSelector(".agent-accordion-name", { timeout: 10_000 });
+    await clickByText(page, "Google Account — 1 of 4 connected");
+    await page.waitForSelector(".connector-service-row", { timeout: 10_000 });
+    await clickInLabeledRow(page, ".connector-service-row", "Gmail", "Disconnect");
+
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT status, account_label, credentials FROM connectors WHERE id = 'gmail'").get() as
+          | { status: string; account_label: string | null; credentials: string | null }
+          | undefined;
+        return r && r.status === "disconnected" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(row?.status).toBe("disconnected");
+    expect(row?.account_label).toBeNull();
+    expect(row?.credentials).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed
Adds Playwright E2E coverage for disconnecting a connected connector (Gmail, seeded as connected directly in the sandbox DB) — Phase 5a of the `e2e-full-coverage` roadmap. `connect`/`test` are explicitly out of scope for this PR.

## Root cause
N/A — new test coverage, not a fix.

## Testing
- Unit/integration: 127 files / 1363 tests passing, eslint 0, `tsc -b` 0 (root + `e2e/tsconfig.json`)
- E2E: 33/33 passing (all specs through Phase 5a), run against the built app
- Manual: n/a — driven entirely through the real Electron app via Playwright, sandboxed `--user-data-dir` per spec

## Notes
- `connect`/`test` need a real, already-authorized Google account, and `runOAuthFlow` opens the OS's actual system browser (`shell.openExternal`) for Google's consent screen — entirely outside Playwright's `_electron` control surface every other spec in this suite uses. Deferred pending a decision on setting up a dedicated test account, possibly with a human-in-the-loop step for the consent screen rather than full automation — Google itself actively resists automated sign-in even against a legitimate account (unusual-activity flags, CAPTCHA), which would be an ongoing flakiness source outside this repo's control, not a one-time setup cost.
- No UI path reaches a "connected" connector without a real OAuth round trip, so the spec seeds one directly into the sandbox DB — same row shape `saveConnectorCredentials` leaves behind, just without a real token — then fires the same `connectors:update` broadcast a real connect/disconnect triggers, since `useConnectors.ts` only fetches its catalog once on mount and has no reason to notice a direct DB write.