### PR TITLE
Release v0.1.2: finalize CHANGELOG and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-08-06
+
 ### Added
 
 - **A `write_checklist` tool** giving Orbit and Cipher a live plan/progress widget in
@@ -489,6 +491,7 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.1...develop
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.2...develop
+[0.1.2]: https://github.com/maneja81/OpenOrbit/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ SmartScreen warning on Windows the first time you run one.
 
 | Platform | Download |
 | --- | --- |
-| macOS (Apple Silicon) | [OpenOrbit-0.1.0-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-arm64.dmg) |
-| macOS (Intel) | [OpenOrbit-0.1.0-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0-x64.dmg) |
-| Windows | [OpenOrbit.Setup.0.1.0.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit.Setup.0.1.0.exe) |
-| Linux | [OpenOrbit-0.1.0.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.0/OpenOrbit-0.1.0.AppImage) |
+| macOS (Apple Silicon) | [OpenOrbit-0.1.2-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2-arm64.dmg) |
+| macOS (Intel) | [OpenOrbit-0.1.2-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2-x64.dmg) |
+| Windows | [OpenOrbit.Setup.0.1.2.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit.Setup.0.1.2.exe) |
+| Linux | [OpenOrbit-0.1.2.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2.AppImage) |
 
-These links are for **v0.1.0** specifically — the filenames carry the version, so they'll
+These links are for **v0.1.2** specifically — the filenames carry the version, so they'll
 change on the next release. [Releases](https://github.com/maneja81/OpenOrbit/releases)
 always has the current set.
 
@@ -223,6 +223,9 @@ it. I read everything that gets posted, but replies land when they land — ofte
 
 Development happens on `develop`. `main` tracks stable. What's changed is in
 [CHANGELOG.md](CHANGELOG.md).
+
+The [wiki](https://github.com/maneja81/OpenOrbit/wiki) has setup and usage docs — the
+in-app Help button opens the same place.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openorbit",
   "productName": "OpenOrbit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenOrbit — a multi-agent orchestrator desktop app",
   "author": "Mohit Aneja",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Relabels the `[Unreleased]` CHANGELOG section (PR #116: checklist/ask_user tools, handoffs→tools change, and the accompanying fixes) as `[0.1.2] — 2026-08-06`
- Bumps `package.json` version to `0.1.2` to match the upcoming tag
- Updates the README download table from stale v0.1.0 links to v0.1.2, and adds a link to the wiki

## Test plan
- [x] `npx eslint src electron` — 0
- [x] `npx tsc -b` — 0
- [x] `npm run build` — 0
- [x] `npm test` — 142 files / 1552 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)