### PR TITLE
Retarget the release header to v0.1.1 instead of v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] — 2026-08-05
+## [0.1.1] — 2026-08-05
 
 ### Added
 
@@ -448,6 +448,6 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.2.0...develop
-[0.2.0]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.1...develop
+[0.1.1]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openorbit",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openorbit",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openorbit",
   "productName": "OpenOrbit",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "OpenOrbit — a multi-agent orchestrator desktop app",
   "author": "Mohit Aneja",
   "license": "MIT",


### PR DESCRIPTION
## What changed
Corrects the just-merged #113: this release should ship as v0.1.1, not v0.2.0. Renames the CHANGELOG's `[0.2.0]` header to `[0.1.1]`, fixes the compare links, and rebumps `package.json`/`package-lock.json` to `0.1.1`.

## Testing
- Unit/integration: 1363/1363 passed (127 files)
- Lint: eslint 0, `tsc -b` 0
- Build: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)