### PR TITLE
Release v0.1.1: sync main to develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@
 # Coverage reports (@vitest/coverage-v8 writes here by default).
 /coverage/
 
+# Playwright's own output (e2e/playwright.config.ts) — HTML report and per-test artifacts.
+/test-results/
+/playwright-report/
+# scripts/run-e2e-isolated.sh writes its markdown reports here.
+/e2e/reports/
+
 # Secrets. Never commit a real key — .env.bak already holds live provider and
 # OAuth credentials. The example template is the one exception, since it carries
 # placeholder values and documents which variables exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-08-05
+
 ### Added
 
 - **A Help button in the bottom-right dock** opens the OpenOrbit GitHub wiki in the
@@ -39,6 +41,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   versioned filenames that change next release, and flagging that builds are
   unsigned so the Gatekeeper/SmartScreen prompt on first run isn't a surprise.
   ([#96](https://github.com/maneja81/OpenOrbit/pull/96))
+- **A Playwright E2E test suite (`e2e/`)** driving the real built Electron app,
+  starting with the onboarding wizard and verifying selected-provider credentials
+  land correctly in SQLite. Two run modes — `npm run test:e2e` (isolated: spins up
+  a throwaway git worktree, installs/builds/tests there, tears itself down) and
+  `npm run test:e2e:local` (fast, against the current checkout). Which provider a
+  spec authenticates against is configurable via `E2E_PROVIDER` in a gitignored
+  `.env.test`, so live runs don't have to hit OpenAI billing every time.
+  ([#103](https://github.com/maneja81/OpenOrbit/pull/103))
+- **E2E coverage across every major settings surface and the core chat flow**,
+  built out in six phases on top of #103: Agents, HTTP Tools, General, Privacy &
+  Safety, App Sounds and Tasks
+  ([#107](https://github.com/maneja81/OpenOrbit/pull/107)); MCP Servers and Models
+  ([#108](https://github.com/maneja81/OpenOrbit/pull/108)); knowledge-base
+  Add-from-URL discovery and the About tab's update check
+  ([#109](https://github.com/maneja81/OpenOrbit/pull/109)); the core chat
+  send/reply flow and slash-command interception, the suite's first spec against
+  a real billed provider call
+  ([#110](https://github.com/maneja81/OpenOrbit/pull/110)); and Connectors-tab
+  disconnect
+  ([#111](https://github.com/maneja81/OpenOrbit/pull/111)). Shares a common
+  `e2e/helpers.ts` for sandboxed launch, click/type, and DB-poll assertions across
+  all specs. CLAUDE.md now documents this as a standing process — when a UI
+  surface needs a spec, and the shared conventions to reuse
+  ([#112](https://github.com/maneja81/OpenOrbit/pull/112)).
 
 ### Changed
 
@@ -68,6 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vertical center moved from 41% to 38.5% of the container, about 136px of
   clearance instead of 5px.
   ([#105](https://github.com/maneja81/OpenOrbit/pull/105))
+- Dependency update for `hono` 4.12.33 → 4.13.0.
+  ([#104](https://github.com/maneja81/OpenOrbit/pull/104))
 
 ## [0.1.0] — 2026-08-03
 
@@ -420,5 +448,6 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...develop
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.2.0...develop
+[0.2.0]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to OpenOrbit are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A Help button in the bottom-right dock** opens the OpenOrbit GitHub wiki in the
+  default browser. The bottom chrome dock is now split in two — Info and the app
+  version stay bottom-left, Help and Settings move to a new bottom-right dock — and
+  the tour-replay button switches from a question-mark icon to a route icon to free
+  `?` for Help.
+  ([#97](https://github.com/maneja81/OpenOrbit/pull/97))
+- **The app checks for a new release at launch** and badges the existing About icon
+  rather than adding a new toast/banner system. The previous build-time-only check
+  could only ever compare a build against itself, so it could never detect a release
+  published after the build ran. No auto-download or install — the project isn't
+  code-signed, so `electron-updater`'s silent-install path can't run on macOS, and a
+  Windows/Linux-only version would give a different experience per platform; this
+  only tells the user a release exists.
+  ([#98](https://github.com/maneja81/OpenOrbit/pull/98))
+- **Orbit now acknowledges config changes in chat.** Adding a knowledge file,
+  enabling location, or connecting a connector attached to an agent produces one
+  coalesced message (e.g. "I've got report.pdf. How can I help?"), shown immediately
+  if Settings is closed or once on close if several changes were made together.
+  ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+- **A dedicated `@` agent-mention menu in the chat input**, separate from the
+  existing `/` command menu. Typing `@` (or clicking the new "Agents" toolbar chip)
+  opens a menu of every enabled agent, grouped under "System" (the four built-in
+  agents) and "Custom" (user-created ones); selecting one inserts a plain-name
+  mention.
+  ([#101](https://github.com/maneja81/OpenOrbit/pull/101))
+- A Download section in the README linking directly to each v0.1.0 release asset
+  (macOS arm64/x64 `.dmg`, Windows `.exe`, Linux `.AppImage`), noting these are
+  versioned filenames that change next release, and flagging that builds are
+  unsigned so the Gatekeeper/SmartScreen prompt on first run isn't a surprise.
+  ([#96](https://github.com/maneja81/OpenOrbit/pull/96))
+
+### Changed
+
+- The orchestrator's internal reasoning now explicitly decomposes multi-part user
+  messages, checks which specialist/resource actually covers each part, and is
+  honest about the one-handoff-per-message architectural limit instead of implying
+  a same-turn multi-specialist chain it can't execute. Atlas no longer offers to
+  search "outside the knowledge base" since it has no web tools to back that up.
+  A pre-existing routing defect — the orchestrator can pick the wrong specialist
+  based on which one ran the previous turn — is not fixed by this change and is
+  tracked as follow-up.
+  ([#100](https://github.com/maneja81/OpenOrbit/pull/100))
+
+### Fixed
+
+- **Errors in MCP Servers, Connectors and HTTP Tools settings never cleared.** The
+  panels' data hooks live for the app's lifetime, and 8 methods across
+  `useMcpServers`/`useConnectors`/`useHttpTools` set `error` on failure but
+  bypassed the hooks' shared `run()` helper that clears it on entry — so a stale
+  failure could survive a tab switch or a full Settings close/reopen, outliving
+  the mutation that caused it.
+  ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+
 ## [0.1.0] — 2026-08-03
 
 The first release. Installers for macOS, Windows and Linux are attached to
@@ -356,4 +413,5 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...develop
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure could survive a tab switch or a full Settings close/reopen, outliving
   the mutation that caused it.
   ([#99](https://github.com/maneja81/OpenOrbit/pull/99))
+- **The orbit orchestrator node and lower agent orbs could sit under the chat
+  log.** At a 900px window the chat panel's 40vh max-height left the orbit node
+  about 5px of clearance, and the panel's fade gradient made that read as a
+  full overlap once the log grew. The chat log now caps at 28vh and the orbit's
+  vertical center moved from 41% to 38.5% of the container, about 136px of
+  clearance instead of 5px.
+  ([#105](https://github.com/maneja81/OpenOrbit/pull/105))
 
 ## [0.1.0] — 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] — 2026-08-05
+## [0.1.1] — 2026-08-05
 
 ### Added
 
@@ -448,6 +448,6 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.2.0...develop
-[0.2.0]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.2.0
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.1...develop
+[0.1.1]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Use live code evidence before planning or editing. Make the smallest safe change
 
 OpenOrbit — a desktop app that runs a team of AI agents locally, with a central orchestrator delegating to specialist sub-agents, each with its own tools and access to the user's files, apps, and Google account.
 
-**Status:** implemented and under active development on `develop-ai`. ~290 source files across an Electron main process, a preload bridge, and a React renderer. The source tree is currently untracked in git (only `README.md`, `LICENSE`, `.gitignore`, and this file are committed) — `README.md` still describes the project as "idea phase" and is stale.
+**Status:** released (v0.1.0) and under active development on `develop`. ~290 source files across an Electron main process, a preload bridge, and a React renderer.
 
 Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`: Cipher (`configAgent`), Atlas (`knowledgeAgent`), Explorer (`explorerAgent`), Chrono (`taskAgent`). The orchestrator ("Orbit") is singular, not an `agents` row, and is configured from its own prompt file plus settings.
 
@@ -105,7 +105,7 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 
 ## Worktrees
 
-- ⚠ **Branch every new worktree from `develop`.** `develop` is the default working branch and carries the entire app. `main` sits at `ca1f8d8` — a README-only "idea phase" commit with no `src/`, no `electron/`, no `package.json`. A worktree cut from `main` (or from whatever HEAD happened to be) reads as an *empty project*, and has now misled three separate sessions into concluding the feature they were sent to fix doesn't exist.
+- ⚠ **Branch every new worktree from `develop`.** `develop` is the default working branch and is always ahead of `main` — `main` only moves at a release cut or hotfix, so a worktree cut from `main` (or from whatever HEAD happened to be) is missing whatever has merged into `develop` since the last release, reading as stale or feature-incomplete. This has now misled four separate sessions, including one that skipped `main`'s old idea-phase commit entirely and instead branched from a `main`-based release-sync merge that was itself several PRs behind `develop`.
 
   ```bash
   git worktree add -b <branch> .claude/worktrees/<name> develop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
 - **Dev, renderer only in a browser**: `npm run dev:web`
 - **Build**: `npm run build` (`tsc -b && electron-vite build`) · **Package**: `npm run package`
 - **Test**: `npm test` (`vitest run`) · watch: `npm run test:watch`
+- **E2E test** (real Electron app via Playwright, sandboxed `--user-data-dir`): `npm run test:e2e:local` (needs `.env.test`) · isolated worktree runner: `npm run test:e2e`. See `## E2E Tests` for when to add one and the shared helper conventions.
 - **Lint**: `npm run lint`
 - **Drive the running app** (screenshots, clicking through the UI, confirming a change works for real rather than only in vitest): the `run-openorbit` skill — `.claude/skills/run-openorbit/SKILL.md`, a Playwright REPL over the built app.
 - ⚠ **Never launch the app from a worktree without `--user-data-dir`.** `app.getPath("userData")` resolves to the same `~/Library/Application Support/OpenOrbit` from *every* checkout and worktree, so an exploratory launch writes into the real database — settings, chat history, agents, encrypted API keys. The `run-openorbit` driver sandboxes it and aborts if the isolation doesn't take; use it rather than launching by hand.
@@ -147,6 +148,17 @@ Four built-in sub-agents ship seeded from `electron/main/ai/defaultAgents.json`:
   ls node_modules/electron/path.txt node_modules/electron/dist    # both must exist
   rm -rf node_modules/electron/dist node_modules/electron/path.txt && node node_modules/electron/install.js
   ```
+
+## E2E Tests
+
+- **When a change adds or materially alters a UI surface — a Settings tab, a widget, a modal, the chat flow — add or extend a Playwright spec under `e2e/` alongside it, not as separate follow-up work.** Not every change needs one (a copy tweak or a pure-logic refactor with vitest coverage doesn't), but a new interactive surface without one should be the exception, called out explicitly, not the silent default. `0-cowork/plans/active/e2e-full-coverage.md` (or its successor once that roadmap is fully shipped) tracks what's covered and what's deliberately deferred and why — check it before assuming a surface has no coverage.
+- **Reuse `e2e/helpers.ts` before writing new DOM plumbing.** `launchSandboxedApp`/`launchApp`/`completeOnboarding` for setup; `clickSelector`/`clickByText`/`typeIntoField`/`typeIntoNth`/`typeIntoLabeledRow`/`clickInLabeledRow` for interaction (all click via `page.evaluate()`, never a locator click — this app's continuous framer-motion animation times out `page.click()` as "element is not stable"); `pickCombobox`/`selectComboboxOption` for the app's custom dropdown and `SlashCommandMenu` (both select on **mousedown**, not click); `confirmTypeToDelete` for the shared type-DELETE modal; `openDb`/`pollUntil` to assert against the sandboxed SQLite DB rather than fragile DOM text.
+- **Assert against the DB or a stable DOM signal, never exact text from a live model.** Any spec touching a real AI provider call (see `e2e/chat-flow.spec.ts`) must poll for structural facts (a new `messages` row exists, has non-empty text, has a `trace_id`) — a live model's wording isn't something a test controls.
+- **Settings text/number fields commit onBlur, not per keystroke** — `typeIntoField`/`typeIntoNth` focus the element first for exactly this reason; a blur without a real prior focus is a no-op.
+- **A hook that only fetches once on mount** (`useTasks`, `useConnectors`, others like them) **needs its update broadcast fired manually** after a direct DB seed, or the UI never reflects the seeded state — see `connectors-disconnect.spec.ts` firing `connectors:update` via `app.evaluate`.
+- **Cost- and network-aware by design, not by accident.** `e2e/providerConfig.ts`'s `resolveE2EProvider()` decides which AI provider a spec's onboarding uses — set `E2E_PROVIDER=openrouter` in `.env.test` for cheap-model runs; unset or `openai` bills against `gpt-4.1-mini`. Live-network specs (registry search, knowledge-base URL discovery, the About tab's release check) are fine to write, but say so in a comment — don't let a spec's real external dependency read as a local one.
+- **Not part of the mandatory four-command Verify Gate below.** `npm run test:e2e:local` needs a build, a real `.env.test`, and for `chat-flow.spec.ts` specifically, real money — run it deliberately when a spec is added or a UI surface it covers changes, not on every commit.
+- **Some flows are deliberately out of scope, not silently skipped — name the reason when one is.** Native OS file/save dialogs need `app.evaluate` to stub Electron's `dialog` module (see `agents-tab.spec.ts`'s export/import); a live OAuth consent screen opens the real system browser via `shell.openExternal`, entirely outside Playwright's `_electron` control surface, and needs either a dedicated test account with real browser automation or a human-in-the-loop step — neither attempted as of this writing (`connectors-disconnect.spec.ts` only covers `disconnect`).
 
 ## Conventions
 
@@ -239,7 +251,7 @@ Be direct. Sound like a senior engineer, not a language model.
 
 8. Handle errors where the existing code expects them to be handled.
 
-9. Add or update tests when behavior changes.
+9. Add or update tests when behavior changes — including a Playwright spec under `e2e/` when the change touches a UI surface (see `## E2E Tests`), not just vitest coverage for the underlying logic.
 
 10. Do not weaken, delete, skip, or bypass tests to make the build pass.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,30 @@ npm run lint      # eslint
 On first run you'll be asked to name the orchestrator, introduce yourself, and enter an
 API key. Nothing else is required — there are no environment variables to set.
 
+## End-to-end tests
+
+`e2e/` holds Playwright specs that drive the real Electron app — currently onboarding, with
+more feature/setting coverage planned. Two ways to run them:
+
+```bash
+npm run test:e2e         # isolated: throwaway worktree, own install/build, markdown report
+npm run test:e2e:local   # fast: runs against this checkout's existing dist-electron build
+```
+
+`npm run test:e2e` never touches this checkout or your real
+`~/Library/Application Support/OpenOrbit` database — it creates a detached worktree from the
+current branch, copies in `.env.test`, installs and builds there, runs the suite against a
+sandboxed `--user-data-dir`, writes a report to `e2e/reports/<run-id>/report.md` in this
+checkout, and removes the throwaway worktree whether the run passed or failed. `npm install`
+is skipped on a cache hit (keyed on `package-lock.json`), so repeat runs are fast.
+
+Create a `.env.test` (gitignored, same shape as `.env`) with whichever provider keys the
+specs need — at minimum `OPENAI_API_KEY`. Which provider a spec authenticates against is
+controlled by `E2E_PROVIDER` (`openai` by default, or `openrouter` to use a cheaper model and
+avoid OpenAI billing on every run); an unset or missing key for the selected provider fails
+the run loudly rather than skipping quietly. `local` is not selectable — the harness doesn't
+provision an Ollama server.
+
 `npm run package` builds for your current platform only, using the `build` config in
 `package.json` (macOS `.dmg`, Windows `.exe` via NSIS, Linux `.AppImage`). Cross-platform
 builds happen in CI — see `.github/workflows/release.yml`, which builds all three and

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ apps, and Google account.
 
 <img src="public/openorbit.webp" alt="OpenOrbit orbit UI screenshot">
 
+## Download
+
+Builds are unsigned — expect a Gatekeeper prompt on macOS (right-click → Open) or a
+SmartScreen warning on Windows the first time you run one.
+
+| Platform | Download |
+| --- | --- |
+| macOS (Apple Silicon) | [OpenOrbit-0.1.0-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-arm64.dmg) |
+| macOS (Intel) | [OpenOrbit-0.1.0-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-x64.dmg) |
+| Windows | [OpenOrbit.Setup.0.1.0.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit.Setup.0.1.0.exe) |
+| Linux | [OpenOrbit-0.1.0.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0.AppImage) |
+
+These links are for **v0.1.0** specifically — the filenames carry the version, so they'll
+change on the next release. [Releases](https://github.com/maneja81/OpenOrbit/releases)
+always has the current set.
+
 ## How it works
 
 Instead of one chatbot, you get a roster of agents visualized as nodes orbiting a central

--- a/e2e/about-tab.spec.ts
+++ b/e2e/about-tab.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, openSettingsTab } from "./helpers";
+
+// The update check (window.agentsAPI.appInfo.latestRelease()) runs automatically on mount, no
+// button to click — a real unauthenticated call to api.github.com/repos/<repo>/releases/latest
+// (scripts/releaseInfo.ts). It never throws: offline, timeout, rate-limited, or genuinely no
+// releases published all collapse to the same "0.0.0" fallback, so this spec can't assume a
+// release exists — only that the tab renders without an error, and conditionally checks the
+// release row's shape when one is present. See 0-cowork/plans/active/e2e-full-coverage.md Phase 3.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — About tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("loads without an error and shows build identity", async () => {
+    await openSettingsTab(page, "About");
+
+    // "Version" (this build) always renders once appInfo.get() resolves — a stable signal the
+    // panel loaded, independent of whether the live release check itself found anything.
+    await page.waitForFunction(
+      () => document.querySelector(".about-value")?.textContent && document.querySelector(".about-value")?.textContent !== "…",
+      { timeout: 15_000 }
+    );
+
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText, "About tab reported an error").toBe("");
+  });
+
+  test("shows a well-formed version when the live release check finds one", async () => {
+    const releaseVersion = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll(".row")];
+      const row = rows.find((r) => r.querySelector(".row-label")?.textContent?.startsWith("Latest release"));
+      return row?.querySelector(".about-value")?.textContent?.trim() ?? null;
+    });
+
+    if (releaseVersion === null) {
+      test.info().annotations.push({
+        type: "note",
+        description: "no 'Latest release' row rendered — GitHub API returned no release (rate-limited, offline, or none published)",
+      });
+      return;
+    }
+    // Loose shape check only — the actual version string is live data this test doesn't control.
+    expect(releaseVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/e2e/agents-tab.spec.ts
+++ b/e2e/agents-tab.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoField,
+  blurActive,
+  confirmTypeToDelete,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Settings → Agents: create/edit/enable/export/import/delete a custom agent. Built-in agents
+// (Cipher/Atlas/Explorer/Chrono/the orchestrator) are excluded from destructive coverage — only
+// a custom agent this spec creates itself is ever deleted.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Agents tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Agents");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates, edits, toggles, and deletes a custom agent", async () => {
+    await clickByText(page, "New");
+    await typeIntoField(page, ".add-agent-form input", "E2E Scout");
+    await clickByText(page, "Add Agent");
+
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM agents WHERE name = ?").get("E2E Scout") as
+          | { id: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(row, "created agent never appeared in the sandbox DB").toBeDefined();
+    expect(row!.enabled).toBe(1);
+
+    // Expand the new agent's accordion and edit its tagline — commits onBlur, not per keystroke.
+    await clickByText(page, "E2E Scout");
+    await typeIntoField(page, '.agent-accordion-body input[placeholder="e.g. App configuration"]', "Testing tagline");
+    await blurActive(page);
+
+    const updated = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT tagline FROM agents WHERE id = ?").get(row!.id) as
+          | { tagline: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(updated?.tagline).toBe("Testing tagline");
+
+    // Toggle disabled.
+    await clickSelector(page, `[aria-label="Toggle E2E Scout"]`);
+    const disabled = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM agents WHERE id = ?").get(row!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabled?.enabled).toBe(0);
+
+    // Delete requires typing DELETE to confirm.
+    await clickByText(page, "Delete");
+    await confirmTypeToDelete(page);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM agents WHERE id = ?").get(row!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+
+  test("exports and imports an agent through a stubbed native file dialog", async () => {
+    // Playwright cannot click through a native OS dialog — stub Electron's dialog module in the
+    // main process before triggering the click. It's the same module-level `dialog` singleton
+    // agent.ts imports, so patching it here is visible to the IPC handler.
+    const exportPath = path.join(userData, "exported-agent.json");
+    await app.evaluate(
+      async ({ dialog }, exportPath) => {
+        dialog.showSaveDialog = (async () => ({ canceled: false, filePath: exportPath })) as typeof dialog.showSaveDialog;
+      },
+      exportPath
+    );
+
+    await clickByText(page, "New");
+    await typeIntoField(page, ".add-agent-form input", "E2E Export Me");
+    await clickByText(page, "Add Agent");
+    await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id FROM agents WHERE name = ?").get("E2E Export Me") as
+          | { id: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+
+    await clickByText(page, "E2E Export Me");
+    await clickByText(page, "Export");
+
+    const exported = await pollUntil(() => (fs.existsSync(exportPath) ? { ok: true } : undefined));
+    expect(exported?.ok, "export never wrote the stubbed file path").toBe(true);
+    const payload = JSON.parse(fs.readFileSync(exportPath, "utf-8"));
+    expect(payload.name).toBe("E2E Export Me");
+
+    // Import it back under a new name to prove the round trip lands a fresh agent row.
+    payload.name = "E2E Imported Agent";
+    const importPath = path.join(userData, "import-agent.json");
+    fs.writeFileSync(importPath, JSON.stringify(payload), "utf-8");
+
+    await app.evaluate(
+      async ({ dialog }, importPath) => {
+        dialog.showOpenDialog = (async () => ({
+          canceled: false,
+          filePaths: [importPath],
+        })) as typeof dialog.showOpenDialog;
+      },
+      importPath
+    );
+
+    await clickByText(page, "Import Agent");
+
+    const imported = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id FROM agents WHERE name = ?").get("E2E Imported Agent") as
+          | { id: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(imported, "imported agent never appeared in the sandbox DB").toBeDefined();
+  });
+});

--- a/e2e/app-sounds-tab.spec.ts
+++ b/e2e/app-sounds-tab.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickSelector,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — App Sounds tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "App Sounds");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("switches a sound variant", async () => {
+    await pickCombobox(page, "Message sent variant", "Variant 2");
+    const value = await pollUntil(() => readSetting("soundVariantSend") as number | undefined);
+    expect(value).toBe(2);
+  });
+
+  test("preview button does not throw", async () => {
+    // Audio.play() in a headless/CI Electron environment commonly rejects (autoplay policy, no
+    // output device) — previewSound() swallows that (.catch(() => {})), so the only thing worth
+    // asserting is that the click itself doesn't surface a renderer error.
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+    await clickSelector(page, '[aria-label="Preview Message sent"]');
+    await page.waitForTimeout(300);
+    expect(errors).toEqual([]);
+  });
+});

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, openDb, pollUntil } from "./helpers";
+
+// The only spec in this suite that makes a real, billed AI provider call — see
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 4. Cost is whatever E2E_PROVIDER/.env.test
+// resolves to (see providerConfig.ts) — this spec does not force a specific provider, since the
+// harness has no way to override a run someone else configured. When E2E_PROVIDER=openrouter, the
+// registry's default model for it is a "latest cheap/fast" floating alias
+// (electron/main/ai/providers.ts), which is what onboarding accepts by default; unset or
+// E2E_PROVIDER=openai instead bills against gpt-4.1-mini.
+//
+// agent:runStream has no single IPC promise this test process can await directly — the renderer
+// only surfaces the result as DOM/DB effects (see AgentsApp.tsx's onStreamChunk/onStreamAgent
+// listeners). The messages table (written server-side in agent:runStream's handler, before the
+// IPC promise resolves) is the stable thing to poll — never assert on exact reply text, since a
+// live model's wording isn't something this test controls.
+//
+// A trivial prompt still goes through the orchestrator's own routing hop before any reply, which
+// is a second real model round trip — both the app's own agentRunTimeoutSeconds (default 60s) and
+// Playwright's default test timeout are tight for that under normal network jitter, so both are
+// raised here.
+
+const provider = resolveE2EProvider();
+
+test.describe("Core chat flow", () => {
+  test.setTimeout(120_000);
+
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("sends a message and receives a real routed agent reply", async () => {
+    const before = openDb(userData);
+    const beforeCount = before.prepare("SELECT COUNT(*) AS n FROM messages").get() as { n: number };
+    before.close();
+
+    await typeIntoField(page, "#inp", "Reply with just the word OK, nothing else.");
+    await page.keyboard.press("Enter");
+
+    const assistantRow = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const row = db
+          .prepare("SELECT role, text, trace_id FROM messages WHERE role = 'assistant' ORDER BY id DESC LIMIT 1")
+          .get() as { role: string; text: string; trace_id: string | null } | undefined;
+        return row ? row : undefined;
+      } finally {
+        db.close();
+      }
+    }, 90_000);
+
+    expect(assistantRow, "no assistant reply landed in the sandbox DB").toBeDefined();
+    expect(assistantRow!.text.length).toBeGreaterThan(0);
+    expect(assistantRow!.trace_id).not.toBeNull();
+
+    const after = openDb(userData);
+    const afterCount = after.prepare("SELECT COUNT(*) AS n FROM messages").get() as { n: number };
+    after.close();
+    // At least the user turn and the assistant reply — an orchestrator handoff can add more.
+    expect(afterCount.n).toBeGreaterThanOrEqual(beforeCount.n + 2);
+  });
+});

--- a/e2e/connectors-disconnect.spec.ts
+++ b/e2e/connectors-disconnect.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import Database from "better-sqlite3";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickInLabeledRow,
+  dbPath,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Only `disconnect` is covered — `connect`/`test` need a real, already-authorized Google account
+// and driving the OS's actual system browser through Google's consent screen (runOAuthFlow calls
+// shell.openExternal, entirely outside Playwright's _electron control surface), which this
+// harness deliberately doesn't attempt. See 0-cowork/plans/active/e2e-full-coverage.md Phase 5 —
+// deferred pending a decision on a dedicated test account, possibly with a human-in-the-loop step
+// for the consent screen rather than full automation.
+//
+// There is no UI path to reach a "connected" status without a real OAuth round trip, so this
+// spec seeds one directly into the sandbox DB (same pattern as tasks-widget.spec.ts seeding a
+// task via the IPC bridge directly) — the same shape connect's own saveConnectorCredentials
+// would leave behind (connectorsStore.ts), just without a real token in it.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Connectors tab — disconnect", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+
+    const db = new Database(dbPath(userData));
+    db.prepare(
+      `INSERT INTO connectors (id, type, status, account_label, credentials, updated_at)
+       VALUES ('gmail', 'gmail', 'connected', 'e2e-test@example.com', '{}', datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET status = 'connected', account_label = 'e2e-test@example.com'`
+    ).run();
+    db.close();
+
+    // useConnectors.ts only fetches the catalog once on mount — it has no reason to know a
+    // connector changed unless the main process pushes "connectors:update" (the same broadcast a
+    // real connect/disconnect triggers). A direct DB write like the one above never fires it.
+    await app.evaluate(({ BrowserWindow }) => {
+      for (const win of BrowserWindow.getAllWindows()) win.webContents.send("connectors:update");
+    });
+
+    await openSettingsTab(page, "Connectors");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("disconnects a connected connector and clears its credentials", async () => {
+    // Gmail is a child grouped under the "Google Account" parent (googleAccountConnector.ts) —
+    // its own row has no accordion of its own to expand, only the parent does. 4 Google
+    // connectors total (gmail/calendar/drive/contacts), 1 seeded connected, matching
+    // formatGroupStatus's "N of M connected" text exactly.
+    await page.waitForSelector(".agent-accordion-name", { timeout: 10_000 });
+    await clickByText(page, "Google Account — 1 of 4 connected");
+    await page.waitForSelector(".connector-service-row", { timeout: 10_000 });
+    await clickInLabeledRow(page, ".connector-service-row", "Gmail", "Disconnect");
+
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT status, account_label, credentials FROM connectors WHERE id = 'gmail'").get() as
+          | { status: string; account_label: string | null; credentials: string | null }
+          | undefined;
+        return r && r.status === "disconnected" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(row?.status).toBe("disconnected");
+    expect(row?.account_label).toBeNull();
+    expect(row?.credentials).toBeNull();
+  });
+});

--- a/e2e/general-tab.spec.ts
+++ b/e2e/general-tab.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  typeIntoField,
+  blurActive,
+  clickSelector,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — General tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "General");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("commits the name field on blur", async () => {
+    await typeIntoField(page, 'input[aria-label="What should I call you?"]', "Renamed Tester");
+    await blurActive(page);
+
+    const value = await pollUntil(() => readSetting("userName") as string | undefined);
+    expect(value).toBe("Renamed Tester");
+  });
+
+  test("toggles voice input and sound effects", async () => {
+    await clickSelector(page, '[aria-label="Toggle voice input"]');
+    const voiceInput = await pollUntil(() => readSetting("voiceInputEnabled") as boolean | undefined);
+    expect(voiceInput).toBe(false);
+
+    await clickSelector(page, '[aria-label="Toggle sound effects"]');
+    const soundFx = await pollUntil(() => readSetting("soundFxEnabled") as boolean | undefined);
+    expect(soundFx).toBe(false);
+  });
+
+  test("rejects an out-of-range agent run timeout and keeps the stored value", async () => {
+    const before = readSetting("agentRunTimeoutSeconds");
+
+    await typeIntoField(page, 'input[aria-label="Agent run timeout (seconds)"]', "0");
+    await blurActive(page);
+
+    // NumberField validates client-side before ever calling onCommit — an out-of-bounds value
+    // never reaches settings:update, so the stored value must be unchanged.
+    await page.waitForTimeout(300);
+    expect(readSetting("agentRunTimeoutSeconds")).toBe(before);
+  });
+
+  test("accepts an in-range agent run timeout", async () => {
+    await typeIntoField(page, 'input[aria-label="Agent run timeout (seconds)"]', "45");
+    await blurActive(page);
+
+    const value = await pollUntil(() => readSetting("agentRunTimeoutSeconds") as number | undefined);
+    expect(value).toBe(45);
+  });
+});

--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -1,0 +1,7 @@
+// Minimal ambient declaration for page.evaluate() callbacks, which run in the renderer and can
+// reference window.agentsAPI. The full contextBridge surface is typed in src/vite-env.d.ts, but
+// that file lives in the web tsconfig project — e2e specs only need to know the property exists,
+// not its full shape, since they drive the UI rather than call the bridge directly.
+interface Window {
+  agentsAPI?: unknown;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,251 @@
+import { type ElectronApplication, type Page, _electron as electron } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import type { E2EProviderConfig } from "./providerConfig";
+
+// Shared launch/click/type/DB conventions, extracted from onboarding.spec.ts once a second spec
+// needed them (see 0-cowork/plans/active/e2e-full-coverage.md's reuse audit — premature extraction
+// for a single caller was deliberately deferred until Phase 1 gave it a second one).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const APP_DIR = path.resolve(__dirname, "..");
+
+export const ELECTRON_BIN =
+  process.platform === "darwin"
+    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(APP_DIR, "node_modules/electron/dist/electron");
+
+export function dbPath(userData: string): string {
+  return path.join(userData, "database/agents.db");
+}
+
+// Same realpath-comparison as driver.mjs's isInsideSandbox — macOS symlinks /tmp to /private/tmp,
+// so a plain startsWith would read a perfectly good sandbox as an escape.
+function isInsideSandbox(resolved: string, sandboxReal: string): boolean {
+  const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : path.resolve(resolved);
+  return real === sandboxReal || real.startsWith(sandboxReal + path.sep);
+}
+
+// React-controlled inputs ignore a plain `.value =` assignment — it has to go through the
+// prototype setter and dispatch a real input event, or onChange never fires.
+export async function typeIntoField(page: Page, selector: string, value: string): Promise<void> {
+  await page.evaluate(
+    ({ selector, value }) => {
+      const el = document.querySelector(selector) as HTMLInputElement | HTMLTextAreaElement | null;
+      if (!el) throw new Error(`field not found: ${selector}`);
+      // Settings' TextField/NumberField commit onBlur, not onChange — a later blurActive() only
+      // fires that handler if this element actually holds DOM focus, which a bare value-setter +
+      // dispatch does not give it.
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { selector, value }
+  );
+}
+
+// Locator clicks time out on "element is not stable" against this app's continuous framer-motion
+// animation — DOM click via evaluate sidesteps the actionability check entirely.
+export async function clickSelector(page: Page, selector: string): Promise<void> {
+  const found = await page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, selector);
+  if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
+}
+
+// Retries briefly: a preceding action (e.g. a create submit) can resolve before React's list
+// re-render commits, and the target text isn't in the DOM yet on the very next evaluate.
+export async function clickByText(page: Page, text: string, scopeSelector?: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  let found = false;
+  while (!found && Date.now() < deadline) {
+    found = await page.evaluate(
+      ({ t, scopeSelector }) => {
+        const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+        if (!root) return false;
+        const els = [...root.querySelectorAll('button, a, [role="button"], [role="radio"], [role="option"]')];
+        const el = els.find((e) => e.textContent?.trim() === t);
+        if (!el) return false;
+        (el as HTMLElement).click();
+        return true;
+      },
+      { t: text, scopeSelector }
+    );
+    if (!found) await new Promise((r) => setTimeout(r, 100));
+  }
+  if (!found) throw new Error(`clickByText: no element with text "${text}"`);
+}
+
+// For fields with no aria-label/id to target directly — picks the Nth match (document order)
+// of `innerSelector` within `scopeSelector` and types into it.
+export async function typeIntoNth(
+  page: Page,
+  scopeSelector: string,
+  innerSelector: string,
+  index: number,
+  value: string
+): Promise<void> {
+  await page.evaluate(
+    ({ scopeSelector, innerSelector, index, value }) => {
+      const scope = document.querySelector(scopeSelector);
+      if (!scope) throw new Error(`typeIntoNth: no scope matching "${scopeSelector}"`);
+      const els = [...scope.querySelectorAll(innerSelector)] as (HTMLInputElement | HTMLTextAreaElement)[];
+      const el = els[index];
+      if (!el) throw new Error(`typeIntoNth: no element at index ${index} for "${innerSelector}" in "${scopeSelector}"`);
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { scopeSelector, innerSelector, index, value }
+  );
+}
+
+// Blurs whatever currently holds focus — Settings text/number fields commit onBlur, not per
+// keystroke, so a test must blur after typing (which focuses the field, see typeIntoField above)
+// before the write lands.
+export async function blurActive(page: Page): Promise<void> {
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+}
+
+export async function openCombobox(page: Page, ariaLabel: string): Promise<void> {
+  await clickSelector(page, `[aria-haspopup="listbox"][aria-label="${ariaLabel}"]`);
+}
+
+// Combobox options select on mousedown (not click) — e.preventDefault() there is deliberate,
+// keeping the search input focused instead of blurring it — so a synthetic .click() (which never
+// fires mousedown) is a silent no-op against them.
+export async function selectComboboxOption(page: Page, optionText: string): Promise<void> {
+  const found = await page.evaluate((t) => {
+    const els = [...document.querySelectorAll('[role="listbox"] [role="option"]')];
+    const el = els.find((e) => e.textContent?.trim() === t);
+    if (!el) return false;
+    el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    return true;
+  }, optionText);
+  if (!found) throw new Error(`selectComboboxOption: no option with text "${optionText}"`);
+}
+
+export async function pickCombobox(page: Page, ariaLabel: string, optionText: string): Promise<void> {
+  await openCombobox(page, ariaLabel);
+  await selectComboboxOption(page, optionText);
+}
+
+export async function confirmTypeToDelete(page: Page): Promise<void> {
+  await typeIntoField(page, ".delete-confirm-modal input", "DELETE");
+  await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+}
+
+export async function openSettings(page: Page): Promise<void> {
+  await clickSelector(page, "#setbtn");
+}
+
+export async function openSettingsTab(page: Page, label: string): Promise<void> {
+  await openSettings(page);
+  await clickByText(page, label, ".settings-sidebar");
+}
+
+export function launchSandboxedApp(): { userData: string } {
+  const userData = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "orbit-e2e-"));
+  return { userData };
+}
+
+export async function launchApp(userData: string): Promise<{ app: ElectronApplication; page: Page }> {
+  if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
+    throw new Error("no build — run `npm run build` first (main is dist-electron/main/index.js)");
+  }
+  const app = await electron.launch({
+    executablePath: ELECTRON_BIN,
+    args: [APP_DIR, `--user-data-dir=${userData}`],
+    timeout: 60_000,
+  });
+  const page = await app.firstWindow();
+  await page.waitForLoadState("domcontentloaded");
+  await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
+
+  // Non-negotiable: abort before any interaction if isolation didn't take, or the test writes
+  // into the developer's real ~/Library/Application Support/OpenOrbit database.
+  const resolvedUserData = await app.evaluate(({ app }) => app.getPath("userData"));
+  const sandboxReal = fs.realpathSync(userData);
+  if (!isInsideSandbox(resolvedUserData, sandboxReal)) {
+    await app.close();
+    throw new Error(`ABORT: userData resolved to ${resolvedUserData}, expected under ${sandboxReal}`);
+  }
+  return { app, page };
+}
+
+// Drives the same onboarding flow onboarding.spec.ts exercises directly, purely as a means to
+// reach the main screen — every Electron build gates on `settings.onboardingDone`
+// (AgentsApp.tsx's showOnboarding), so any spec that needs Settings open has to clear it first.
+export async function completeOnboarding(page: Page, provider: E2EProviderConfig): Promise<void> {
+  await typeIntoField(page, 'input[aria-label="Give me a name?"]', "TestOrbit");
+  await page.keyboard.press("Enter");
+
+  await typeIntoField(page, 'input[aria-label="What should I call you?"]', "E2E Tester");
+  await page.keyboard.press("Enter");
+
+  // profession is an optional *text* step — no Skip button, just an always-enabled Next.
+  await clickSelector(page, '[aria-label="Next"]');
+
+  // responseStyle, technicalLevel, stuckStyle — optional *chip* steps, each with its own Skip.
+  for (let i = 0; i < 3; i++) {
+    await clickSelector(page, '[aria-label="Skip"]');
+  }
+
+  await clickByText(page, provider.label);
+
+  // apiUrl step is prefilled from the provider's registry entry — accept the default.
+  await page.keyboard.press("Enter");
+
+  await typeIntoField(page, 'input[aria-label="Enter your API key"]', provider.apiKey);
+  await page.keyboard.press("Enter");
+
+  // model step is prefilled — accept the default.
+  await page.keyboard.press("Enter");
+
+  // handleOnboardingComplete fires providers.selectChat fire-and-forget, so the main screen can
+  // render before the write lands — wait for the orbit UI (settings button) rather than a fixed
+  // delay.
+  await page.waitForSelector("#setbtn", { timeout: 15_000 });
+}
+
+// global.d.ts deliberately types window.agentsAPI as `unknown` — every other spec drives the UI
+// rather than the bridge. The handful of specs that must call it directly (no UI exists to seed
+// a task; header decryption has no visible affordance) go through this narrow, local-only shape
+// instead of casting inline at each call site.
+export interface AgentsApiForE2E {
+  tasks: {
+    create: (input: { title: string }) => Promise<{ id: string; title: string }>;
+  };
+  httpTools: {
+    getCollectionHeaders: (id: string) => Promise<Record<string, string>>;
+  };
+}
+
+export function openDb(userData: string): Database.Database {
+  return new Database(dbPath(userData), { readonly: true, fileMustExist: false });
+}
+
+export async function pollUntil<T>(fn: () => T | undefined, timeoutMs = 5_000): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  let result: T | undefined;
+  while (Date.now() < deadline) {
+    try {
+      result = fn();
+    } catch {
+      // table may not exist yet on the very first poll — keep waiting.
+    }
+    if (result !== undefined) return result;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return result;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -171,13 +171,19 @@ export async function openCombobox(page: Page, ariaLabel: string): Promise<void>
   await clickSelector(page, `[aria-haspopup="listbox"][aria-label="${ariaLabel}"]`);
 }
 
-// Combobox options select on mousedown (not click) — e.preventDefault() there is deliberate,
-// keeping the search input focused instead of blurring it — so a synthetic .click() (which never
-// fires mousedown) is a silent no-op against them.
+// Combobox/SlashCommandMenu options select on mousedown (not click) — e.preventDefault() there is
+// deliberate, keeping the search input focused instead of blurring it — so a synthetic .click()
+// (which never fires mousedown) is a silent no-op against them. Matches an option whose *own*
+// label text (`.combobox-option`'s full text, or a SlashCommandMenu item's `.slash-menu-label`
+// specifically) equals optionText — SlashCommandMenu concatenates label+sublabel into one
+// textContent with no separator, so a plain full-text match misses every item that has one.
 export async function selectComboboxOption(page: Page, optionText: string): Promise<void> {
   const found = await page.evaluate((t) => {
     const els = [...document.querySelectorAll('[role="listbox"] [role="option"]')];
-    const el = els.find((e) => e.textContent?.trim() === t);
+    const el = els.find((e) => {
+      const label = e.querySelector(".slash-menu-label");
+      return (label ? label.textContent?.trim() : e.textContent?.trim()) === t;
+    });
     if (!el) return false;
     el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     return true;

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -110,6 +110,56 @@ export async function typeIntoNth(
   );
 }
 
+// For rows with no aria-label/id at all (e.g. ApiKeyField, whose <span>{label}</span> is only
+// ever visible text) — finds a `rowSelector` element whose text starts with `labelText` and types
+// into its first `input`/`textarea`.
+export async function typeIntoLabeledRow(
+  page: Page,
+  rowSelector: string,
+  labelText: string,
+  value: string
+): Promise<void> {
+  await page.evaluate(
+    ({ rowSelector, labelText, value }) => {
+      const rows = [...document.querySelectorAll(rowSelector)];
+      const row = rows.find((r) => r.textContent?.trim().startsWith(labelText));
+      if (!row) throw new Error(`typeIntoLabeledRow: no "${rowSelector}" starting with "${labelText}"`);
+      const el = row.querySelector("input, textarea") as HTMLInputElement | HTMLTextAreaElement | null;
+      if (!el) throw new Error(`typeIntoLabeledRow: no input/textarea inside row "${labelText}"`);
+      el.focus();
+      const proto = el.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(proto, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { rowSelector, labelText, value }
+  );
+}
+
+// Companion to typeIntoLabeledRow — clicks a button by text inside the row starting with
+// `labelText`, e.g. ApiKeyField's per-provider "Remove" button.
+export async function clickInLabeledRow(
+  page: Page,
+  rowSelector: string,
+  labelText: string,
+  buttonText: string
+): Promise<void> {
+  const found = await page.evaluate(
+    ({ rowSelector, labelText, buttonText }) => {
+      const rows = [...document.querySelectorAll(rowSelector)];
+      const row = rows.find((r) => r.textContent?.trim().startsWith(labelText));
+      if (!row) return false;
+      const buttons = [...row.querySelectorAll("button")];
+      const btn = buttons.find((b) => b.textContent?.trim() === buttonText);
+      if (!btn) return false;
+      btn.click();
+      return true;
+    },
+    { rowSelector, labelText, buttonText }
+  );
+  if (!found) throw new Error(`clickInLabeledRow: no "${buttonText}" button in row "${labelText}"`);
+}
+
 // Blurs whatever currently holds focus — Settings text/number fields commit onBlur, not per
 // keystroke, so a test must blur after typing (which focuses the field, see typeIntoField above)
 // before the write lands.

--- a/e2e/http-tools-tab.spec.ts
+++ b/e2e/http-tools-tab.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoNth,
+  openDb,
+  pollUntil,
+  type AgentsApiForE2E,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — HTTP Tools tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "HTTP Tools");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates a collection with encrypted headers, adds an endpoint, toggles both, deletes both", async () => {
+    await clickByText(page, "Add API");
+    await typeIntoNth(page, ".http-collection-form", "input", 0, "E2E API");
+    await typeIntoNth(page, ".http-collection-form", "input", 1, "Test collection");
+    await typeIntoNth(page, ".http-collection-form", "input", 2, "https://example.com");
+    await typeIntoNth(page, ".http-collection-form", "textarea", 0, "Authorization=Bearer secret-token");
+    await clickByText(page, "Add API", ".http-collection-form");
+
+    const collection = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, headers FROM http_tool_collections WHERE name = ?").get("E2E API") as
+          | { id: string; headers: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(collection, "collection never appeared in the sandbox DB").toBeDefined();
+    // Headers are encrypted at rest — the raw column must not contain the plaintext token.
+    expect(collection!.headers).not.toContain("secret-token");
+
+    const decrypted = await page.evaluate(
+      (id) => (window.agentsAPI as unknown as AgentsApiForE2E).httpTools.getCollectionHeaders(id),
+      collection!.id
+    );
+    expect(decrypted).toEqual({ Authorization: "Bearer secret-token" });
+
+    // Expand the collection row, add an endpoint.
+    await clickByText(page, "E2E API — no endpoints yet");
+    await clickByText(page, "Add endpoint");
+    await typeIntoNth(page, ".http-tool-form", "input", 0, "Get Widget");
+    await typeIntoNth(page, ".http-tool-form", "input", 1, "Fetch a widget");
+    await typeIntoNth(page, ".http-tool-form", "input", 2, "/widget");
+    await clickByText(page, "Add endpoint", ".http-tool-form");
+
+    const tool = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM http_tools WHERE name = ?").get("Get Widget") as
+          | { id: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(tool, "endpoint never appeared in the sandbox DB").toBeDefined();
+    expect(tool!.enabled).toBe(1);
+
+    // Toggle the endpoint off.
+    await clickSelector(page, '[aria-label="Toggle Get Widget"]');
+    const disabledTool = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM http_tools WHERE id = ?").get(tool!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabledTool?.enabled).toBe(0);
+
+    // Delete the endpoint (type-to-confirm), then the collection.
+    await clickSelector(page, '[aria-label="Remove Get Widget"]');
+    await typeIntoNth(page, ".delete-confirm-modal", "input", 0, "DELETE");
+    await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+
+    const toolGone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM http_tools WHERE id = ?").get(tool!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(toolGone?.deleted).toBe(true);
+
+    await clickSelector(page, '[aria-label="Remove E2E API"]');
+    await typeIntoNth(page, ".delete-confirm-modal", "input", 0, "DELETE");
+    await clickSelector(page, ".delete-confirm-modal .danger-zone-reset-btn");
+
+    const collectionGone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM http_tool_collections WHERE id = ?").get(collection!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(collectionGone?.deleted).toBe(true);
+  });
+});

--- a/e2e/knowledge-url-discovery.spec.ts
+++ b/e2e/knowledge-url-discovery.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  clickSelector,
+  clickByText,
+  selectComboboxOption,
+  typeIntoNth,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// discoverLinks is a real fetch — POSTed to the local open-websearch daemon (started at app
+// launch, electron/main/index.ts) which does the actual outbound HTTP fetch + link extraction of
+// the URL given. example.com is used deliberately: a static IANA page with no outbound links, no
+// JS rendering and no cookie gate, so the daemon's fast request-only path handles it and the
+// discovered-links assertions are stable (both link sections empty). See
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 3.
+
+const provider = resolveE2EProvider();
+const SEED_URL = "https://example.com";
+
+test.describe("Knowledge base — Add from URL", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("discovers links for a real URL and adds the seed page as a knowledge file", async () => {
+    await clickSelector(page, '[aria-label="Add to knowledge base"]');
+    await selectComboboxOption(page, "URL");
+    await page.waitForSelector('[role="dialog"][aria-label="Add from URL"]', { timeout: 10_000 });
+
+    await typeIntoNth(page, ".au-field", "input", 0, SEED_URL);
+    await clickByText(page, "Fetch page", ".km-body");
+
+    // The daemon fetch is a real network round trip — give it real time, and tolerate the
+    // daemon's own startup health-check window right after a fresh onboarding.
+    await page.waitForSelector(".au-section", { timeout: 30_000 });
+
+    const errorText = await page.evaluate(() => document.querySelector(".widget-error")?.textContent ?? "");
+    expect(errorText, "discoverLinks reported an error for a known-good URL").toBe("");
+
+    // Seed URL's own checkbox is pre-checked by default — confirm with that selection.
+    await clickByText(page, "Add 1 selected", ".km-body");
+
+    // handleConfirm is fire-and-forget (see AddUrlModal.tsx) — poll the DB rather than the click.
+    // addUrl() re-fetches through the daemon a second time (it doesn't reuse discoverLinks'
+    // result), so this is a second real network round trip on top of the one above. The daemon
+    // normalizes the seed URL (trailing slash added), so match with LIKE rather than exact equal.
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, title, source_url FROM knowledge_files WHERE source_url LIKE ?").get(`${SEED_URL}%`) as
+          | { id: string; title: string; source_url: string }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    }, 30_000);
+    expect(row, "discovered URL was never added as a knowledge file").toBeDefined();
+    expect(row!.title).toBe("Example Domain");
+  });
+});

--- a/e2e/mcp-servers-tab.spec.ts
+++ b/e2e/mcp-servers-tab.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickByText,
+  clickSelector,
+  typeIntoNth,
+  confirmTypeToDelete,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// mcp:create/update/delete/toggle are pure local DB writes with no command validation (see
+// electron/main/ai/mcp.ts's createMcpServer) — a fake command is safe to use throughout. Only
+// mcp:test's failure path is exercised: a real successful connect needs an actual MCP-protocol
+// server process on the other end (MCPServerStdio's real JSON-RPC handshake), which this harness
+// doesn't provision — see 0-cowork/plans/active/e2e-full-coverage.md Phase 2.
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — MCP Servers tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "MCP Servers");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("creates, edits, toggles, and deletes a server with a fake command", async () => {
+    await clickByText(page, "Add MCP Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "E2E Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 1, "does-not-exist-xyz");
+    await typeIntoNth(page, ".mcp-add-form", "input", 2, "--flag value");
+    await typeIntoNth(page, ".mcp-add-form", "textarea", 0, "API_KEY=test-value");
+    await clickByText(page, "Save", ".mcp-add-form");
+
+    const server = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, command, args, enabled FROM mcp_servers WHERE name = ?").get("E2E Server") as
+          | { id: string; command: string; args: string; enabled: number }
+          | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(server, "server never appeared in the sandbox DB").toBeDefined();
+    expect(server!.command).toBe("does-not-exist-xyz");
+    expect(JSON.parse(server!.args)).toEqual(["--flag", "value"]);
+    expect(server!.enabled).toBe(1);
+
+    // Expand the row and edit the command.
+    await clickByText(page, "E2E Server");
+    await typeIntoNth(page, ".agent-accordion-body", "input", 1, "still-does-not-exist");
+    await clickByText(page, "Save changes", ".agent-accordion-body");
+
+    const updated = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT command FROM mcp_servers WHERE id = ?").get(server!.id) as
+          | { command: string }
+          | undefined;
+        return r && r.command === "still-does-not-exist" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(updated?.command).toBe("still-does-not-exist");
+
+    // Toggle disabled.
+    await clickSelector(page, '[aria-label="Toggle E2E Server"]');
+    const disabled = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT enabled FROM mcp_servers WHERE id = ?").get(server!.id) as
+          | { enabled: number }
+          | undefined;
+        return r && r.enabled === 0 ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(disabled?.enabled).toBe(0);
+
+    // Delete (type-to-confirm).
+    await clickSelector(page, '[aria-label="Remove E2E Server"]');
+    await confirmTypeToDelete(page);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM mcp_servers WHERE id = ?").get(server!.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+
+  test("Test connection surfaces an error for a command that can't spawn", async () => {
+    await clickByText(page, "Add MCP Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "E2E Bad Server");
+    await typeIntoNth(page, ".mcp-add-form", "input", 1, "definitely-not-a-real-binary-xyz");
+    await clickByText(page, "Test connection", ".mcp-add-form");
+
+    await page.waitForSelector(".settings-error", { timeout: 15_000 });
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText.length).toBeGreaterThan(0);
+
+    // Test connection never writes to the DB — confirm the row doesn't exist.
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT id FROM mcp_servers WHERE name = ?").get("E2E Bad Server");
+      expect(row).toBeUndefined();
+    } finally {
+      db.close();
+    }
+
+    await clickByText(page, "Cancel", ".mcp-add-form");
+  });
+
+  // Registry search is a live HTTPS call to registry.modelcontextprotocol.io (searchMcpRegistry in
+  // electron/main/ai/mcp.ts) — the roadmap doc filed MCP Servers under Phase 2 as "local", which
+  // this test corrects: search genuinely depends on an external service being reachable. Assertions
+  // stay lenient about *what* comes back (a registry-side hiccup shouldn't fail the suite) but not
+  // about *whether the call completed cleanly* (a thrown error is a real regression to catch).
+  test("registry search reaches the live MCP registry and installs a result", async () => {
+    await clickByText(page, "Add MCP Server");
+    await clickByText(page, "Browse Registry", ".mcp-add-form");
+    await typeIntoNth(page, ".mcp-add-form", "input", 0, "filesystem");
+    await clickByText(page, "Search", ".mcp-add-form");
+
+    await page.waitForFunction(
+      () => document.querySelector(".settings-hint, .settings-empty, .settings-error") !== null,
+      { timeout: 15_000 }
+    );
+
+    const errorText = await page.evaluate(() => document.querySelector(".settings-error")?.textContent ?? "");
+    expect(errorText, "registry search reported an error").toBe("");
+
+    const hasInstallButton = await page.evaluate(
+      () => [...document.querySelectorAll(".settings-folder-row button")].some((b) => b.textContent?.trim() === "Install")
+    );
+    if (!hasInstallButton) {
+      test.info().annotations.push({ type: "note", description: "registry returned no installable results for this query" });
+      return;
+    }
+
+    await clickByText(page, "Install");
+    const installed = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        return db.prepare("SELECT id, enabled FROM mcp_servers WHERE command LIKE ? OR command LIKE ?").get(
+          "%npx%",
+          "%node%"
+        ) as { id: string; enabled: number } | undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(installed, "installed server never appeared in the sandbox DB").toBeDefined();
+    // Installed servers land disabled by design (mcp.ts's handleInstall comment) — a
+    // registry-sourced command shouldn't silently start running before it's reviewed.
+    expect(installed?.enabled).toBe(0);
+  });
+});

--- a/e2e/models-tab.spec.ts
+++ b/e2e/models-tab.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  typeIntoLabeledRow,
+  clickInLabeledRow,
+  typeIntoField,
+  blurActive,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+// Only non-Test-button actions — settings:testChat/testVoice (the "Test" buttons beside the Chat
+// provider and Voice rows) are explicitly out of scope here, deferred to Phase 4 alongside the
+// live-provider chat flow. See 0-cowork/plans/active/e2e-full-coverage.md.
+
+const provider = resolveE2EProvider();
+// A non-chat provider to exercise the plain providers:save path — onboarding always selects
+// E2E_PROVIDER as Chat, so any other AI_PROVIDERS entry works here as long as it isn't that one.
+const OTHER_PROVIDER_LABEL = provider.id === "openai" ? "OpenRouter" : "OpenAI";
+
+test.describe("Settings — Models tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Models");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readProviderRow(id: string): { api_url: string; keylen: number } | undefined {
+    const db = openDb(userData);
+    try {
+      return db.prepare("SELECT api_url, length(api_key) AS keylen FROM providers WHERE id = ?").get(id) as
+        | { api_url: string; keylen: number }
+        | undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("saves, then clears, a non-chat provider's API key and URL", async () => {
+    await typeIntoLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API key`, "sk-e2e-test-key");
+    await blurActive(page);
+
+    const saved = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row && row.keylen > 0 ? row : undefined;
+    });
+    expect(saved?.keylen).toBeGreaterThan(0);
+
+    await typeIntoLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API URL`, "https://example.com/v1");
+    await blurActive(page);
+    const withUrl = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row?.api_url === "https://example.com/v1" ? row : undefined;
+    });
+    expect(withUrl?.api_url).toBe("https://example.com/v1");
+
+    await clickInLabeledRow(page, ".row-field", `${OTHER_PROVIDER_LABEL} API key`, "Remove");
+    const cleared = await pollUntil(() => {
+      const row = readProviderRow(OTHER_PROVIDER_LABEL === "OpenRouter" ? "openrouter" : "openai");
+      return row && row.keylen === 0 ? row : undefined;
+    });
+    expect(cleared?.keylen).toBe(0);
+  });
+
+  test("switches the Chat provider slot and updates the Chat model", async () => {
+    const targetLabel = OTHER_PROVIDER_LABEL;
+    const targetId = targetLabel === "OpenRouter" ? "openrouter" : "openai";
+
+    await pickCombobox(page, "Chat provider", targetLabel);
+
+    // selectChatProvider writes via setSetting, bypassing settings:update, then self-broadcasts —
+    // poll the DB rather than the UI so the assertion doesn't depend on catching that broadcast.
+    const switched = await pollUntil(() => readSetting("chatProviderId") as string | undefined);
+    expect(switched).toBe(targetId);
+
+    await typeIntoField(page, 'input[aria-label="Chat model"]', "test-model-id");
+    await blurActive(page);
+    const model = await pollUntil(() => readSetting("orchestratorModel") as string | undefined);
+    expect(model).toBe("test-model-id");
+  });
+
+  test("edits transcription, TTS model, and TTS voice fields", async () => {
+    await typeIntoField(page, 'input[aria-label="Transcription model"]', "test-transcription-model");
+    await blurActive(page);
+    expect(await pollUntil(() => readSetting("voiceTranscriptionModel") as string | undefined)).toBe(
+      "test-transcription-model"
+    );
+
+    await typeIntoField(page, 'input[aria-label="Speech (TTS) model"]', "test-tts-model");
+    await blurActive(page);
+    expect(await pollUntil(() => readSetting("voiceTtsModel") as string | undefined)).toBe("test-tts-model");
+
+    const currentVoice = readSetting("voiceTtsVoice") as string;
+    const otherVoice = currentVoice === "alloy" ? "echo" : "alloy";
+    await pickCombobox(page, "Speech (TTS) voice", otherVoice);
+    expect(await pollUntil(() => readSetting("voiceTtsVoice") as string | undefined)).toBe(otherVoice);
+  });
+});

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,76 +1,16 @@
-import { test, expect, _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { fileURLToPath } from "node:url";
-import Database from "better-sqlite3";
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, openDb, pollUntil } from "./helpers";
 
 // Drives the real Electron app through onboarding, selecting whichever provider E2E_PROVIDER
 // resolves to (see providerConfig.ts), and asserts the credential landed in the sandbox DB.
 // See .claude/skills/run-openorbit/driver.mjs for the manual-REPL version of the same
-// sandbox/click/DB-read conventions this spec reuses.
+// sandbox/click/DB-read conventions this spec reuses (now shared with the rest of e2e/ via
+// helpers.ts).
 
 // Resolved at module load, not inside a test/hook: a bad or unconfigured E2E_PROVIDER should
 // fail the whole suite immediately, not surface as a confusing mid-test failure.
 const provider = resolveE2EProvider();
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const APP_DIR = path.resolve(__dirname, "..");
-
-const ELECTRON_BIN =
-  process.platform === "darwin"
-    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
-    : path.join(APP_DIR, "node_modules/electron/dist/electron");
-
-function dbPath(userData: string): string {
-  return path.join(userData, "database/agents.db");
-}
-
-// Same realpath-comparison as driver.mjs's isInsideSandbox — macOS symlinks /tmp to /private/tmp,
-// so a plain startsWith would read a perfectly good sandbox as an escape.
-function isInsideSandbox(resolved: string, sandboxReal: string): boolean {
-  const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : path.resolve(resolved);
-  return real === sandboxReal || real.startsWith(sandboxReal + path.sep);
-}
-
-// React-controlled inputs ignore a plain `.value =` assignment — it has to go through the
-// prototype setter and dispatch a real input event, or onChange never fires.
-async function typeIntoField(page: Page, selector: string, value: string): Promise<void> {
-  await page.evaluate(
-    ({ selector, value }) => {
-      const el = document.querySelector(selector) as HTMLInputElement | null;
-      if (!el) throw new Error(`field not found: ${selector}`);
-      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
-      setter.call(el, value);
-      el.dispatchEvent(new Event("input", { bubbles: true }));
-    },
-    { selector, value }
-  );
-}
-
-// Locator clicks time out on "element is not stable" against this app's continuous framer-motion
-// animation — DOM click via evaluate sidesteps the actionability check entirely.
-async function clickSelector(page: Page, selector: string): Promise<void> {
-  const found = await page.evaluate((s) => {
-    const el = document.querySelector(s);
-    if (!el) return false;
-    (el as HTMLElement).click();
-    return true;
-  }, selector);
-  if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
-}
-
-async function clickByText(page: Page, text: string): Promise<void> {
-  const found = await page.evaluate((t) => {
-    const els = [...document.querySelectorAll('button, a, [role="button"], [role="radio"]')];
-    const el = els.find((e) => e.textContent?.trim() === t);
-    if (!el) return false;
-    (el as HTMLElement).click();
-    return true;
-  }, text);
-  if (!found) throw new Error(`clickByText: no element with text "${text}"`);
-}
 
 test.describe(`onboarding — ${provider.label}`, () => {
   let app: ElectronApplication;
@@ -78,29 +18,8 @@ test.describe(`onboarding — ${provider.label}`, () => {
   let userData: string;
 
   test.beforeAll(async () => {
-    if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
-      throw new Error("no build — run `npm run build` first (main is dist-electron/main/index.js)");
-    }
-
-    userData = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "orbit-e2e-"));
-
-    app = await electron.launch({
-      executablePath: ELECTRON_BIN,
-      args: [APP_DIR, `--user-data-dir=${userData}`],
-      timeout: 60_000,
-    });
-    page = await app.firstWindow();
-    await page.waitForLoadState("domcontentloaded");
-    await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
-
-    // Non-negotiable: abort before any interaction if isolation didn't take, or the test writes
-    // into the developer's real ~/Library/Application Support/OpenOrbit database.
-    const resolvedUserData = await app.evaluate(({ app }) => app.getPath("userData"));
-    const sandboxReal = fs.realpathSync(userData);
-    if (!isInsideSandbox(resolvedUserData, sandboxReal)) {
-      await app.close();
-      throw new Error(`ABORT: userData resolved to ${resolvedUserData}, expected under ${sandboxReal}`);
-    }
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
   });
 
   test.afterAll(async () => {
@@ -108,55 +27,26 @@ test.describe(`onboarding — ${provider.label}`, () => {
   });
 
   test(`completes onboarding selecting ${provider.label} and persists the provider`, async () => {
-    await typeIntoField(page, 'input[aria-label="Give me a name?"]', "TestOrbit");
-    await page.keyboard.press("Enter");
-
-    await typeIntoField(page, 'input[aria-label="What should I call you?"]', "E2E Tester");
-    await page.keyboard.press("Enter");
-
-    // profession is an optional *text* step — no Skip button, just an always-enabled Next.
-    await clickSelector(page, '[aria-label="Next"]');
-
-    // responseStyle, technicalLevel, stuckStyle — optional *chip* steps, each with its own Skip.
-    for (let i = 0; i < 3; i++) {
-      await clickSelector(page, '[aria-label="Skip"]');
-    }
-
-    await clickByText(page, provider.label);
-
-    // apiUrl step is prefilled from the provider's registry entry — accept the default.
-    await page.keyboard.press("Enter");
-
-    await typeIntoField(page, 'input[aria-label="Enter your API key"]', provider.apiKey);
-    await page.keyboard.press("Enter");
-
-    // model step is prefilled — accept the default.
-    await page.keyboard.press("Enter");
+    await completeOnboarding(page, provider);
 
     // handleOnboardingComplete fires providers.selectChat fire-and-forget (not awaited by the UI),
     // so the DB write can land after the click resolves. Poll rather than assert immediately.
-    const deadline = Date.now() + 5_000;
-    let row: { id: string; api_url: string; keylen: number } | undefined;
-    while (Date.now() < deadline) {
-      const db = new Database(dbPath(userData), { readonly: true, fileMustExist: false });
+    const row = await pollUntil(() => {
+      const db = openDb(userData);
       try {
-        row = db
+        return db
           .prepare("SELECT id, api_url, length(api_key) AS keylen FROM providers WHERE id = ?")
-          .get(provider.id) as typeof row;
-      } catch {
-        // table may not exist yet on the very first poll — keep waiting.
+          .get(provider.id) as { id: string; api_url: string; keylen: number } | undefined;
       } finally {
         db.close();
       }
-      if (row) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
+    });
 
     expect(row, `${provider.id} provider row never appeared in the sandbox DB`).toBeDefined();
     expect(row!.keylen).toBeGreaterThan(0);
     expect(row!.api_url).not.toBe("");
 
-    const settingsDb = new Database(dbPath(userData), { readonly: true });
+    const settingsDb = openDb(userData);
     const chatProviderRow = settingsDb
       .prepare("SELECT setting_value FROM settings WHERE setting_name = ?")
       .get("appSettings.chatProviderId") as { setting_value: string } | undefined;

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect, _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+import { resolveE2EProvider } from "./providerConfig";
+
+// Drives the real Electron app through onboarding, selecting whichever provider E2E_PROVIDER
+// resolves to (see providerConfig.ts), and asserts the credential landed in the sandbox DB.
+// See .claude/skills/run-openorbit/driver.mjs for the manual-REPL version of the same
+// sandbox/click/DB-read conventions this spec reuses.
+
+// Resolved at module load, not inside a test/hook: a bad or unconfigured E2E_PROVIDER should
+// fail the whole suite immediately, not surface as a confusing mid-test failure.
+const provider = resolveE2EProvider();
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const APP_DIR = path.resolve(__dirname, "..");
+
+const ELECTRON_BIN =
+  process.platform === "darwin"
+    ? path.join(APP_DIR, "node_modules/electron/dist/Electron.app/Contents/MacOS/Electron")
+    : path.join(APP_DIR, "node_modules/electron/dist/electron");
+
+function dbPath(userData: string): string {
+  return path.join(userData, "database/agents.db");
+}
+
+// Same realpath-comparison as driver.mjs's isInsideSandbox — macOS symlinks /tmp to /private/tmp,
+// so a plain startsWith would read a perfectly good sandbox as an escape.
+function isInsideSandbox(resolved: string, sandboxReal: string): boolean {
+  const real = fs.existsSync(resolved) ? fs.realpathSync(resolved) : path.resolve(resolved);
+  return real === sandboxReal || real.startsWith(sandboxReal + path.sep);
+}
+
+// React-controlled inputs ignore a plain `.value =` assignment — it has to go through the
+// prototype setter and dispatch a real input event, or onChange never fires.
+async function typeIntoField(page: Page, selector: string, value: string): Promise<void> {
+  await page.evaluate(
+    ({ selector, value }) => {
+      const el = document.querySelector(selector) as HTMLInputElement | null;
+      if (!el) throw new Error(`field not found: ${selector}`);
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { selector, value }
+  );
+}
+
+// Locator clicks time out on "element is not stable" against this app's continuous framer-motion
+// animation — DOM click via evaluate sidesteps the actionability check entirely.
+async function clickSelector(page: Page, selector: string): Promise<void> {
+  const found = await page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, selector);
+  if (!found) throw new Error(`clickSelector: no element matching "${selector}"`);
+}
+
+async function clickByText(page: Page, text: string): Promise<void> {
+  const found = await page.evaluate((t) => {
+    const els = [...document.querySelectorAll('button, a, [role="button"], [role="radio"]')];
+    const el = els.find((e) => e.textContent?.trim() === t);
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, text);
+  if (!found) throw new Error(`clickByText: no element with text "${text}"`);
+}
+
+test.describe(`onboarding — ${provider.label}`, () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    if (!fs.existsSync(path.join(APP_DIR, "dist-electron/main/index.js"))) {
+      throw new Error("no build — run `npm run build` first (main is dist-electron/main/index.js)");
+    }
+
+    userData = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "orbit-e2e-"));
+
+    app = await electron.launch({
+      executablePath: ELECTRON_BIN,
+      args: [APP_DIR, `--user-data-dir=${userData}`],
+      timeout: 60_000,
+    });
+    page = await app.firstWindow();
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForFunction(() => typeof window.agentsAPI !== "undefined", { timeout: 30_000 });
+
+    // Non-negotiable: abort before any interaction if isolation didn't take, or the test writes
+    // into the developer's real ~/Library/Application Support/OpenOrbit database.
+    const resolvedUserData = await app.evaluate(({ app }) => app.getPath("userData"));
+    const sandboxReal = fs.realpathSync(userData);
+    if (!isInsideSandbox(resolvedUserData, sandboxReal)) {
+      await app.close();
+      throw new Error(`ABORT: userData resolved to ${resolvedUserData}, expected under ${sandboxReal}`);
+    }
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test(`completes onboarding selecting ${provider.label} and persists the provider`, async () => {
+    await typeIntoField(page, 'input[aria-label="Give me a name?"]', "TestOrbit");
+    await page.keyboard.press("Enter");
+
+    await typeIntoField(page, 'input[aria-label="What should I call you?"]', "E2E Tester");
+    await page.keyboard.press("Enter");
+
+    // profession is an optional *text* step — no Skip button, just an always-enabled Next.
+    await clickSelector(page, '[aria-label="Next"]');
+
+    // responseStyle, technicalLevel, stuckStyle — optional *chip* steps, each with its own Skip.
+    for (let i = 0; i < 3; i++) {
+      await clickSelector(page, '[aria-label="Skip"]');
+    }
+
+    await clickByText(page, provider.label);
+
+    // apiUrl step is prefilled from the provider's registry entry — accept the default.
+    await page.keyboard.press("Enter");
+
+    await typeIntoField(page, 'input[aria-label="Enter your API key"]', provider.apiKey);
+    await page.keyboard.press("Enter");
+
+    // model step is prefilled — accept the default.
+    await page.keyboard.press("Enter");
+
+    // handleOnboardingComplete fires providers.selectChat fire-and-forget (not awaited by the UI),
+    // so the DB write can land after the click resolves. Poll rather than assert immediately.
+    const deadline = Date.now() + 5_000;
+    let row: { id: string; api_url: string; keylen: number } | undefined;
+    while (Date.now() < deadline) {
+      const db = new Database(dbPath(userData), { readonly: true, fileMustExist: false });
+      try {
+        row = db
+          .prepare("SELECT id, api_url, length(api_key) AS keylen FROM providers WHERE id = ?")
+          .get(provider.id) as typeof row;
+      } catch {
+        // table may not exist yet on the very first poll — keep waiting.
+      } finally {
+        db.close();
+      }
+      if (row) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    expect(row, `${provider.id} provider row never appeared in the sandbox DB`).toBeDefined();
+    expect(row!.keylen).toBeGreaterThan(0);
+    expect(row!.api_url).not.toBe("");
+
+    const settingsDb = new Database(dbPath(userData), { readonly: true });
+    const chatProviderRow = settingsDb
+      .prepare("SELECT setting_value FROM settings WHERE setting_name = ?")
+      .get("appSettings.chatProviderId") as { setting_value: string } | undefined;
+    settingsDb.close();
+
+    expect(chatProviderRow?.setting_value).toBe(JSON.stringify(provider.id));
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+// E2E specs drive one real Electron instance each against an isolated --user-data-dir (see
+// onboarding.spec.ts). They are not browser-context tests, so most of Playwright's `use` surface
+// (viewport, browserName, etc.) does not apply here — only the test-runner pieces are used.
+export default defineConfig({
+  testDir: ".",
+  timeout: 60_000,
+  // One real Electron app per test, launched/closed serially. Parallel workers would each need
+  // their own build + userData + no shared singleton state — not worth it for a small suite.
+  workers: 1,
+  reporter: "list",
+});

--- a/e2e/privacy-safety-tab.spec.ts
+++ b/e2e/privacy-safety-tab.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  openSettingsTab,
+  clickSelector,
+  pickCombobox,
+  openDb,
+  pollUntil,
+} from "./helpers";
+
+const provider = resolveE2EProvider();
+
+test.describe("Settings — Privacy & Safety tab", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+    await openSettingsTab(page, "Privacy & Safety");
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  function readSetting(key: string): unknown {
+    const db = openDb(userData);
+    try {
+      const row = db.prepare("SELECT setting_value FROM settings WHERE setting_name = ?").get(`appSettings.${key}`) as
+        | { setting_value: string }
+        | undefined;
+      return row ? JSON.parse(row.setting_value) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  test("toggles the three approval methods", async () => {
+    await clickSelector(page, '[aria-label="Ask before POST requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalPost") as boolean | undefined)).toBe(false);
+
+    await clickSelector(page, '[aria-label="Ask before PUT / PATCH requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalPutPatch") as boolean | undefined)).toBe(false);
+
+    await clickSelector(page, '[aria-label="Ask before DELETE requests"]');
+    expect(await pollUntil(() => readSetting("httpToolApprovalDelete") as boolean | undefined)).toBe(false);
+  });
+
+  test("switches the approval display method", async () => {
+    await pickCombobox(page, "How to ask for approval", "Card in the chat");
+    const value = await pollUntil(() => readSetting("toolApprovalDisplay") as string | undefined);
+    expect(value).toBe("inline");
+  });
+
+  test("toggles location access and remote image loading", async () => {
+    await clickSelector(page, '[aria-label="Toggle location access"]');
+    expect(await pollUntil(() => readSetting("locationEnabled") as boolean | undefined)).toBe(true);
+
+    await clickSelector(page, '[aria-label="Toggle automatic remote image loading"]');
+    expect(await pollUntil(() => readSetting("remoteImagesAutoLoad") as boolean | undefined)).toBe(true);
+  });
+});

--- a/e2e/providerConfig.ts
+++ b/e2e/providerConfig.ts
@@ -1,0 +1,52 @@
+import { AI_PROVIDERS } from "../electron/main/ai/providers";
+
+// "local" is deliberately excluded: its registry entry has a blank baseUrl/defaultChatModel
+// (electron/main/ai/providers.ts) because only a real Ollama install knows those — this harness
+// doesn't provision one, so treating it as selectable would fail unpredictably mid-run instead
+// of at config-resolution time.
+const SUPPORTED = ["openai", "openrouter"] as const;
+type SupportedProviderId = (typeof SUPPORTED)[number];
+
+const API_KEY_ENV_VAR: Record<SupportedProviderId, string> = {
+  openai: "OPENAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+};
+
+export interface E2EProviderConfig {
+  id: SupportedProviderId;
+  label: string;
+  apiKey: string;
+}
+
+function isSupported(id: string): id is SupportedProviderId {
+  return (SUPPORTED as readonly string[]).includes(id);
+}
+
+/**
+ * Resolves which AI_PROVIDERS entry E2E specs should drive onboarding against, from the
+ * E2E_PROVIDER env var (set in .env.test). Fails loudly on a bad or unconfigured choice rather
+ * than skipping quietly, so a broken .env.test reads as a broken suite, not a suite with fewer
+ * tests than expected.
+ */
+export function resolveE2EProvider(): E2EProviderConfig {
+  const requested = (process.env.E2E_PROVIDER || "openai").trim();
+  if (!isSupported(requested)) {
+    throw new Error(
+      `E2E_PROVIDER="${requested}" is not supported. Use one of: ${SUPPORTED.join(", ")}. ` +
+        `"local" is excluded — it needs a running Ollama server this harness doesn't provision.`
+    );
+  }
+
+  const provider = AI_PROVIDERS.find((p) => p.id === requested);
+  if (!provider) {
+    throw new Error(`"${requested}" is not in AI_PROVIDERS — e2e/providerConfig.ts and the registry have drifted.`);
+  }
+
+  const apiKeyEnvVar = API_KEY_ENV_VAR[requested];
+  const apiKey = process.env[apiKeyEnvVar];
+  if (!apiKey) {
+    throw new Error(`E2E_PROVIDER="${requested}" needs ${apiKeyEnvVar} set in .env.test.`);
+  }
+
+  return { id: requested, label: provider.label, apiKey };
+}

--- a/e2e/slash-commands.spec.ts
+++ b/e2e/slash-commands.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, clickSelector } from "./helpers";
+
+// AgentsApp.tsx's handleSend intercepts these exact strings BEFORE any provider call (see
+// 0-cowork/plans/active/e2e-full-coverage.md Phase 4) — genuinely zero-cost, local-only. Two
+// commands in the same intercept block are deliberately excluded: /agents-create rewrites the
+// text and falls through to a real orchestrator call, and /<agent-slug> routing is likewise a
+// real call — neither belongs in a zero-cost spec. /add-file and /add-folder open native OS
+// pickers Playwright can't drive, and /tour's resulting DOM wasn't traced for this phase — all
+// three are left uncovered here rather than guessed at.
+
+const provider = resolveE2EProvider();
+
+// Typing a full command opens ChatInputBar's own autocomplete menu (matches the app's other
+// slash-driven surfaces) — Enter while it's open selects the highlighted menu item (completing
+// the text) rather than submitting. Escape closes the menu without touching the typed text, so
+// the next Enter takes the normal send path and handleSend's exact-string intercept fires.
+async function sendSlashCommand(page: Page, command: string): Promise<void> {
+  await typeIntoField(page, "#inp", command);
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Enter");
+}
+
+test.describe("Slash-command interception", () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const { userData } = launchSandboxedApp();
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("/settings opens the Settings modal", async () => {
+    await sendSlashCommand(page, "/settings");
+    await page.waitForSelector('[role="dialog"][aria-label="Settings"]', { timeout: 10_000 });
+    await clickSelector(page, '[aria-label="Close settings"]');
+  });
+
+  test("/chat-history opens the Chat History modal", async () => {
+    await sendSlashCommand(page, "/chat-history");
+    await page.waitForSelector('[role="dialog"][aria-label="Chat History"]', { timeout: 10_000 });
+    await clickSelector(page, '.modal-panel--chat-history [aria-label="Close"]');
+  });
+
+  test("/http-tools opens Settings deep-linked to the HTTP Tools section", async () => {
+    await sendSlashCommand(page, "/http-tools");
+    await page.waitForSelector('[role="dialog"][aria-label="Settings"]', { timeout: 10_000 });
+    const title = await page.evaluate(() => document.querySelector(".settings-detail h1")?.textContent ?? "");
+    expect(title).toBe("HTTP Tools");
+    await clickSelector(page, '[aria-label="Close settings"]');
+  });
+
+  test("/knowledgebase opens the Knowledge modal", async () => {
+    await sendSlashCommand(page, "/knowledgebase");
+    await page.waitForSelector('[role="dialog"][aria-label="Knowledge"]', { timeout: 10_000 });
+    await clickSelector(page, '.km-header [aria-label="Close"]');
+  });
+
+  test("/system-stats appends a local reply with no provider call", async () => {
+    const before = await page.evaluate(() => document.querySelectorAll("#chat-log .turn.assistant").length);
+    await sendSlashCommand(page, "/system-stats");
+    await page.waitForFunction(
+      (n) => document.querySelectorAll("#chat-log .turn.assistant").length > n,
+      before,
+      { timeout: 10_000 }
+    );
+    const lastReply = await page.evaluate(() => {
+      const turns = [...document.querySelectorAll("#chat-log .turn.assistant .mb--assistant")];
+      return turns[turns.length - 1]?.textContent ?? "";
+    });
+    expect(lastReply).toMatch(/CPU:|not available/);
+  });
+
+  test("/usage appends a local reply with no provider call", async () => {
+    const before = await page.evaluate(() => document.querySelectorAll("#chat-log .turn.assistant").length);
+    await sendSlashCommand(page, "/usage");
+    await page.waitForFunction(
+      (n) => document.querySelectorAll("#chat-log .turn.assistant").length > n,
+      before,
+      { timeout: 10_000 }
+    );
+    const lastReply = await page.evaluate(() => {
+      const turns = [...document.querySelectorAll("#chat-log .turn.assistant .mb--assistant")];
+      return turns[turns.length - 1]?.textContent ?? "";
+    });
+    expect(lastReply).toMatch(/Today's usage/);
+  });
+});

--- a/e2e/tasks-widget.spec.ts
+++ b/e2e/tasks-widget.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
+import { resolveE2EProvider } from "./providerConfig";
+import {
+  launchSandboxedApp,
+  launchApp,
+  completeOnboarding,
+  clickSelector,
+  openDb,
+  pollUntil,
+  type AgentsApiForE2E,
+} from "./helpers";
+
+// There is no UI to create a task (electron/main/ai/tools/taskAgentTools.ts's createTaskTool is
+// the only real entry point, invoked mid-conversation by the agent, and the scheduler creates
+// recurring ones) — see 0-cowork/plans/active/e2e-full-coverage.md. Seeding here goes straight
+// through the same window.agentsAPI.tasks.create() contract the agent tool calls, so it still
+// exercises the real IPC validation (assertTaskFields) and DB write; only Complete/Delete are
+// driven through the actual TasksWidget UI.
+
+const provider = resolveE2EProvider();
+
+// TasksWidget only re-fetches on the "tasks:update" broadcast (electron/main/ipc/agent.ts's
+// broadcastTasksUpdate) — the same path Chrono's tools and the scheduler rely on for writes that
+// bypass the tasks:* IPC handlers, which is exactly what this seed does too (see the comment
+// below). Without firing it ourselves, a task created this way never appears in the widget.
+async function broadcastTasksUpdate(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ BrowserWindow }) => {
+    for (const win of BrowserWindow.getAllWindows()) win.webContents.send("tasks:update");
+  });
+}
+
+test.describe("Tasks widget", () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let userData: string;
+
+  test.beforeAll(async () => {
+    ({ userData } = launchSandboxedApp());
+    ({ app, page } = await launchApp(userData));
+    await completeOnboarding(page, provider);
+  });
+
+  test.afterAll(async () => {
+    await app?.close().catch(() => {});
+  });
+
+  test("tasks:create rejects a blank title", async () => {
+    const error = await page.evaluate(async () => {
+      try {
+        await (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "" });
+        return null;
+      } catch (err) {
+        return String(err);
+      }
+    });
+    expect(error).toContain("non-empty title");
+  });
+
+  test("completes a task through the widget", async () => {
+    const created = await page.evaluate(
+      () => (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "E2E Complete Me" })
+    );
+    await broadcastTasksUpdate(app);
+    await page.waitForSelector(`[aria-label="Complete ${created.title}"]`, { timeout: 10_000 });
+
+    await clickSelector(page, `[aria-label="Complete ${created.title}"]`);
+
+    const done = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT status FROM tasks WHERE id = ?").get(created.id) as
+          | { status: string }
+          | undefined;
+        return r && r.status === "done" ? r : undefined;
+      } finally {
+        db.close();
+      }
+    });
+    expect(done?.status).toBe("done");
+  });
+
+  test("deletes a task through the widget", async () => {
+    const created = await page.evaluate(
+      () => (window.agentsAPI as unknown as AgentsApiForE2E).tasks.create({ title: "E2E Delete Me" })
+    );
+    await broadcastTasksUpdate(app);
+    await page.waitForSelector(`[aria-label="Delete ${created.title}"]`, { timeout: 10_000 });
+
+    await clickSelector(page, `[aria-label="Delete ${created.title}"]`);
+
+    const gone = await pollUntil(() => {
+      const db = openDb(userData);
+      try {
+        const r = db.prepare("SELECT id FROM tasks WHERE id = ?").get(created.id);
+        return r ? undefined : { deleted: true };
+      } finally {
+        db.close();
+      }
+    });
+    expect(gone?.deleted).toBe(true);
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,21 +1,13 @@
 import { resolve } from "node:path";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
-import { resolveReleaseInfo } from "./scripts/releaseInfo";
+import { resolveCommit } from "./scripts/releaseInfo";
 
-// Resolved once per build, never at runtime, so the shipped app makes no release-check
-// network call and needs no GitHub token. resolveReleaseInfo never rejects — an offline
-// build falls back to 0.0.0 rather than failing (see scripts/releaseInfo.ts).
-const release = await resolveReleaseInfo();
-
-/** JSON.stringify is required, not cosmetic: release notes are arbitrary markdown carrying
- * quotes and newlines, which would produce broken JS if substituted raw. */
-export const releaseDefines: Record<string, string> = {
-  __APP_RELEASE_VERSION__: JSON.stringify(release.version),
-  __APP_RELEASE_DATE__: JSON.stringify(release.releaseDate),
-  __APP_RELEASE_NOTES__: JSON.stringify(release.releaseNotes),
-  __APP_RELEASE_URL__: JSON.stringify(release.releaseUrl),
-  __APP_COMMIT__: JSON.stringify(release.commit),
+// The packaged app has no .git dir of its own, so the building machine's commit can only
+// ever be captured here, at build time — resolveCommit() returns "" without a .git dir
+// (see scripts/releaseInfo.ts) rather than throwing, so an archive-only build still works.
+export const buildDefines: Record<string, string> = {
+  __APP_COMMIT__: JSON.stringify(resolveCommit()),
 };
 
 export default defineConfig({
@@ -51,7 +43,7 @@ export default defineConfig({
   },
   renderer: {
     root: ".",
-    define: releaseDefines,
+    define: buildDefines,
     build: {
       outDir: "dist-electron/renderer",
       rollupOptions: {

--- a/electron/main/ai/prompts/knowledgeAgent.md
+++ b/electron/main/ai/prompts/knowledgeAgent.md
@@ -29,6 +29,7 @@ Same tone as {{agentName}} — direct, warm, no filler. When you cite a file, na
 
 - Never fabricate file contents — only report what the tools return.
 - If the knowledgebase genuinely doesn't have an answer — after checking the unfiltered list and reading any plausible candidates — say so plainly and hand back to {{agentName}}.
+- Never offer to search the web or "other sources outside the knowledge base" — you have no tools for that. If the request needs live web information, say the knowledge base doesn't cover it and hand back to {{agentName}}, who can route to Explorer.
 
 ## Output Format
 

--- a/electron/main/ai/prompts/orchestrator.md
+++ b/electron/main/ai/prompts/orchestrator.md
@@ -11,7 +11,7 @@ You talk with {{userName}} directly and handle most requests yourself. You have 
 - **Explorer** — searches the live web for current information: news, "what's the latest on X," comparisons, recommendations, or anything about the outside world that isn't in {{userName}}'s own documents. Hand off to Explorer for questions about current events, public figures, products, or general topics that need up-to-date information rather than {{userName}}'s personal files — and never answer these from training data, since it can be stale. If the last thing Explorer said was a clarifying question, treat {{userName}}'s next message as continuing that same research request and hand off to Explorer again rather than re-deciding from scratch.
 - **Chrono** — manages reminders and prompt tasks: one-shot or recurring, with an OS notification when due. Hand off to Chrono whenever {{userName}} asks to be reminded of something, or to set up, list, change, or cancel any recurring/scheduled task — e.g. "remind me to call the dentist tomorrow at 2pm" or "every morning check my email for anything urgent" — you have no tools of your own to create or manage tasks, so never guess or make one up.
 
-Never tell {{userName}} you don't have information about them (background, documents, qualifications, preferences, anything they may have written down) without first handing off to Atlas to check the knowledge base. Only say the information isn't available after Atlas has actually looked and confirmed nothing relevant exists — never assume the Knowledgebase is empty or irrelevant on your own.
+Never tell {{userName}} you don't have information about them (background, documents, qualifications, preferences, anything they may have written down) without first handing off to Atlas to check the knowledge base. Only say the information isn't available after Atlas has actually looked and confirmed nothing relevant exists — never assume the Knowledgebase is empty or irrelevant on your own. This holds regardless of what the previous turn was about — a message like "check my resume for X" is always Atlas, even immediately after an Explorer handoff on an unrelated topic. Don't let the prior turn's specialist carry over into this one; re-decide from this message alone.
 
 If {{userName}} tells you something durable worth remembering across future conversations (a preference, a recurring detail, anything they'd otherwise have to repeat) — not just something specific to answering the current message — call **save_user_info** once for it. Every agent, not just you, will then know it going forward.
 
@@ -29,18 +29,23 @@ The current date and time is {{currentDateTime}} — trust this over anything yo
 
 Before writing any reply, work through these in order:
 
-1. **Intent** — What is {{userName}} actually asking? Separate the surface request from the underlying need. If there are multiple parts, list them.
-2. **Route** — For each part: direct answer / Cipher / Atlas / Explorer / Chrono / clarify?
-3. **Constraint check** — Am I about to guess a setting value? → Cipher. Am I about to say I don't know something about {{userName}}? → Atlas first. Am I about to use stale training data for a current-world question? → Explorer.
-4. **Validate** — After drafting a reply, check: did I actually answer every part of what was asked? If not, fix it before sending.
+1. **Decompose** — Break {{userName}}'s message into its distinct asks. A message can have more than one; list each one silently, even if the split feels obvious.
+2. **Resource check per part** — For each part, name what actually answers it: your own direct knowledge, `search_conversation_history`, `save_user_info`, or one specific specialist (Cipher/Atlas/Explorer/Chrono) and which of *its* tools/resources the part needs (a setting, a knowledge-base file, a live search, a reminder). Don't route on a guess about what a specialist can do — the descriptions in the Instruction section above are the ground truth for what each one covers.
+3. **Sequencing reality check** — You get exactly **one** handoff per message: once you transfer to a specialist, that specialist finishes the turn and nothing routes onward from it — it cannot then reach a second specialist for you. So if two parts of one message need *two different specialists*, you cannot complete both in this turn. Decide: (a) if one part is a direct answer and the other needs a specialist, answer the direct part yourself in the same reply, then hand off for the other; (b) if both parts need different specialists, handle the more urgent/primary one now and say plainly, in the reply, that {{userName}} should follow up for the other — never imply both will happen in this one turn.
+4. **Constraint check** — Am I about to guess a setting value? → Cipher. Am I about to say I don't know something about {{userName}}? → Atlas first. Am I about to use stale training data for a current-world question? → Explorer.
+5. **Validate** — After drafting a reply, check: did I actually answer every part I can answer in this turn, and did I say clearly what still needs a follow-up message? If not, fix it before sending.
 
 This reasoning is invisible — {{userName}} never sees it.
 
 ## Visible plan (show only when needed)
 
-Show a one-line plan before executing **only** when the request requires two or more sequential specialist handoffs or tool calls — e.g.:
+Show a one-line plan before executing **only** when a single part requires a specialist plus one of your own steps (e.g. saving a fact, then handing off), or when you're about to answer one part directly and hand off for another *in the same reply*. Never promise a second specialist's involvement as part of the same plan — that can't execute in one turn. e.g.:
 
-> "I'll have Atlas check your resume for that, then Explorer for the current market rate — back in a moment."
+> "Today's Wednesday — and I'll have Atlas pull that up from your resume."
+
+If a message needs two different specialists, say so honestly instead of a chained plan:
+
+> "I'll get Atlas checking your resume now — ask me again once that's back and I'll bring in Explorer for the market rate."
 
 For single-step requests or direct answers, skip the plan entirely and respond as normal.
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -24,6 +24,7 @@ import { registerKnowledgeBaseHandlers } from "./ipc/knowledgeBase";
 import { registerTaskHandlers } from "./ipc/tasks";
 import { registerUserInfoHandlers } from "./ipc/userInfo";
 import { registerAppInfoHandlers } from "./ipc/appInfo";
+import { registerUpdateCheckHandlers } from "./ipc/updateCheck";
 import { ensureAppDirectories, migrateLegacyUserData } from "./appDirs";
 import { startExplorerDaemon, stopExplorerDaemon } from "./ai/webSearchDaemon";
 import { startTaskScheduler, stopTaskScheduler, waitForInFlightPoll } from "./tasks/scheduler";
@@ -132,6 +133,7 @@ app.whenReady().then(() => {
   registerTaskHandlers();
   registerUserInfoHandlers();
   registerAppInfoHandlers();
+  registerUpdateCheckHandlers();
   // Fire-and-forget: Explorer's tools await getExplorerDaemonPort() themselves, so a
   // slow/failed daemon start doesn't block app launch — it just fails that tool call later.
   // The .catch is required, not optional: Node's default disposition for an unhandled

--- a/electron/main/ipc/updateCheck.ts
+++ b/electron/main/ipc/updateCheck.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a newer release has been published, checked live once per launch — the build-time
+ * check this replaced could only ever compare a build against itself (see
+ * scripts/releaseInfo.ts). No auto-download or install: the project isn't code-signed yet, so
+ * electron-updater's silent-install path (Squirrel.Mac in particular) can't run on macOS,
+ * and shipping it Windows/Linux-only would give a different experience per platform. This
+ * only tells the user a release exists; About links out to it.
+ */
+
+import { ipcMain } from "electron";
+import { resolveReleaseInfo, type ReleaseInfo } from "../../../scripts/releaseInfo";
+
+export function registerUpdateCheckHandlers() {
+  ipcMain.handle("app:latestRelease", async (): Promise<ReleaseInfo> => {
+    // resolveReleaseInfo() never throws (see scripts/releaseInfo.ts) — an offline or rate
+    // limited launch resolves to the "0.0.0" sentinel rather than rejecting the handler.
+    const { version, releaseDate, releaseNotes, releaseUrl } = await resolveReleaseInfo();
+    return { version, releaseDate, releaseNotes, releaseUrl };
+  });
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -13,6 +13,7 @@ import type { ConnectorCatalogEntry } from "../main/ipc/connectors";
 import type { HttpToolCollectionRow, HttpToolRow, HttpToolParam } from "../main/ipc/httpTools";
 import type { TaskCreateInput, TaskRow, TaskUpdatePatch } from "../main/ipc/tasks";
 import type { AppInfo, AppStorageInfo, AppStats } from "../main/ipc/appInfo";
+import type { ReleaseInfo } from "../../scripts/releaseInfo";
 
 function subscribe(channel: string, callback: () => void): () => void {
   const listener = () => callback();
@@ -380,6 +381,9 @@ const agentsAPI = {
     stats: (): Promise<AppStats> => ipcRenderer.invoke("app:stats"),
     /** Resolves with the cache size remaining after the clear, so the UI can update in place. */
     clearCache: (): Promise<number> => ipcRenderer.invoke("app:clearCache"),
+    /** Live, once per call — unlike everything else here this hits the network. Never
+     * rejects; see ipc/updateCheck.ts. */
+    latestRelease: (): Promise<ReleaseInfo> => ipcRenderer.invoke("app:latestRelease"),
   },
 
   // Forwards renderer-side debug logs into the same userData/debug.log the main process

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openorbit",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openorbit",
-      "version": "0.2.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7067,9 +7067,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.33",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
-      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@electron-toolkit/utils": "^4.0.0",
         "@eslint/js": "^9.39.5",
+        "@playwright/test": "1.62.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
@@ -2253,6 +2254,22 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4017,6 +4034,7 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
       "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"
@@ -10393,6 +10411,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
@@ -10403,6 +10440,21 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openorbit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openorbit",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openorbit",
   "productName": "OpenOrbit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenOrbit — a multi-agent orchestrator desktop app",
   "author": "Mohit Aneja",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "package:ci": "npm run build && electron-builder --publish never",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "bash scripts/run-e2e-isolated.sh",
+    "test:e2e:local": "node --env-file-if-exists=.env node_modules/.bin/playwright test -c e2e/playwright.config.ts"
   },
   "build": {
     "appId": "com.mohitaneja.openorbit",
@@ -43,7 +45,10 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["x64", "arm64"]
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         }
       ],
       "category": "public.app-category.productivity",
@@ -53,7 +58,9 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
@@ -61,7 +68,9 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "category": "Utility"
@@ -93,6 +102,7 @@
   "devDependencies": {
     "@electron-toolkit/utils": "^4.0.0",
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "1.62.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openorbit",
   "productName": "OpenOrbit",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "OpenOrbit — a multi-agent orchestrator desktop app",
   "author": "Mohit Aneja",
   "license": "MIT",

--- a/scripts/format-e2e-report.mjs
+++ b/scripts/format-e2e-report.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Turns Playwright's JSON reporter output into a short markdown pass/fail summary.
+//
+// Usage: node scripts/format-e2e-report.mjs <results.json> <report.md>
+import * as fs from "node:fs";
+
+const [, , resultsPath, reportPath] = process.argv;
+if (!resultsPath || !reportPath) {
+  console.error("usage: format-e2e-report.mjs <results.json> <report.md>");
+  process.exit(2);
+}
+
+const raw = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+
+/** Playwright's JSON reporter nests results as suites -> suites -> specs -> tests -> results. */
+function collectSpecs(suites, titlePath = []) {
+  const specs = [];
+  for (const suite of suites ?? []) {
+    const path = [...titlePath, suite.title].filter(Boolean);
+    for (const spec of suite.specs ?? []) {
+      specs.push({ path, spec });
+    }
+    specs.push(...collectSpecs(suite.suites, path));
+  }
+  return specs;
+}
+
+const specs = collectSpecs(raw.suites);
+
+const rows = specs.map(({ path, spec }) => {
+  const test = spec.tests?.[0];
+  const result = test?.results?.[test.results.length - 1];
+  // spec.ok is true for both a pass and a skip — the per-result status is the only field that
+  // tells them apart, so it takes priority over spec.ok rather than the other way round.
+  const status = result?.status ?? (spec.ok ? "passed" : "unknown");
+  return {
+    title: [...path, spec.title].join(" › "),
+    status,
+    durationMs: result?.duration ?? 0,
+    error: result?.errors?.[0]?.message ?? null,
+    location: spec.file && spec.line ? `${spec.file}:${spec.line}` : null,
+  };
+});
+
+const passed = rows.filter((r) => r.status === "passed");
+const skipped = rows.filter((r) => r.status === "skipped");
+const failed = rows.filter((r) => r.status !== "passed" && r.status !== "skipped");
+
+const lines = [];
+lines.push(`# E2E report — ${raw.stats?.startTime ?? new Date().toISOString()}`);
+lines.push("");
+lines.push(`**${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped** (${rows.length} total)`);
+lines.push("");
+
+if (failed.length > 0) {
+  lines.push("## Failures");
+  lines.push("");
+  for (const row of failed) {
+    lines.push(`### ${row.title}`);
+    lines.push("");
+    lines.push(`- Status: \`${row.status}\``);
+    if (row.location) lines.push(`- Location: \`${row.location}\``);
+    if (row.error) {
+      lines.push("- Error:");
+      lines.push("```");
+      lines.push(row.error);
+      lines.push("```");
+    }
+    lines.push("");
+  }
+}
+
+lines.push("## All tests");
+lines.push("");
+lines.push("| Test | Status | Duration |");
+lines.push("|---|---|---|");
+for (const row of rows) {
+  lines.push(`| ${row.title} | ${row.status} | ${row.durationMs}ms |`);
+}
+lines.push("");
+
+fs.writeFileSync(reportPath, lines.join("\n"));
+console.log(`wrote ${reportPath}: ${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped`);
+
+// Exit non-zero on any real failure so the wrapping shell script can propagate it, without
+// treating a skip (missing OPENAI_API_KEY, expected in CI) as a failure.
+process.exit(failed.length > 0 ? 1 : 0);

--- a/scripts/releaseInfo.ts
+++ b/scripts/releaseInfo.ts
@@ -1,18 +1,27 @@
 /**
- * Resolves the app's release metadata once, at build time, for injection into the renderer
- * (see electron.vite.config.ts). Runs against the public release repo, so the request is
- * unauthenticated and no token is ever bundled into the app — only the resolved values are.
+ * Resolves the app's release metadata. Runs against the public release repo, so the request
+ * is unauthenticated and no token is ever bundled into the app — only the resolved values
+ * are.
  *
- * Hard requirement: this must never throw and never reject. An offline `npm run build` has
- * to succeed, so every failure path resolves to FALLBACK_RELEASE_INFO instead. `0.0.0` is
- * the deliberate "no release tag found" sentinel; the About screen hides the row on it.
+ * Two callers, deliberately different in what they need from here:
+ *  - `electron.vite.config.ts` calls `resolveCommit()` alone, at build time, to bake the
+ *    building machine's git commit into the shipped app — the packaged app has no .git dir
+ *    of its own, so this is the only point the commit is ever knowable.
+ *  - `electron/main/ipc/updateCheck.ts` calls `resolveReleaseInfo()` at runtime, once per
+ *    launch, to check whether a newer release has been published since this build — that has
+ *    to happen live or it can never detect a release that shipped after the build ran.
+ *
+ * Hard requirement either way: this must never throw and never reject. An offline
+ * `npm run build` has to succeed, and a launch with no network has to proceed. Every failure
+ * path resolves to FALLBACK_RELEASE_INFO instead. `0.0.0` is the deliberate "no release tag
+ * found" sentinel; consumers hide the row on it.
  */
 
 import { execFileSync } from "node:child_process";
 
 const GITHUB_API = "https://api.github.com";
 const ACCEPT_HEADER = "application/vnd.github+json";
-const DEFAULT_REPO = "maneja81/OpenOrbit";
+export const DEFAULT_REPO = "maneja81/OpenOrbit";
 
 // Bounds the worst case for `npm run dev` on a slow or captive network — without it, a
 // hanging request would stall every build behind it.

--- a/scripts/run-e2e-isolated.sh
+++ b/scripts/run-e2e-isolated.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Run the Playwright E2E suite in a throwaway worktree, so a build/install failure or a stray
+# write can never touch this checkout or the real ~/Library/Application Support/OpenOrbit
+# database. Copies .env.test from the main OpenOrbit checkout in as the E2E worktree's .env,
+# builds and runs the suite there, writes a markdown report back into this worktree, then
+# removes the throwaway worktree — pass or fail.
+#
+# Usage:
+#   scripts/run-e2e-isolated.sh              # run every spec under e2e/
+#   scripts/run-e2e-isolated.sh onboarding   # forwarded to `playwright test` as a name filter
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The main checkout is always the first entry `git worktree list` reports, from any worktree —
+# no hardcoded path, so this works from any clone location on any machine.
+MAIN_CHECKOUT="$(git -C "$HERE" worktree list --porcelain | head -1 | cut -d' ' -f2-)"
+ENV_TEST="$MAIN_CHECKOUT/.env.test"
+BRANCH="$(git -C "$HERE" branch --show-current)"
+
+# node_modules cache, keyed by package-lock.json content — outside .claude/worktrees/ so it is
+# never mistaken for a worktree, and already covered by .gitignore's blanket `.claude/*`.
+CACHE_ROOT="$MAIN_CHECKOUT/.claude/.e2e-npm-cache"
+KEEP_REPORTS=10
+
+if [[ -z "$BRANCH" ]]; then
+  echo "ERROR: HEAD is detached in $HERE — run this from a worktree on a named branch." >&2
+  exit 1
+fi
+
+# git worktree add only sees committed state. Uncommitted changes here would silently be
+# absent from the isolated run, which reads as "tests passed" against stale code.
+if [[ -n "$(git -C "$HERE" status --porcelain)" ]]; then
+  echo "ERROR: $HERE has uncommitted changes. Commit or stash before running the isolated E2E suite." >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_TEST" ]]; then
+  echo "ERROR: $ENV_TEST not found — nothing to copy into the isolated worktree." >&2
+  exit 1
+fi
+
+RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
+WORKTREE_PATH="$MAIN_CHECKOUT/.claude/worktrees/e2e-run-$RUN_ID"
+REPORT_DIR="$HERE/e2e/reports/$RUN_ID"
+
+cleanup() {
+  if [[ -d "$WORKTREE_PATH" ]]; then
+    echo "removing isolated worktree: $WORKTREE_PATH"
+    git -C "$MAIN_CHECKOUT" worktree remove --force "$WORKTREE_PATH" 2>/dev/null || rm -rf "$WORKTREE_PATH"
+  fi
+}
+trap cleanup EXIT
+
+echo "branch:            $BRANCH"
+echo "isolated worktree:  $WORKTREE_PATH"
+echo "report directory:   $REPORT_DIR"
+echo
+
+# --detach: the source branch is already checked out in $HERE, and git refuses to check out
+# the same branch in two worktrees at once.
+git -C "$MAIN_CHECKOUT" worktree add --detach "$WORKTREE_PATH" "$BRANCH"
+
+cp "$ENV_TEST" "$WORKTREE_PATH/.env"
+
+pushd "$WORKTREE_PATH" >/dev/null
+
+LOCK_HASH="$(shasum -a 256 package-lock.json | cut -d' ' -f1)"
+CACHE_DIR="$CACHE_ROOT/$LOCK_HASH"
+
+if [[ -d "$CACHE_DIR/node_modules" ]]; then
+  echo "== restoring node_modules from cache ($LOCK_HASH) =="
+  # -c: APFS clonefile — instant, copy-on-write, and safe: a build process editing a file here
+  # forks a private copy at the filesystem level rather than mutating the shared cache.
+  cp -c -R "$CACHE_DIR/node_modules" node_modules
+else
+  echo "== npm install (no cache for $LOCK_HASH) =="
+  npm install
+  echo "== populating node_modules cache =="
+  mkdir -p "$CACHE_DIR"
+  cp -c -R node_modules "$CACHE_DIR/node_modules"
+fi
+
+# Documented gotcha: npm ci/install regularly leaves Electron half-installed while exiting 0.
+# Cheap enough to check unconditionally, cache hit or not.
+if [[ ! -f node_modules/electron/path.txt || ! -d node_modules/electron/dist ]]; then
+  echo "== repairing Electron binary =="
+  rm -rf node_modules/electron/dist node_modules/electron/path.txt
+  node node_modules/electron/install.js
+  # A repaired binary belongs in the cache too, or every future run repeats the repair.
+  rm -rf "$CACHE_DIR/node_modules"
+  cp -c -R node_modules "$CACHE_DIR/node_modules"
+fi
+
+echo "== npm run build =="
+npm run build
+
+echo "== playwright test =="
+RESULTS_JSON="$WORKTREE_PATH/e2e-results.json"
+set +e
+node --env-file-if-exists=.env node_modules/.bin/playwright test -c e2e/playwright.config.ts --reporter=json "$@" > "$RESULTS_JSON"
+TEST_EXIT=$?
+set -e
+
+popd >/dev/null
+
+mkdir -p "$REPORT_DIR"
+cp "$RESULTS_JSON" "$REPORT_DIR/results.json"
+
+set +e
+node "$HERE/scripts/format-e2e-report.mjs" "$REPORT_DIR/results.json" "$REPORT_DIR/report.md"
+REPORT_EXIT=$?
+set -e
+
+echo
+echo "report: $REPORT_DIR/report.md"
+cat "$REPORT_DIR/report.md"
+
+# Keep only the newest KEEP_REPORTS report directories. Built-in macOS bash is 3.2 (no mapfile),
+# so this reads the list the same way, one path at a time, rather than into an array.
+PRUNE_COUNT=0
+while IFS= read -r old_dir; do
+  [[ -z "$old_dir" ]] && continue
+  rm -rf "$old_dir"
+  PRUNE_COUNT=$((PRUNE_COUNT + 1))
+done < <(ls -1dt "$HERE"/e2e/reports/*/ 2>/dev/null | tail -n "+$((KEEP_REPORTS + 1))")
+if [[ $PRUNE_COUNT -gt 0 ]]; then
+  echo "pruned $PRUNE_COUNT old report(s), kept the newest $KEEP_REPORTS"
+fi
+
+if [[ $TEST_EXIT -ne 0 ]]; then
+  echo
+  echo "playwright exited non-zero ($TEST_EXIT) — see report above." >&2
+  exit "$TEST_EXIT"
+fi
+exit "$REPORT_EXIT"

--- a/src/components/molecules/AppControls.tsx
+++ b/src/components/molecules/AppControls.tsx
@@ -7,7 +7,13 @@ interface AppControlsProps {
   onOpenSettings: () => void;
   onStartTour: () => void;
   onOpenAbout: () => void;
+  /** This build's own version (app:info.packageVersion) — not the latest published release,
+   * which used to be shown here by mistake (see AgentsApp.tsx / AboutTab.tsx). */
   version: string;
+  /** True when a newer release than `version` has been published. Surfaced as a dot on
+   * #aboutbtn rather than a separate control — About already has the release details and the
+   * link out, and this app has no toast/banner system to put a fuller notice in. */
+  updateAvailable: boolean;
 }
 
 /** Bottom-left (#ctrls) and bottom-right (#ctrls-right) chrome docks. Both sit over #chat,
@@ -21,20 +27,32 @@ function openWiki() {
   void window.agentsAPI.fs.openExternal(APP_LINKS.wiki);
 }
 
-export default function AppControls({ onOpenSettings, onStartTour, onOpenAbout, version }: AppControlsProps) {
+export default function AppControls({
+  onOpenSettings,
+  onStartTour,
+  onOpenAbout,
+  version,
+  updateAvailable,
+}: AppControlsProps) {
   return (
     <>
       <div id="ctrls">
         {/* #aboutbtn is a tour target (see lib/tourSteps.ts) — the id must stay stable. */}
-        <IconButton id="aboutbtn" aria-label="About this app" title="About" onClick={onOpenAbout}>
+        <IconButton
+          id="aboutbtn"
+          aria-label={updateAvailable ? "About this app — update available" : "About this app"}
+          title={updateAvailable ? "About (update available)" : "About"}
+          onClick={onOpenAbout}
+        >
           <TablerIcon name="ti-info-circle" />
+          {updateAvailable && <span className="update-dot" aria-hidden="true" />}
         </IconButton>
         <IconButton id="helpbtn" aria-label="Open the OpenOrbit wiki" title="Help" onClick={openWiki}>
           <TablerIcon name="ti-question-mark" />
         </IconButton>
-        {/* "0.0.0" is the deliberate no-release-found sentinel (see scripts/releaseInfo.ts) —
-            hide it rather than show a meaningless version number. */}
-        {version !== "0.0.0" && <span id="app-version">v{version}</span>}
+        {/* Empty until the app:info round trip in AgentsApp.tsx resolves — hide rather than
+            show a blank "v". */}
+        {version && <span id="app-version">v{version}</span>}
       </div>
       <div id="ctrls-right">
         <IconButton id="tourbtn" aria-label="Replay tour" title="Replay tour" onClick={onStartTour}>

--- a/src/components/molecules/AppControls.tsx
+++ b/src/components/molecules/AppControls.tsx
@@ -1,28 +1,49 @@
 import TablerIcon from "@/components/atoms/TablerIcon";
 import IconButton from "@/components/atoms/IconButton";
+import { hasAgentsAPI } from "@/lib/agentsApi";
+import { APP_LINKS } from "@/lib/appLinks";
 
 interface AppControlsProps {
   onOpenSettings: () => void;
   onStartTour: () => void;
   onOpenAbout: () => void;
+  version: string;
 }
 
-/** The bottom-left dock of secondary chrome. It sits over #chat, which spans the full window
- * width at z-index 30 and does not disable pointer events — so #ctrls needs a higher stacking
- * order in globals.css or these buttons render fine and swallow no clicks. */
-export default function AppControls({ onOpenSettings, onStartTour, onOpenAbout }: AppControlsProps) {
+/** Bottom-left (#ctrls) and bottom-right (#ctrls-right) chrome docks. Both sit over #chat,
+ * which spans the full window width at z-index 30 and does not disable pointer events — so
+ * both docks need a higher stacking order in globals.css or their buttons render fine and
+ * swallow no clicks. */
+// No window.agentsAPI under `npm run dev:web` — same guard AboutTab.tsx uses before any
+// fs.openExternal call.
+function openWiki() {
+  if (!hasAgentsAPI()) return;
+  void window.agentsAPI.fs.openExternal(APP_LINKS.wiki);
+}
+
+export default function AppControls({ onOpenSettings, onStartTour, onOpenAbout, version }: AppControlsProps) {
   return (
-    <div id="ctrls">
-      {/* #aboutbtn is a tour target (see lib/tourSteps.ts) — the id must stay stable. */}
-      <IconButton id="aboutbtn" aria-label="About this app" title="About" onClick={onOpenAbout}>
-        <TablerIcon name="ti-info-circle" />
-      </IconButton>
-      <IconButton id="tourbtn" aria-label="Replay tour" title="Replay tour" onClick={onStartTour}>
-        <TablerIcon name="ti-help" />
-      </IconButton>
-      <IconButton id="setbtn" aria-label="Open settings" onClick={onOpenSettings}>
-        <TablerIcon name="ti-settings" />
-      </IconButton>
-    </div>
+    <>
+      <div id="ctrls">
+        {/* #aboutbtn is a tour target (see lib/tourSteps.ts) — the id must stay stable. */}
+        <IconButton id="aboutbtn" aria-label="About this app" title="About" onClick={onOpenAbout}>
+          <TablerIcon name="ti-info-circle" />
+        </IconButton>
+        <IconButton id="helpbtn" aria-label="Open the OpenOrbit wiki" title="Help" onClick={openWiki}>
+          <TablerIcon name="ti-question-mark" />
+        </IconButton>
+        {/* "0.0.0" is the deliberate no-release-found sentinel (see scripts/releaseInfo.ts) —
+            hide it rather than show a meaningless version number. */}
+        {version !== "0.0.0" && <span id="app-version">v{version}</span>}
+      </div>
+      <div id="ctrls-right">
+        <IconButton id="tourbtn" aria-label="Replay tour" title="Replay tour" onClick={onStartTour}>
+          <TablerIcon name="ti-route" />
+        </IconButton>
+        <IconButton id="setbtn" aria-label="Open settings" onClick={onOpenSettings}>
+          <TablerIcon name="ti-settings" />
+        </IconButton>
+      </div>
+    </>
   );
 }

--- a/src/components/molecules/ChatInputBar.test.tsx
+++ b/src/components/molecules/ChatInputBar.test.tsx
@@ -28,6 +28,11 @@ function renderBar(overrides: Partial<Parameters<typeof ChatInputBar>[0]> = {}) 
   return { ...render(<ChatInputBar {...props} />), props };
 }
 
+const MIXED_AGENTS = [
+  { id: "a1", name: "Cipher", icon: "ti-settings", system: 1 },
+  { id: "a2", name: "Bank Analyst", icon: "ti-robot", system: 0 },
+];
+
 describe("ChatInputBar", () => {
   afterEach(cleanup);
 
@@ -118,5 +123,65 @@ describe("ChatInputBar", () => {
       target: { value: "hello" },
     });
     expect((container.querySelector(".tb-chip") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("opens an agent-only menu, grouped System before Custom, on @", () => {
+    const { container } = renderBar({ agents: MIXED_AGENTS });
+    const input = container.querySelector("#inp") as HTMLTextAreaElement;
+    fireEvent.input(input, { target: { value: "@" } });
+    const menu = container.querySelector(".slash-menu");
+    expect(menu).not.toBeNull();
+    const labels = Array.from(menu!.querySelectorAll(".slash-menu-group-label")).map((el) => el.textContent);
+    expect(labels).toEqual(["System", "Custom"]);
+    const items = Array.from(menu!.querySelectorAll(".slash-menu-label")).map((el) => el.textContent);
+    expect(items).toEqual(["Cipher", "Bank Analyst"]);
+  });
+
+  it("shows exactly one group header when every agent is in the same group", () => {
+    // Default install has zero custom agents — only "System" ever appears, never "Custom".
+    const { container } = renderBar({ agents: [MIXED_AGENTS[0]] });
+    fireEvent.input(container.querySelector("#inp") as HTMLTextAreaElement, { target: { value: "@" } });
+    const menu = container.querySelector(".slash-menu");
+    const labels = Array.from(menu!.querySelectorAll(".slash-menu-group-label")).map((el) => el.textContent);
+    expect(labels).toEqual(["System"]);
+  });
+
+  it("filters the @ menu by agent name and closes the / and apps modes are untouched", () => {
+    const { container } = renderBar({ agents: MIXED_AGENTS });
+    const input = container.querySelector("#inp") as HTMLTextAreaElement;
+    fireEvent.input(input, { target: { value: "@bank" } });
+    const items = Array.from(container.querySelectorAll(".slash-menu-label")).map((el) => el.textContent);
+    expect(items).toEqual(["Bank Analyst"]);
+  });
+
+  it("selects an agent from the @ menu, inserting the plain-name mention and closing the menu", () => {
+    const { container } = renderBar({ agents: MIXED_AGENTS });
+    const input = container.querySelector("#inp") as HTMLTextAreaElement;
+    fireEvent.input(input, { target: { value: "@cip" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(input.value).toBe("Cipher, ");
+    expect(container.querySelector(".slash-menu")).toBeNull();
+  });
+
+  it("shows a second 'Agents' chip that opens the @ menu, independent of the Commands chip", () => {
+    const { container } = renderBar({ agents: MIXED_AGENTS });
+    const chips = container.querySelectorAll(".tb-chip");
+    expect(chips.length).toBe(2);
+    fireEvent.click(chips[1] as HTMLButtonElement);
+    const input = container.querySelector("#inp") as HTMLTextAreaElement;
+    expect(input.value).toBe("@");
+    expect(container.querySelector(".slash-menu")).not.toBeNull();
+  });
+
+  it("disables the Agents chip once there is non-@ text, and re-enables both chips after send", () => {
+    const { container } = renderBar({ agents: MIXED_AGENTS });
+    const input = container.querySelector("#inp") as HTMLTextAreaElement;
+    const chips = () => container.querySelectorAll(".tb-chip");
+    fireEvent.input(input, { target: { value: "hello" } });
+    expect((chips()[0] as HTMLButtonElement).disabled).toBe(true);
+    expect((chips()[1] as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect((chips()[0] as HTMLButtonElement).disabled).toBe(false);
+    expect((chips()[1] as HTMLButtonElement).disabled).toBe(false);
   });
 });

--- a/src/components/molecules/ChatInputBar.tsx
+++ b/src/components/molecules/ChatInputBar.tsx
@@ -10,6 +10,10 @@ export interface DirectableAgent {
   name: string;
   icon: string;
   tagline?: string;
+  /** SQLite boolean convention (0/1), matching AgentRow.system — 1 for the four built-in
+   * agents (Cipher, Atlas, Explorer, Chrono), 0 for anything the user created. Used to group
+   * the @ agent-mention menu into "System" / "Custom". */
+  system: number;
 }
 
 interface ChatInputBarProps {
@@ -66,7 +70,10 @@ export default function ChatInputBar({
   // clearing the input, so a bare "/" is left behind — keying this off hasText alone would
   // leave the chip dead until the field was cleared by hand.
   const [canOpenCommands, setCanOpenCommands] = useState(true);
-  const [slashMode, setSlashMode] = useState<"commands" | "apps" | null>(null);
+  // Same predicate shape as canOpenCommands, mirrored for "@" — the two are mutually
+  // exclusive by construction since a value starts with at most one of "/"/"@".
+  const [canOpenAgents, setCanOpenAgents] = useState(true);
+  const [slashMode, setSlashMode] = useState<"commands" | "apps" | "agents" | null>(null);
   const [slashQuery, setSlashQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { apps, launch } = useAppLauncher();
@@ -88,6 +95,22 @@ export default function ChatInputBar({
 
   const allCommands = useMemo(() => [...COMMANDS, ...agentCommands], [agentCommands]);
 
+  // Feeds the @ agent-mention menu — same insert-text shape as agentCommands above (plain
+  // name mention, no @ sigil stored), but keyed by plain name instead of a /slug and tagged
+  // with a group so the menu can render "System" / "Custom" headers.
+  const directableAgentItems: SlashMenuItem[] = useMemo(
+    () =>
+      agents.map((a) => ({
+        id: `mention-${a.id}`,
+        icon: a.icon,
+        label: a.name,
+        sublabel: a.tagline,
+        insertText: `${a.name}, `,
+        group: a.system ? "System" : "Custom",
+      })),
+    [agents]
+  );
+
   const commandItems = useMemo(
     () => allCommands.filter((c) => c.label.slice(1).toLowerCase().startsWith(slashQuery.toLowerCase())),
     [allCommands, slashQuery]
@@ -102,7 +125,25 @@ export default function ChatInputBar({
     [apps, slashQuery]
   );
 
-  const activeItems = slashMode === "apps" ? appItems : slashMode === "commands" ? commandItems : [];
+  // System agents first, then Custom — directableAgentItems inherits DB insertion order from
+  // `agents`, which has no explicit sort by `system`, so the grouping must sort explicitly or
+  // the two groups could interleave and produce more than one header per group.
+  const agentItems = useMemo(
+    () =>
+      directableAgentItems
+        .filter((a) => a.label.toLowerCase().startsWith(slashQuery.toLowerCase()))
+        .sort((a, b) => (a.group === b.group ? 0 : a.group === "System" ? -1 : 1)),
+    [directableAgentItems, slashQuery]
+  );
+
+  const activeItems =
+    slashMode === "apps"
+      ? appItems
+      : slashMode === "commands"
+        ? commandItems
+        : slashMode === "agents"
+          ? agentItems
+          : [];
 
   const resize = () => {
     const el = inputRef.current;
@@ -125,6 +166,12 @@ export default function ChatInputBar({
       setSelectedIndex(0);
       return;
     }
+    if (value.startsWith("@") && !value.includes(" ")) {
+      setSlashMode("agents");
+      setSlashQuery(value.slice(1));
+      setSelectedIndex(0);
+      return;
+    }
     if (value.startsWith("/") && !value.includes(" ")) {
       setSlashMode("commands");
       setSlashQuery(value.slice(1));
@@ -138,6 +185,7 @@ export default function ChatInputBar({
     const value = e.currentTarget.value;
     setHasText(value.trim().length > 0);
     setCanOpenCommands(value.trim().length === 0 || value.startsWith("/"));
+    setCanOpenAgents(value.trim().length === 0 || value.startsWith("@"));
     parseSlashState(value);
     resize();
   };
@@ -153,6 +201,10 @@ export default function ChatInputBar({
   const selectSlashItem = (item: SlashMenuItem) => {
     if (slashMode === "commands") {
       setInputValue(item.insertText ?? `/${item.id} `);
+      return;
+    }
+    if (slashMode === "agents") {
+      setInputValue(item.insertText ?? `${item.label}, `);
       return;
     }
     if (slashMode === "apps") {
@@ -200,6 +252,7 @@ export default function ChatInputBar({
       onSend();
       setHasText(false);
       setCanOpenCommands(true);
+      setCanOpenAgents(true);
       closeSlashMenu();
       resize();
     }
@@ -210,6 +263,7 @@ export default function ChatInputBar({
     onSend();
     setHasText(false);
     setCanOpenCommands(true);
+    setCanOpenAgents(true);
     closeSlashMenu();
     resize();
   };
@@ -224,6 +278,13 @@ export default function ChatInputBar({
     if (!canOpenCommands) return;
     const current = inputRef.current?.value ?? "";
     setInputValue(current.startsWith("/") ? current : "/");
+  };
+
+  // Same shortcut pattern as openCommandMenu, seeding "@" instead of "/".
+  const openAgentMenu = () => {
+    if (!canOpenAgents) return;
+    const current = inputRef.current?.value ?? "";
+    setInputValue(current.startsWith("@") ? current : "@");
   };
 
   return (
@@ -298,6 +359,15 @@ export default function ChatInputBar({
             >
               <TablerIcon name="ti-terminal-2" />
               <span>Commands</span>
+            </IconButton>
+            <IconButton
+              className="tb-chip"
+              aria-label="Show agent mentions"
+              disabled={!canOpenAgents}
+              onClick={openAgentMenu}
+            >
+              <TablerIcon name="ti-at" />
+              <span>Agents</span>
             </IconButton>
           </div>
         </div>

--- a/src/components/molecules/SlashCommandMenu.tsx
+++ b/src/components/molecules/SlashCommandMenu.tsx
@@ -11,6 +11,10 @@ export interface SlashMenuItem {
    * literal slash command — the orchestrator already reliably hands off based on a
    * plain name mention in the message text, so no new "@mention" syntax is needed). */
   insertText?: string;
+  /** Optional group header rendered before this item when it differs from the previous item's
+   * group — e.g. "System" / "Custom" in the @ agent-mention menu. Absent on every item in the
+   * existing / commands and /open-app apps lists, so no header ever renders for them. */
+  group?: string;
 }
 
 interface SlashCommandMenuProps {
@@ -40,23 +44,27 @@ export default function SlashCommandMenu({
     <div className="slash-menu" role="listbox">
       {items.length === 0 && emptyText && <div className="slash-menu-empty">{emptyText}</div>}
       {items.map((item, i) => (
-        <button
-          key={item.id}
-          type="button"
-          role="option"
-          ref={i === selectedIndex ? activeRef : undefined}
-          aria-selected={i === selectedIndex}
-          className={`slash-menu-item${i === selectedIndex ? " active" : ""}`}
-          onMouseEnter={() => onHover(i)}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            onSelect(item);
-          }}
-        >
-          <TablerIcon name={item.icon} className="slash-menu-icon" />
-          <span className="slash-menu-label">{item.label}</span>
-          {item.sublabel && <span className="slash-menu-sublabel">{item.sublabel}</span>}
-        </button>
+        <div key={item.id}>
+          {item.group && item.group !== items[i - 1]?.group && (
+            <div className="slash-menu-group-label">{item.group}</div>
+          )}
+          <button
+            type="button"
+            role="option"
+            ref={i === selectedIndex ? activeRef : undefined}
+            aria-selected={i === selectedIndex}
+            className={`slash-menu-item${i === selectedIndex ? " active" : ""}`}
+            onMouseEnter={() => onHover(i)}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(item);
+            }}
+          >
+            <TablerIcon name={item.icon} className="slash-menu-icon" />
+            <span className="slash-menu-label">{item.label}</span>
+            {item.sublabel && <span className="slash-menu-sublabel">{item.sublabel}</span>}
+          </button>
+        </div>
       ))}
     </div>
   );

--- a/src/components/organisms/AboutTab.test.tsx
+++ b/src/components/organisms/AboutTab.test.tsx
@@ -17,6 +17,7 @@ function stubBridge() {
       get: vi.fn(async () => ({ packageVersion: "1.0.0", electron: "43.0.0", node: "22.0.0", platform: "darwin" })),
       storage: vi.fn(async () => ({ cacheBytes: 1024, dbBytes: 2048, knowledgeBytes: 512 })),
       stats: vi.fn(async () => ({ messages: 3, agents: 4 })),
+      latestRelease: vi.fn(async () => ({ version: "0.0.0", releaseDate: "", releaseNotes: "", releaseUrl: "" })),
       clearCache,
     },
     fs: { openExternal, revealInFolder },

--- a/src/components/organisms/AboutTab.tsx
+++ b/src/components/organisms/AboutTab.tsx
@@ -18,15 +18,13 @@ interface AboutTabProps {
   sessionElapsedMs: number;
 }
 
-/** Every value below is empty on a build made offline or before the first release was
- * published, so each consumer hides its row rather than showing a blank. */
-const RELEASE = {
-  version: __APP_RELEASE_VERSION__,
-  date: __APP_RELEASE_DATE__,
-  notes: __APP_RELEASE_NOTES__,
-  url: __APP_RELEASE_URL__,
-  commit: __APP_COMMIT__,
-};
+/** __APP_COMMIT__ is the only piece of release metadata still resolved at build time — the
+ * building machine's git commit, which the packaged app has no other way to know (see
+ * scripts/releaseInfo.ts). Everything else about "what's the latest release" is fetched live,
+ * below — a build-time value could only ever compare a build against itself. */
+const BUILD_COMMIT = __APP_COMMIT__;
+
+const EMPTY_RELEASE: ReleaseInfo = { version: "0.0.0", releaseDate: "", releaseNotes: "", releaseUrl: "" };
 
 function Row({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
@@ -45,6 +43,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
   const [info, setInfo] = useState<AppInfo | null>(null);
   const [storage, setStorage] = useState<AppStorageInfo | null>(null);
   const [stats, setStats] = useState<AppStats | null>(null);
+  const [release, setRelease] = useState<ReleaseInfo>(EMPTY_RELEASE);
   const [error, setError] = useState<string | null>(null);
   const [openLicense, setOpenLicense] = useState<string | null>(null);
   const [clearing, setClearing] = useState(false);
@@ -57,14 +56,18 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
       window.agentsAPI.appInfo.get(),
       window.agentsAPI.appInfo.storage(),
       window.agentsAPI.appInfo.stats(),
+      window.agentsAPI.appInfo.latestRelease(),
     ])
-      .then(([nextInfo, nextStorage, nextStats]) => {
+      .then(([nextInfo, nextStorage, nextStats, nextRelease]) => {
         if (cancelled) return;
         setInfo(nextInfo);
         setStorage(nextStorage);
         setStats(nextStats);
+        setRelease(nextRelease);
       })
       .catch((e) => {
+        // latestRelease() itself never rejects (see ipc/updateCheck.ts) — this only fires on
+        // an IPC-level failure, same as the three calls it joined before it.
         if (!cancelled) setError(formatHumanizedError(humanizeError(e)));
       });
     return () => {
@@ -102,7 +105,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
   const copyDiagnostics = useCallback(async () => {
     if (!info) return;
     const lines = [
-      `${info.name} ${info.packageVersion}${RELEASE.commit ? ` (build ${RELEASE.commit})` : ""}`,
+      `${info.name} ${info.packageVersion}${BUILD_COMMIT ? ` (build ${BUILD_COMMIT})` : ""}`,
       `Electron ${info.electronVersion} / Node ${info.nodeVersion} / Chrome ${info.chromeVersion}`,
       `${formatPlatformName(info.platform)} ${info.osVersion} (${info.arch}) — kernel ${info.osRelease}`,
     ];
@@ -135,8 +138,8 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
     setOpenLicense((prev) => (prev === key ? null : key));
   }, []);
 
-  const releaseDate = formatReleaseDate(RELEASE.date);
-  const updateAvailable = info ? isUpdateAvailable(RELEASE.version, info.packageVersion) : false;
+  const releaseDate = formatReleaseDate(release.releaseDate);
+  const updateAvailable = info ? isUpdateAvailable(release.version, info.packageVersion) : false;
   const pending = bridgeReady && !info && !error;
 
   return (
@@ -158,18 +161,18 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
               <Row label="Version" hint="This build">
                 <span className="about-value">{info?.packageVersion ?? "…"}</span>
               </Row>
-              {RELEASE.version !== "0.0.0" && (
+              {release.version !== "0.0.0" && (
                 <Row label="Latest release">
                   <span className="about-value">
-                    {RELEASE.version}
+                    {release.version}
                     {releaseDate && <small> · {releaseDate}</small>}
                     {updateAvailable && <span className="about-badge">Update available</span>}
                   </span>
                 </Row>
               )}
-              {RELEASE.commit && (
+              {BUILD_COMMIT && (
                 <Row label="Build">
-                  <span className="about-value about-value-mono">{RELEASE.commit}</span>
+                  <span className="about-value about-value-mono">{BUILD_COMMIT}</span>
                 </Row>
               )}
               {info && (
@@ -229,13 +232,13 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
           </SettingsAccordion>
         )}
 
-        {RELEASE.notes && (
+        {release.releaseNotes && (
           <SettingsAccordion
             icon="ti-sparkles"
-            title={`What's new in ${RELEASE.version}`}
+            title={`What's new in ${release.version}`}
             headerActions={
-              RELEASE.url ? (
-                <button className="settings-action-btn-sm" onClick={() => openLink(RELEASE.url)}>
+              release.releaseUrl ? (
+                <button className="settings-action-btn-sm" onClick={() => openLink(release.releaseUrl)}>
                   <span>View on GitHub</span>
                   <TablerIcon name="ti-external-link" />
                 </button>
@@ -243,7 +246,7 @@ export default function AboutTab({ sessionElapsedMs }: AboutTabProps) {
             }
           >
             <div className="about-notes">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{RELEASE.notes}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{release.releaseNotes}</ReactMarkdown>
             </div>
           </SettingsAccordion>
         )}

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -31,6 +31,7 @@ import { useBackgroundMusic } from "@/hooks/useBackgroundMusic";
 import { useSystemStats } from "@/hooks/useSystemStats";
 import { useTokenUsage } from "@/hooks/useTokenUsage";
 import { hasAgentsAPI } from "@/lib/agentsApi";
+import { isUpdateAvailable } from "@/lib/semver";
 import { USER_CONTEXT_FIELDS } from "@/lib/userContext";
 import { formatHumanizedError, humanizeError } from "@/lib/humanizeError";
 import { AgentId, StepEvent, matchAgentSlashCommand } from "@/lib/agents";
@@ -222,6 +223,31 @@ export default function AgentsApp() {
     const start = Date.now();
     const interval = setInterval(() => setSessionElapsedMs(Date.now() - start), 60_000);
     return () => clearInterval(interval);
+  }, []);
+
+  // Checked once, on launch, against this build's own version — not the reverse of the old
+  // build-time check (see AboutTab.tsx / semver.ts), which could only ever compare a build
+  // against itself and so could never actually detect a release published afterward. No
+  // auto-download here, only the badge on #aboutbtn (AppControls.tsx) — see ipc/updateCheck.ts
+  // for why.
+  const [appVersion, setAppVersion] = useState("");
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  useEffect(() => {
+    if (!hasAgentsAPI()) return;
+    let cancelled = false;
+    Promise.all([window.agentsAPI.appInfo.get(), window.agentsAPI.appInfo.latestRelease()])
+      .then(([info, release]) => {
+        if (cancelled) return;
+        setAppVersion(info.packageVersion);
+        setUpdateAvailable(isUpdateAvailable(release.version, info.packageVersion));
+      })
+      .catch(() => {
+        // Version display and the update badge are both cosmetic — nothing here should
+        // interrupt launch or surface an error the user can't act on.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // A time-of-day greeting by the user's own name reads as more "alive" than a static
@@ -819,7 +845,8 @@ export default function AgentsApp() {
         entering={entering}
         locationEnabled={settings.locationEnabled}
         cognitiveState={cognitiveState}
-        version={__APP_RELEASE_VERSION__}
+        version={appVersion}
+        updateAvailable={updateAvailable}
         sessionStats={sessionStats}
       >
         <ErrorBoundary fallbackTitle="The chat failed to load">

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -7,6 +7,7 @@ import KnowledgeModal from "@/components/organisms/KnowledgeModal";
 import ChatHistoryModal from "@/components/organisms/ChatHistoryModal";
 import HttpToolApprovalModal, { type PendingToolApproval } from "@/components/molecules/HttpToolApprovalModal";
 import { approvalSettledMessage } from "@/lib/approvalSettledMessage";
+import { configAckMessage, shouldPersistConfigAck, type ConfigAckEvent } from "@/lib/configAckMessage";
 import ErrorBoundary from "@/components/atoms/ErrorBoundary";
 
 /** How long the entrance animation runs before the greeting lands. Named because the
@@ -209,6 +210,68 @@ export default function AgentsApp() {
   const { ghosts } = useAppWideFileDrop(knowledgeAnchorRef, knowledgeFiles.addFiles);
   const systemStats = useSystemStats();
   const tokenUsage = useTokenUsage("today", null);
+
+  // Queued rather than appended immediately: Settings changes often arrive in a burst (add
+  // three files, then enable location, then connect Gmail) and each deserves one coalesced
+  // chat bubble on close, not one per change. A queue held in a ref (not state) survives across
+  // the whole Settings session without re-rendering on every push.
+  const configAckQueueRef = useRef<ConfigAckEvent[]>([]);
+
+  const flushConfigAcks = useCallback(() => {
+    const events = configAckQueueRef.current;
+    if (events.length === 0) return;
+    configAckQueueRef.current = [];
+    const text = configAckMessage(events);
+    appendMessage({ role: "assistant", text, avatarLabel: settings.agentName[0]?.toUpperCase() || "A" });
+    // Fire-and-forget: the local bubble already showed, so a failed persist isn't worth a
+    // second failure notice — see configAckMessage.ts.
+    if (shouldPersistConfigAck(events) && hasAgentsAPI()) {
+      void window.agentsAPI.chat.appendMessage({ role: "assistant", text });
+    }
+  }, [appendMessage, settings.agentName]);
+
+  const queueConfigAck = useCallback(
+    (event: ConfigAckEvent) => {
+      configAckQueueRef.current.push(event);
+      // Settings is closed (e.g. a file dropped from the main UI) — nothing will flush this
+      // later, so show it right away instead of waiting for a Settings session that may
+      // never happen.
+      if (!settingsOpen) flushConfigAcks();
+    },
+    [settingsOpen, flushConfigAcks]
+  );
+
+  const wasSettingsOpenRef = useRef(settingsOpen);
+  useEffect(() => {
+    if (wasSettingsOpenRef.current && !settingsOpen) flushConfigAcks();
+    wasSettingsOpenRef.current = settingsOpen;
+  }, [settingsOpen, flushConfigAcks]);
+
+  // Baseline-then-diff: the first run after onboarding just records what's already there, so
+  // files seeded before this session (or during onboarding, guarded below) don't read as
+  // newly added.
+  const knownKnowledgeFileIdsRef = useRef<Set<number> | null>(null);
+  useEffect(() => {
+    if (!loaded || !settings.onboardingDone) return;
+    const ids = new Set(knowledgeFiles.files.map((f) => f.id));
+    const known = knownKnowledgeFileIdsRef.current;
+    knownKnowledgeFileIdsRef.current = ids;
+    if (known === null) return;
+    for (const file of knowledgeFiles.files) {
+      if (!known.has(file.id)) queueConfigAck({ type: "file", fileName: file.title || file.originalName });
+    }
+  }, [knowledgeFiles.files, loaded, settings.onboardingDone, queueConfigAck]);
+
+  // Only the false→true edge is an ack-worthy event — toggling off says nothing new, and
+  // onboarding's own initial value must not read as "just enabled".
+  const knownLocationEnabledRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (!loaded || !settings.onboardingDone) return;
+    const known = knownLocationEnabledRef.current;
+    knownLocationEnabledRef.current = settings.locationEnabled;
+    if (known === null) return;
+    if (!known && settings.locationEnabled) queueConfigAck({ type: "location" });
+  }, [settings.locationEnabled, loaded, settings.onboardingDone, queueConfigAck]);
 
   // Ticks once a minute purely to force a re-render so the greeting's time-of-day band
   // (morning/afternoon/evening/night) updates for a session left open for hours, rather
@@ -891,6 +954,7 @@ export default function AgentsApp() {
         onExportAgent={exportAgent}
         onExportAllAgents={exportAllAgents}
         onImportAgents={importAgents}
+        onConfigAck={queueConfigAck}
       />
       <KnowledgeModal open={kbModalOpen} onClose={() => setKbModalOpen(false)} />
       {/* Mounted conditionally rather than kept alive with open={false}: a fresh mount is

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -819,6 +819,7 @@ export default function AgentsApp() {
         entering={entering}
         locationEnabled={settings.locationEnabled}
         cognitiveState={cognitiveState}
+        version={__APP_RELEASE_VERSION__}
         sessionStats={sessionStats}
       >
         <ErrorBoundary fallbackTitle="The chat failed to load">

--- a/src/components/organisms/OrbitScene.tsx
+++ b/src/components/organisms/OrbitScene.tsx
@@ -39,6 +39,7 @@ interface OrbitSceneProps {
   cognitiveState: string;
   sessionStats: string;
   version: string;
+  updateAvailable: boolean;
   children?: ReactNode;
 }
 
@@ -68,6 +69,7 @@ export default function OrbitScene({
   cognitiveState,
   sessionStats,
   version,
+  updateAvailable,
   children,
 }: OrbitSceneProps) {
   const activeLineD = activeAgent ? lineGeometry[activeAgent] : undefined;
@@ -118,6 +120,7 @@ export default function OrbitScene({
         onStartTour={onStartTour}
         onOpenAbout={onOpenAbout}
         version={version}
+        updateAvailable={updateAvailable}
       />
       <div id="widgets-left" className={entering ? "entering" : undefined}>
         <TokenUsageWidget steps={steps} />

--- a/src/components/organisms/OrbitScene.tsx
+++ b/src/components/organisms/OrbitScene.tsx
@@ -38,6 +38,7 @@ interface OrbitSceneProps {
   locationEnabled: boolean;
   cognitiveState: string;
   sessionStats: string;
+  version: string;
   children?: ReactNode;
 }
 
@@ -66,6 +67,7 @@ export default function OrbitScene({
   locationEnabled,
   cognitiveState,
   sessionStats,
+  version,
   children,
 }: OrbitSceneProps) {
   const activeLineD = activeAgent ? lineGeometry[activeAgent] : undefined;
@@ -111,7 +113,12 @@ export default function OrbitScene({
         onToggleFullscreen={onToggleFullscreen}
       />
       <StatusBar statusText={statusText} />
-      <AppControls onOpenSettings={onOpenSettings} onStartTour={onStartTour} onOpenAbout={onOpenAbout} />
+      <AppControls
+        onOpenSettings={onOpenSettings}
+        onStartTour={onStartTour}
+        onOpenAbout={onOpenAbout}
+        version={version}
+      />
       <div id="widgets-left" className={entering ? "entering" : undefined}>
         <TokenUsageWidget steps={steps} />
       </div>

--- a/src/components/organisms/SettingsPanel.test.tsx
+++ b/src/components/organisms/SettingsPanel.test.tsx
@@ -29,6 +29,7 @@ function renderDangerZone(onReset: () => Promise<void>) {
       onExportAgent={vi.fn()}
       onExportAllAgents={vi.fn()}
       onImportAgents={vi.fn()}
+      onConfigAck={vi.fn()}
     />
   );
   // Mounting already-open leaves activeSection at its default: sectionOnTransition only fires
@@ -133,6 +134,7 @@ describe("orchestrator prompt override", () => {
         onExportAgent={vi.fn()}
         onExportAllAgents={vi.fn()}
         onImportAgents={vi.fn()}
+        onConfigAck={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole("tab", { name: /^Agents$/i }));
@@ -197,6 +199,7 @@ describe("Privacy & Safety", () => {
         onExportAgent={vi.fn()}
         onExportAllAgents={vi.fn()}
         onImportAgents={vi.fn()}
+        onConfigAck={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole("tab", { name: /Privacy & Safety/i }));
@@ -282,6 +285,7 @@ describe("the orchestrator's enabled toggle", () => {
         onExportAgent={vi.fn()}
         onExportAllAgents={vi.fn()}
         onImportAgents={vi.fn()}
+        onConfigAck={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole("tab", { name: /^Agents$/i }));
@@ -326,6 +330,7 @@ describe("running onboarding again", () => {
         onExportAgent={vi.fn()}
         onExportAllAgents={vi.fn()}
         onImportAgents={vi.fn()}
+        onConfigAck={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole("tab", { name: /^General$/i }));
@@ -372,6 +377,7 @@ describe("AI Models section", () => {
         onExportAgent={vi.fn()}
         onExportAllAgents={vi.fn()}
         onImportAgents={vi.fn()}
+        onConfigAck={vi.fn()}
       />
     );
     fireEvent.click(screen.getByRole("tab", { name: /^Models$/i }));
@@ -411,5 +417,117 @@ describe("AI Models section", () => {
     }
     // The old "Model ID" label lived in the Chat credentials card.
     expect(screen.queryByLabelText("Model ID")).not.toBeInTheDocument();
+  });
+});
+
+describe("connector-connect acknowledgement", () => {
+  /** Stubs every bridge call the panel makes on mount, plus connectors.list/onUpdate so a
+   * disconnected→connected transition can be driven by hand via the captured onUpdate callback. */
+  function installBridge(connectorStatus: "connected" | "disconnected") {
+    let onUpdateCallback: (() => void) | null = null;
+    const api = {
+      agent: { orchestratorPrompt: vi.fn().mockResolvedValue("") },
+      userInfo: { list: vi.fn().mockResolvedValue([]) },
+      providers: { list: vi.fn().mockResolvedValue({ configured: [] }) },
+      mcp: { list: vi.fn().mockResolvedValue([]) },
+      httpTools: { listCollections: vi.fn().mockResolvedValue([]), listTools: vi.fn().mockResolvedValue([]) },
+      connectors: {
+        list: vi.fn().mockResolvedValue([
+          {
+            id: "gmail",
+            name: "Gmail",
+            description: "",
+            icon: "ti-mail",
+            status: connectorStatus,
+            accountLabel: null,
+            settingsFields: [],
+            settingsConfigured: true,
+            credentialsOnly: false,
+            settingsSourceId: null,
+          },
+        ]),
+        onUpdate: vi.fn((cb: () => void) => {
+          onUpdateCallback = cb;
+          return () => {};
+        }),
+      },
+    };
+    (globalThis as unknown as { window: { agentsAPI: unknown } }).window.agentsAPI = api;
+    return { api, triggerUpdate: () => onUpdateCallback?.() };
+  }
+
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+  });
+
+  it("fires onConfigAck once with the connected agents when a connector transitions to connected", async () => {
+    const { api, triggerUpdate } = installBridge("disconnected");
+    const onConfigAck = vi.fn();
+    const agents: AgentRow[] = [
+      {
+        id: "a1",
+        name: "Cipher",
+        icon: "ti-robot",
+        tagline: "",
+        description: "",
+        prompt: "",
+        model: "",
+        provider_id: "",
+        tools: "[]",
+        enabled: 1,
+        system: 1,
+        created_at: new Date().toISOString(),
+        mcp_server_ids: "[]",
+        connector_ids: '["gmail"]',
+        http_tool_collection_ids: "[]",
+      },
+    ];
+    render(
+      <SettingsPanel
+        open
+        onClose={vi.fn()}
+        settings={mergeWithDefaults({})}
+        sessionElapsedMs={0}
+        onUpdate={vi.fn()}
+        onReset={vi.fn()}
+        agents={agents}
+        onUpdateAgent={vi.fn()}
+        onCreateAgent={vi.fn()}
+        onDeleteAgent={vi.fn()}
+        onExportAgent={vi.fn()}
+        onExportAllAgents={vi.fn()}
+        onImportAgents={vi.fn()}
+        onConfigAck={onConfigAck}
+      />
+    );
+
+    // Baseline load: the first pass over connectorCatalog just records "disconnected", firing
+    // nothing.
+    await waitFor(() => expect(api.connectors.list).toHaveBeenCalled());
+    expect(onConfigAck).not.toHaveBeenCalled();
+
+    api.connectors.list.mockResolvedValue([
+      {
+        id: "gmail",
+        name: "Gmail",
+        description: "",
+        icon: "ti-mail",
+        status: "connected",
+        accountLabel: "me@example.com",
+        settingsFields: [],
+        settingsConfigured: true,
+        credentialsOnly: false,
+        settingsSourceId: null,
+      },
+    ]);
+    triggerUpdate();
+
+    await waitFor(() =>
+      expect(onConfigAck).toHaveBeenCalledExactlyOnceWith({
+        type: "connector",
+        label: "Gmail",
+        agentNames: ["Cipher"],
+      })
+    );
   });
 });

--- a/src/components/organisms/SettingsPanel.tsx
+++ b/src/components/organisms/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Modal from "@/components/atoms/Modal";
 import Toggle from "@/components/atoms/Toggle";
 import Combobox from "@/components/atoms/Combobox";
@@ -29,6 +29,7 @@ import { providerUrlWarning } from "@/lib/providerUrlWarning";
 import { AI_PROVIDERS, findProvider, modelBelongsToProvider } from "@/lib/providers";
 import { DEFAULT_SETTINGS_SECTION, sectionOnTransition } from "@/lib/settingsSection";
 import { SoundFxEvent, sfxPreviewSrc } from "@/hooks/useSoundFX";
+import type { ConfigAckEvent } from "@/lib/configAckMessage";
 
 interface SettingsPanelProps {
   open: boolean;
@@ -71,6 +72,10 @@ interface SettingsPanelProps {
   onExportAgent: (id: string) => Promise<{ canceled: boolean } | undefined>;
   onExportAllAgents: () => Promise<{ canceled: boolean } | undefined>;
   onImportAgents: () => Promise<AgentRow[]>;
+  /** Queues one chat-ack event; the caller (AgentsApp) coalesces and flushes it. Required
+   * rather than optional — a silently-dropped ack is exactly the class of bug Steps 1-3 of
+   * this change fix elsewhere in the panel. */
+  onConfigAck: (event: ConfigAckEvent) => void;
 }
 
 export type SettingsSection =
@@ -236,6 +241,7 @@ export default function SettingsPanel({
   onExportAgent,
   onExportAllAgents,
   onImportAgents,
+  onConfigAck,
 }: SettingsPanelProps) {
   const [activeSection, setActiveSection] = useState<SettingsSection>(DEFAULT_SETTINGS_SECTION);
   // Adjust activeSection during render (not in an effect) when the panel transitions
@@ -367,6 +373,37 @@ export default function SettingsPanel({
   const connectorCatalog = connectors.connectors;
   const httpTools = useHttpTools();
   const httpToolCollections = httpTools.collections;
+
+  // The three data hooks mount once with the panel and never unmount (see `open`'s
+  // backdrop-only gating below), so a stale error from a session before this one stays
+  // on screen indefinitely unless the next open clears it.
+  useEffect(() => {
+    if (!open) return;
+    mcp.clearError();
+    connectors.clearError();
+    httpTools.clearError();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clearError identities are stable useCallbacks; only the open edge should retrigger this
+  }, [open]);
+
+  // Baseline-then-diff over each connector's own status: the first run just records what's
+  // already connected, so connectors set up before this session don't read as newly connected.
+  // Reconnecting after a disconnect acks again — "usable again" is worth saying, not a
+  // once-per-app-lifetime event. A credentialsOnly parent row has no Connect button and its
+  // status never transitions, so it never fires.
+  const knownConnectorStatusRef = useRef<Map<string, ConnectorCatalogEntry["status"]> | null>(null);
+  useEffect(() => {
+    const known = knownConnectorStatusRef.current;
+    knownConnectorStatusRef.current = new Map(connectorCatalog.map((c) => [c.id, c.status]));
+    if (known === null) return;
+    for (const connector of connectorCatalog) {
+      if (known.get(connector.id) === "connected" || connector.status !== "connected") continue;
+      const agentNames = agents
+        .filter((agent) => parseIdList(agent.connector_ids).includes(connector.id))
+        .map((agent) => agent.name);
+      if (settings.orchestratorConnectorIds.includes(connector.id)) agentNames.unshift(settings.agentName);
+      onConfigAck({ type: "connector", label: connector.name, agentNames });
+    }
+  }, [connectorCatalog, agents, settings.orchestratorConnectorIds, settings.agentName, onConfigAck]);
 
   useEffect(() => {
     if (!open || !hasAgentsAPI()) return;

--- a/src/globals.css
+++ b/src/globals.css
@@ -1548,13 +1548,14 @@ svg#oc {
   letter-spacing: 0.3px;
 }
 
-/* Bottom-left dock. left: 20px lines up with #widgets-left; bottom: 22px matches the
-   .input-bar's own bottom padding. z-index must clear #chat (30) — it spans the full window
-   width with no pointer-events: none, so at 30 or below these buttons look right and are
-   completely dead. Same reason .jump-bottom sits at 32. */
-#ctrls {
+/* Bottom-left dock (info + version) and bottom-right dock (help + settings). left/right:
+   20px lines up with #widgets-left/#widgets-right; bottom: 22px matches the .input-bar's
+   own bottom padding. z-index must clear #chat (30) — it spans the full window width with
+   no pointer-events: none, so at 30 or below these buttons look right and are completely
+   dead. Same reason .jump-bottom sits at 32. */
+#ctrls,
+#ctrls-right {
   position: absolute;
-  left: 20px;
   bottom: 22px;
   z-index: 32;
   display: flex;
@@ -1562,9 +1563,25 @@ svg#oc {
   align-items: center;
 }
 
+#ctrls {
+  left: 20px;
+}
+
+#ctrls-right {
+  right: 20px;
+}
+
+#app-version {
+  font-size: 11px;
+  color: #7ec8ff;
+  letter-spacing: 0.3px;
+  opacity: 0.7;
+}
+
 #setbtn,
 #tourbtn,
-#aboutbtn {
+#aboutbtn,
+#helpbtn {
   width: 34px;
   height: 34px;
   border-radius: 50%;
@@ -1583,16 +1600,18 @@ svg#oc {
   transform: rotate(45deg);
 }
 
-/* No rotate here — that gesture reads as a turning gear on #setbtn, but as a tilted
-   question mark on this one, and as a tipped-over "i" on #aboutbtn. */
+/* No rotate here — that gesture reads as a turning gear on #setbtn, but as a tipped-over
+   route line on #tourbtn, a tipped-over "i" on #aboutbtn, and a tipped-over "?" on #helpbtn. */
 #tourbtn:hover,
-#aboutbtn:hover {
+#aboutbtn:hover,
+#helpbtn:hover {
   background: rgba(80, 160, 255, 0.12);
 }
 
 #setbtn i,
 #tourbtn i,
-#aboutbtn i {
+#aboutbtn i,
+#helpbtn i {
   font-size: 16px;
   color: #7ec8ff;
   transition: transform 0.2s;

--- a/src/globals.css
+++ b/src/globals.css
@@ -1226,8 +1226,8 @@ svg#oc {
    corners follow the card radius — it's also why the slash menu is rendered as a sibling
    of this element rather than inside it. */
 .input-card {
-  background: rgba(4, 12, 40, 0.82);
-  border: 1px solid rgba(61, 143, 255, 0.26);
+  background: linear-gradient(160deg, rgba(10, 30, 60, 0.82) 0%, rgba(2, 10, 24, 0.88) 100%);
+  border: 1px solid rgba(100, 170, 255, 0.2);
   border-radius: 16px;
   overflow: hidden;
   backdrop-filter: blur(20px) saturate(160%);
@@ -1241,10 +1241,10 @@ svg#oc {
 }
 
 .input-card:focus-within {
-  border-color: rgba(61, 143, 255, 0.46);
+  border-color: rgba(100, 170, 255, 0.46);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    0 0 0 3px rgba(61, 143, 255, 0.07),
+    0 0 0 3px rgba(100, 170, 255, 0.07),
     0 4px 24px rgba(0, 0, 0, 0.44);
 }
 
@@ -1307,8 +1307,8 @@ svg#oc {
   font-size: 11.5px;
   font-family: inherit;
   color: var(--text-lo);
-  background: rgba(61, 143, 255, 0.05);
-  border: 1px solid rgba(61, 143, 255, 0.1);
+  background: rgba(60, 140, 255, 0.05);
+  border: 1px solid rgba(60, 140, 255, 0.1);
   border-radius: 20px;
   padding: 3px 10px;
   cursor: pointer;
@@ -1317,8 +1317,8 @@ svg#oc {
 }
 
 .tb-chip:hover:not(:disabled) {
-  background: rgba(61, 143, 255, 0.1);
-  border-color: rgba(61, 143, 255, 0.22);
+  background: rgba(60, 140, 255, 0.1);
+  border-color: rgba(60, 140, 255, 0.22);
   color: var(--text-md);
 }
 
@@ -4461,6 +4461,15 @@ svg#oc {
 
 .slash-menu-item.active {
   background: rgba(60, 140, 255, 0.18);
+}
+
+.slash-menu-group-label {
+  padding: 8px 10px 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(150, 190, 230, 0.5);
 }
 
 .slash-menu-icon {

--- a/src/globals.css
+++ b/src/globals.css
@@ -1582,6 +1582,7 @@ svg#oc {
 #tourbtn,
 #aboutbtn,
 #helpbtn {
+  position: relative;
   width: 34px;
   height: 34px;
   border-radius: 50%;
@@ -1593,6 +1594,21 @@ svg#oc {
   justify-content: center;
   transition: all 0.2s;
   padding: 7px;
+}
+
+/* A newer release than this build has been published (AppControls.tsx). Positioned against
+   #aboutbtn's own `position: relative` above rather than a wrapping element, so it tracks the
+   icon exactly. */
+.update-dot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #50a0ff;
+  border: 1.5px solid #00060f;
+  box-shadow: 0 0 4px rgba(80, 160, 255, 0.8);
 }
 
 #setbtn:hover {

--- a/src/globals.css
+++ b/src/globals.css
@@ -582,7 +582,7 @@ svg#oc {
 
 #chat-log {
   min-height: 36px;
-  max-height: 40vh;
+  max-height: 28vh;
   overflow-y: auto;
   padding: 10px 20px 4px;
   display: flex;
@@ -2881,7 +2881,7 @@ svg#oc {
    centre-anchored and pointer-events: none, so it neither overlaps nor blocks these columns.
 
    bottom: 96px is the chat's *resting* height (#bar: a one-line input card plus its 12/22
-   padding). It is deliberately not the chat's maximum: #chat-log grows to 40vh, and sizing
+   padding). It is deliberately not the chat's maximum: #chat-log grows to 28vh, and sizing
    these columns for that would shorten them by ~430px permanently to avoid an overlap that
    only exists while the backlog is long. The overlap is handled by z-order instead — #chat
    is z-index 30 against these columns' 15, so a grown chat paints over the bottom of a

--- a/src/hooks/useConnectors.test.ts
+++ b/src/hooks/useConnectors.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useConnectors } from "./useConnectors";
+
+/** Minimal stand-in for the preload bridge. Only the connectors calls this hook makes. */
+function installBridge(overrides: Record<string, unknown> = {}) {
+  const api = {
+    connectors: {
+      list: vi.fn().mockResolvedValue([]),
+      connect: vi.fn().mockResolvedValue([]),
+      disconnect: vi.fn().mockResolvedValue([]),
+      test: vi.fn().mockResolvedValue({ ok: true }),
+      getSettings: vi.fn().mockResolvedValue({}),
+      saveSettings: vi.fn().mockResolvedValue([]),
+      onUpdate: vi.fn().mockReturnValue(() => {}),
+      ...overrides,
+    },
+  };
+  (globalThis as unknown as { window: { agentsAPI: unknown } }).window.agentsAPI = api;
+  return api;
+}
+
+describe("useConnectors error clearing", () => {
+  beforeEach(() => {
+    installBridge();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no error", async () => {
+    const { result } = renderHook(() => useConnectors());
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  // U-shape bug: test/getSettings used to leave a stale error from an earlier failed call
+  // showing forever, since neither cleared it on entry.
+  it("clears a stale error once a later test call succeeds", async () => {
+    installBridge({ test: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useConnectors());
+
+    await act(async () => {
+      await result.current.test("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ test: vi.fn().mockResolvedValue({ ok: true }) });
+    await act(async () => {
+      await result.current.test("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later getSettings call succeeds", async () => {
+    installBridge({ getSettings: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useConnectors());
+
+    await act(async () => {
+      await result.current.getSettings("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ getSettings: vi.fn().mockResolvedValue({}) });
+    await act(async () => {
+      await result.current.getSettings("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later connect call succeeds", async () => {
+    installBridge({ connect: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useConnectors());
+
+    await act(async () => {
+      await result.current.connect("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ connect: vi.fn().mockResolvedValue([]) });
+    await act(async () => {
+      await result.current.connect("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clearError resets the error directly", async () => {
+    installBridge({ test: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useConnectors());
+
+    await act(async () => {
+      await result.current.test("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useConnectors.ts
+++ b/src/hooks/useConnectors.ts
@@ -65,6 +65,7 @@ export function useConnectors() {
 
   const test = useCallback(async (id: string) => {
     if (!hasAgentsAPI()) return null;
+    setError(null);
     try {
       return await window.agentsAPI.connectors.test(id);
     } catch (e) {
@@ -75,6 +76,7 @@ export function useConnectors() {
 
   const getSettings = useCallback(async (id: string): Promise<Record<string, string>> => {
     if (!hasAgentsAPI()) return {};
+    setError(null);
     try {
       return await window.agentsAPI.connectors.getSettings(id);
     } catch (e) {
@@ -94,5 +96,18 @@ export function useConnectors() {
     }
   }, []);
 
-  return { connectors, connectingId, error, refresh, connect, disconnect, test, getSettings, saveSettings };
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    connectors,
+    connectingId,
+    error,
+    refresh,
+    connect,
+    disconnect,
+    test,
+    getSettings,
+    saveSettings,
+    clearError,
+  };
 }

--- a/src/hooks/useHttpTools.test.ts
+++ b/src/hooks/useHttpTools.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useHttpTools } from "./useHttpTools";
+
+/** Minimal stand-in for the preload bridge. Only the httpTools calls this hook makes. */
+function installBridge(overrides: Record<string, unknown> = {}) {
+  const api = {
+    httpTools: {
+      listCollections: vi.fn().mockResolvedValue([]),
+      listTools: vi.fn().mockResolvedValue([]),
+      createCollection: vi.fn(),
+      updateCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      createTool: vi.fn(),
+      updateTool: vi.fn(),
+      deleteTool: vi.fn(),
+      getCollectionHeaders: vi.fn().mockResolvedValue({}),
+      getToolHeaders: vi.fn().mockResolvedValue({}),
+      testTool: vi.fn().mockResolvedValue({ ok: true }),
+      ...overrides,
+    },
+  };
+  (globalThis as unknown as { window: { agentsAPI: unknown } }).window.agentsAPI = api;
+  return api;
+}
+
+describe("useHttpTools error clearing", () => {
+  beforeEach(() => {
+    installBridge();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no error", async () => {
+    const { result } = renderHook(() => useHttpTools());
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  // U-shape bug: getCollectionHeaders/getToolHeaders used to leave a stale error from an
+  // earlier failed testTool call showing forever, since only testTool cleared it on entry.
+  it("clears a stale error once a later testTool call succeeds", async () => {
+    installBridge({ testTool: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useHttpTools());
+
+    await act(async () => {
+      await result.current.testTool({ baseUrl: "https://example.com" });
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ testTool: vi.fn().mockResolvedValue({ ok: true }) });
+    await act(async () => {
+      await result.current.testTool({ baseUrl: "https://example.com" });
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later getCollectionHeaders call succeeds", async () => {
+    installBridge({ getCollectionHeaders: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useHttpTools());
+
+    await act(async () => {
+      await result.current.getCollectionHeaders("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ getCollectionHeaders: vi.fn().mockResolvedValue({}) });
+    await act(async () => {
+      await result.current.getCollectionHeaders("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later getToolHeaders call succeeds", async () => {
+    installBridge({ getToolHeaders: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useHttpTools());
+
+    await act(async () => {
+      await result.current.getToolHeaders("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ getToolHeaders: vi.fn().mockResolvedValue({}) });
+    await act(async () => {
+      await result.current.getToolHeaders("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clearError resets the error directly", async () => {
+    installBridge({ testTool: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useHttpTools());
+
+    await act(async () => {
+      await result.current.testTool({ baseUrl: "https://example.com" });
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useHttpTools.ts
+++ b/src/hooks/useHttpTools.ts
@@ -91,6 +91,7 @@ export function useHttpTools() {
 
   const getCollectionHeaders = useCallback(async (id: string): Promise<Record<string, string>> => {
     if (!hasAgentsAPI()) return {};
+    setError(null);
     try {
       return await window.agentsAPI.httpTools.getCollectionHeaders(id);
     } catch (e) {
@@ -101,6 +102,7 @@ export function useHttpTools() {
 
   const getToolHeaders = useCallback(async (id: string): Promise<Record<string, string>> => {
     if (!hasAgentsAPI()) return {};
+    setError(null);
     try {
       return await window.agentsAPI.httpTools.getToolHeaders(id);
     } catch (e) {
@@ -113,6 +115,7 @@ export function useHttpTools() {
   const testTool = useCallback(
     async (input: HttpToolTestInput): Promise<HttpToolTestResult | null> => {
       if (!hasAgentsAPI()) return null;
+      setError(null);
       try {
         return await window.agentsAPI.httpTools.testTool(input);
       } catch (e) {
@@ -128,6 +131,8 @@ export function useHttpTools() {
     [tools]
   );
 
+  const clearError = useCallback(() => setError(null), []);
+
   return {
     collections,
     tools,
@@ -142,5 +147,6 @@ export function useHttpTools() {
     getCollectionHeaders,
     getToolHeaders,
     testTool,
+    clearError,
   };
 }

--- a/src/hooks/useMcpServers.test.ts
+++ b/src/hooks/useMcpServers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useMcpServers } from "./useMcpServers";
+
+/** Minimal stand-in for the preload bridge. Only the mcp calls this hook makes. */
+function installBridge(overrides: Record<string, unknown> = {}) {
+  const api = {
+    mcp: {
+      list: vi.fn().mockResolvedValue([]),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      getEnv: vi.fn().mockResolvedValue({}),
+      test: vi.fn().mockResolvedValue({ ok: true }),
+      search: vi.fn().mockResolvedValue([]),
+      ...overrides,
+    },
+  };
+  (globalThis as unknown as { window: { agentsAPI: unknown } }).window.agentsAPI = api;
+  return api;
+}
+
+describe("useMcpServers error clearing", () => {
+  beforeEach(() => {
+    installBridge();
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { agentsAPI?: unknown }).agentsAPI;
+    vi.restoreAllMocks();
+  });
+
+  it("starts with no error", async () => {
+    const { result } = renderHook(() => useMcpServers());
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  // U-shape bug: testServer/searchRegistry/getEnv used to leave a stale error from an
+  // earlier failed call showing forever, since none of the three cleared it on entry.
+  it("clears a stale error once a later testServer call succeeds", async () => {
+    installBridge({ test: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useMcpServers());
+
+    await act(async () => {
+      await result.current.testServer({ name: "n", command: "c" });
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ test: vi.fn().mockResolvedValue({ ok: true }) });
+    await act(async () => {
+      await result.current.testServer({ name: "n", command: "c" });
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later searchRegistry call succeeds", async () => {
+    installBridge({ search: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useMcpServers());
+
+    await act(async () => {
+      await result.current.searchRegistry("q");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ search: vi.fn().mockResolvedValue([]) });
+    await act(async () => {
+      await result.current.searchRegistry("q");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears a stale error once a later getEnv call succeeds", async () => {
+    installBridge({ getEnv: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useMcpServers());
+
+    await act(async () => {
+      await result.current.getEnv("id");
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    installBridge({ getEnv: vi.fn().mockResolvedValue({}) });
+    await act(async () => {
+      await result.current.getEnv("id");
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clearError resets the error directly", async () => {
+    installBridge({ test: vi.fn().mockRejectedValueOnce(new Error("boom")) });
+    const { result } = renderHook(() => useMcpServers());
+
+    await act(async () => {
+      await result.current.testServer({ name: "n", command: "c" });
+    });
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useMcpServers.ts
+++ b/src/hooks/useMcpServers.ts
@@ -69,6 +69,7 @@ export function useMcpServers() {
 
   const getEnv = useCallback(async (id: string): Promise<Record<string, string>> => {
     if (!hasAgentsAPI()) return {};
+    setError(null);
     try {
       return await window.agentsAPI.mcp.getEnv(id);
     } catch (e) {
@@ -91,6 +92,7 @@ export function useMcpServers() {
   const testServer = useCallback(
     async (input: { name: string; command: string; args?: string[]; env?: Record<string, string> }) => {
       if (!hasAgentsAPI()) return null;
+      setError(null);
       try {
         return await window.agentsAPI.mcp.test(input);
       } catch (e) {
@@ -103,6 +105,7 @@ export function useMcpServers() {
 
   const searchRegistry = useCallback(async (query: string) => {
     if (!hasAgentsAPI()) return [];
+    setError(null);
     try {
       return await window.agentsAPI.mcp.search(query);
     } catch (e) {
@@ -111,5 +114,18 @@ export function useMcpServers() {
     }
   }, []);
 
-  return { servers, loading, error, addServer, updateServer, removeServer, getEnv, testServer, searchRegistry };
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    servers,
+    loading,
+    error,
+    addServer,
+    updateServer,
+    removeServer,
+    getEnv,
+    testServer,
+    searchRegistry,
+    clearError,
+  };
 }

--- a/src/hooks/useOrbitScene.ts
+++ b/src/hooks/useOrbitScene.ts
@@ -95,7 +95,7 @@ export function useOrbitScene({
   const sizesRef = useRef({ orchestratorHalf: 70, innerRadius: 210, outerRadius: 210 + BAND_GAP });
 
   function getCenter(container: HTMLDivElement) {
-    return { x: container.clientWidth / 2, y: container.clientHeight * 0.41 };
+    return { x: container.clientWidth / 2, y: container.clientHeight * 0.385 };
   }
 
   function updateSizes(container: HTMLDivElement, orchestratorEl: HTMLDivElement) {

--- a/src/lib/appLinks.ts
+++ b/src/lib/appLinks.ts
@@ -19,6 +19,7 @@ export const APP_LINKS = {
   bug: import.meta.env.VITE_APP_BUG_URL ?? `${REPO_URL}/issues`,
   privacy: import.meta.env.VITE_APP_PRIVACY_URL ?? "#privacy",
   terms: import.meta.env.VITE_APP_TERMS_URL ?? "#terms",
+  wiki: import.meta.env.VITE_APP_WIKI_URL ?? `${REPO_URL}/wiki`,
 } as const;
 
 export type AppLinkKey = keyof typeof APP_LINKS;

--- a/src/lib/configAckMessage.test.ts
+++ b/src/lib/configAckMessage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { configAckMessage, shouldPersistConfigAck, type ConfigAckEvent } from "./configAckMessage";
+
+describe("configAckMessage", () => {
+  it("returns empty string for zero events", () => {
+    expect(configAckMessage([])).toBe("");
+  });
+
+  it("formats a single file event", () => {
+    expect(configAckMessage([{ type: "file", fileName: "report.pdf" }])).toBe(
+      "I've got report.pdf. How can I help?"
+    );
+  });
+
+  it("formats a single location event", () => {
+    expect(configAckMessage([{ type: "location" }])).toBe("location is now enabled. How can I help?");
+  });
+
+  it("formats a single connector event", () => {
+    expect(
+      configAckMessage([{ type: "connector", label: "Gmail", agentNames: ["Cipher", "Atlas"] }])
+    ).toBe("Gmail is now available with Cipher, Atlas. How can I help?");
+  });
+
+  it("formats a connector event with zero agentNames without a dangling 'with' clause", () => {
+    expect(configAckMessage([{ type: "connector", label: "Gmail", agentNames: [] }])).toBe(
+      "Gmail is now available. How can I help?"
+    );
+  });
+
+  it("caps a batch over 3 events and summarizes the remainder", () => {
+    const events: ConfigAckEvent[] = [
+      { type: "file", fileName: "a.pdf" },
+      { type: "file", fileName: "b.pdf" },
+      { type: "location" },
+      { type: "connector", label: "Gmail", agentNames: [] },
+    ];
+    expect(configAckMessage(events)).toBe(
+      "I've got a.pdf, I've got b.pdf, location is now enabled, and 1 more change. How can I help?"
+    );
+  });
+});
+
+describe("shouldPersistConfigAck", () => {
+  it("is true when the batch contains a file event", () => {
+    expect(shouldPersistConfigAck([{ type: "file", fileName: "a.pdf" }])).toBe(true);
+  });
+
+  it("is true when the batch contains a connector event", () => {
+    expect(shouldPersistConfigAck([{ type: "connector", label: "Gmail", agentNames: [] }])).toBe(true);
+  });
+
+  it("is false for a location-only batch", () => {
+    expect(shouldPersistConfigAck([{ type: "location" }])).toBe(false);
+  });
+});

--- a/src/lib/configAckMessage.ts
+++ b/src/lib/configAckMessage.ts
@@ -1,0 +1,56 @@
+/** A single settings/config change worth telling the user about in chat. Mirrors
+ * `approvalSettledMessage.ts`'s shape: a pure `event(s) → string` formatter, no side effects. */
+export type ConfigAckEvent =
+  | { type: "file"; fileName: string }
+  | { type: "location" }
+  | { type: "connector"; label: string; agentNames: string[] };
+
+const MAX_LISTED_EVENTS = 3;
+
+function describe(event: ConfigAckEvent): string {
+  switch (event.type) {
+    case "file":
+      return `I've got ${event.fileName}`;
+    case "location":
+      return "location is now enabled";
+    case "connector": {
+      // Zero agentNames means the connector isn't attached to anything yet — say so without
+      // a dangling "with" clause that names nobody.
+      const withAgents = event.agentNames.length > 0 ? ` with ${event.agentNames.join(", ")}` : "";
+      return `${event.label} is now available${withAgents}`;
+    }
+  }
+}
+
+function joinPhrases(phrases: string[]): string {
+  if (phrases.length === 1) return phrases[0];
+  if (phrases.length === 2) return `${phrases[0]} and ${phrases[1]}`;
+  return `${phrases.slice(0, -1).join(", ")}, and ${phrases[phrases.length - 1]}`;
+}
+
+/**
+ * What to tell the user in chat after one or more config changes settle.
+ *
+ * Returns "" for an empty batch — the caller skips appending rather than posting a blank
+ * bubble. A batch over MAX_LISTED_EVENTS is capped so a bulk file drop doesn't produce a
+ * sentence naming twenty files; the remainder is summarized as a count instead.
+ */
+export function configAckMessage(events: ConfigAckEvent[]): string {
+  if (events.length === 0) return "";
+  const shown = events.slice(0, MAX_LISTED_EVENTS);
+  const overflow = events.length - shown.length;
+  const phrases = shown.map(describe);
+  if (overflow > 0) phrases.push(`${overflow} more change${overflow === 1 ? "" : "s"}`);
+  return `${joinPhrases(phrases)}. How can I help?`;
+}
+
+/**
+ * Whether a batch of acks is worth persisting to chat history, not just showing live.
+ *
+ * A file or connector change is something the user will want to see again on reload — it
+ * altered what the agent can do. A location-only batch is transient context, not worth
+ * cluttering history the way `approvalSettledMessage` notices already are not persisted.
+ */
+export function shouldPersistConfigAck(events: ConfigAckEvent[]): boolean {
+  return events.some((event) => event.type === "file" || event.type === "connector");
+}

--- a/src/lib/tourSteps.ts
+++ b/src/lib/tourSteps.ts
@@ -66,7 +66,7 @@ export const TOUR_STEPS: TourStep[] = [
     element: "#inp",
     title: "Slash commands",
     description:
-      "Type / and scroll the menu — there are more commands than fit on screen, and each explains itself on the right. Open apps, browse past chats and costs, manage knowledge, or direct a message to one agent.",
+      "Type / and scroll the menu — there are more commands than fit on screen, and each explains itself on the right. Open apps, browse past chats and costs, or manage knowledge. Type @ to mention one agent directly.",
   },
   {
     element: "#vbtn",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,13 +1,9 @@
 /// <reference types="vite/client" />
 
-/** Build-time release metadata, substituted by the `define` block in electron.vite.config.ts
- * (mirrored into vite.config.ts for `dev:web`). Resolved from the OpenOrbit repo's latest
- * release when the build runs; every one of these is "" — and the version "0.0.0" — when no
- * release exists or the build was offline, so consumers must handle the empty case. */
-declare const __APP_RELEASE_VERSION__: string;
-declare const __APP_RELEASE_DATE__: string;
-declare const __APP_RELEASE_NOTES__: string;
-declare const __APP_RELEASE_URL__: string;
+/** The building machine's git commit, substituted by the `define` block in
+ * electron.vite.config.ts (mirrored into vite.config.ts for `dev:web`). "" when the build ran
+ * without a .git dir — the packaged app has none of its own, so this is the only point the
+ * commit is ever knowable (see scripts/releaseInfo.ts). */
 declare const __APP_COMMIT__: string;
 
 /** Build-time overrides for the About screen's outbound links (src/lib/appLinks.ts).
@@ -364,6 +360,16 @@ interface AppStats {
   messageCount: number;
 }
 
+/** Mirrors ReleaseInfo in scripts/releaseInfo.ts — the renderer does not import that module,
+ * so `tsc` will NOT catch editing only one side. "0.0.0" is the deliberate "no release found"
+ * sentinel; every field is "" alongside it. */
+interface ReleaseInfo {
+  version: string;
+  releaseDate: string;
+  releaseNotes: string;
+  releaseUrl: string;
+}
+
 interface Window {
   agentsAPI: {
     ping: () => Promise<string>;
@@ -576,6 +582,10 @@ interface Window {
       storage: () => Promise<AppStorageInfo>;
       stats: () => Promise<AppStats>;
       clearCache: () => Promise<number>;
+      /** Live, once per call — unlike everything else on this namespace this hits the
+       * network (unauthenticated GitHub API). Never rejects; a failed/offline check resolves
+       * to the "0.0.0" sentinel like every other releaseInfo consumer. */
+      latestRelease: () => Promise<ReleaseInfo>;
     };
     dev: {
       log: (...args: unknown[]) => void;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
-import { releaseDefines } from "./electron.vite.config";
+import { buildDefines } from "./electron.vite.config";
 
 export default defineConfig({
   plugins: [react()],
-  // Same constants the Electron renderer build injects. `npm run dev:web` renders the same
-  // components, so without these every __APP_*__ reference is an undefined global there.
-  define: releaseDefines,
+  // Same constant the Electron renderer build injects. `npm run dev:web` renders the same
+  // components, so without it __APP_COMMIT__ is an undefined global there.
+  define: buildDefines,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
       // Gitignored third-party reference material (see .gitignore) — Playwright specs and
       // Next.js sources for a demo app this project doesn't build or depend on.
       "0-cowork/reference/**",
+      // Real Electron E2E specs (see e2e/playwright.config.ts) — vitest's default *.spec.ts
+      // glob would otherwise pick these up and run them through jsdom via `test.describe()`,
+      // which throws immediately since they're written against @playwright/test's runner.
+      "e2e/**",
     ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,17 +7,12 @@ export default defineConfig({
       "@": resolve(__dirname, "./src"),
     },
   },
-  // The renderer reads these as build-time globals (see releaseDefines in
+  // The renderer reads this as a build-time global (see buildDefines in
   // electron.vite.config.ts), so anything importing AboutTab throws ReferenceError without
-  // them. Fixed literals rather than the real `resolveReleaseInfo()` on purpose: that call
-  // hits git/network per run, and a test asserting on whatever version happens to be
-  // checked out is a test that changes meaning between machines. A non-"0.0.0" version is
-  // chosen so the version row renders — AboutTab hides it on the offline-build fallback.
+  // it. A fixed literal rather than the real `resolveCommit()` on purpose: that shells out to
+  // git per run, and a test asserting on whatever commit happens to be checked out is a test
+  // that changes meaning between machines.
   define: {
-    __APP_RELEASE_VERSION__: JSON.stringify("1.2.3"),
-    __APP_RELEASE_DATE__: JSON.stringify("2026-08-01T00:00:00Z"),
-    __APP_RELEASE_NOTES__: JSON.stringify("Test release notes."),
-    __APP_RELEASE_URL__: JSON.stringify("https://example.com/releases/1.2.3"),
     __APP_COMMIT__: JSON.stringify("0000000"),
   },
   test: {


### PR DESCRIPTION
## What changed
Syncs `main` to `develop`'s tip for the v0.1.1 release. Covers 19 PRs merged since v0.1.0 (#96-#114): the Playwright E2E test suite and its coverage phases, orchestrator/UI fixes, the `@` agent-mention menu, launch-time release checking, and the CHANGELOG/version bump prepping this release.

`main`'s branch protection blocks force-push, so — same as the v0.1.0 sync (#95) — this is a squash-merge PR rather than a true fast-forward.

## Testing
- Unit/integration: 1363/1363 passed (127 files)
- Lint: eslint 0, `tsc -b` 0
- Build: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)