### PR TITLE
Fix folder-access relative-path resolution silently escaping to cwd

### DIFF
--- a/electron/main/ipc/filesystem.test.ts
+++ b/electron/main/ipc/filesystem.test.ts
@@ -100,6 +100,14 @@ describe("filesystem IPC allowlist (assertAllowed)", () => {
     await expect(readFolderFile(traversal)).rejects.toThrow("Access denied");
   });
 
+  it("rejects a relative path instead of silently resolving it against process.cwd()", async () => {
+    // Regression: a relative path like "open-orbit-workspace" used to resolve via
+    // path.resolve() against process.cwd() (the Electron main process cwd), landing
+    // outside every granted root and throwing a misleading "outside all allowed
+    // folders" error instead of a clear "must be absolute" one.
+    await expect(readFolderFile("note.txt")).rejects.toThrow("Path must be absolute");
+  });
+
   it("denies a symlink inside the allowed root that points outside it", async () => {
     const targetFile = path.join(outsideDir, "secret.txt");
     writeFileSync(targetFile, "nope");

--- a/electron/main/ipc/filesystem.ts
+++ b/electron/main/ipc/filesystem.ts
@@ -30,8 +30,16 @@ export function removeAllowedRoot(root: string): string[] {
 }
 
 /** Resolves symlinks for `target`. If it doesn't exist yet (e.g. a file about to be created),
- * resolves symlinks on the nearest existing ancestor directory instead. */
+ * resolves symlinks on the nearest existing ancestor directory instead. Requires `target` to
+ * already be absolute: path.resolve() on a relative string silently resolves it against
+ * process.cwd() (the Electron main process's cwd, not any user-granted folder), which let an
+ * agent-supplied relative path like "open-orbit-workspace" pass through here, land outside every
+ * allowed root, and fail assertAllowed's containment check with a misleading "outside all
+ * allowed folders" error instead of a clear "must be absolute" one. */
 async function realpathOrNearestExisting(target: string): Promise<string> {
+  if (!path.isAbsolute(target)) {
+    throw new Error(`Path must be absolute, got: "${target}"`);
+  }
   const resolved = path.resolve(target);
   try {
     return await fs.realpath(resolved);


### PR DESCRIPTION
## What changed
Agent-supplied folder/file paths (used by Atlas's `list_folder_contents` / `read_folder_file` tools) that were relative instead of absolute now fail immediately with a clear `Path must be absolute` error, instead of being silently resolved against the Electron main process's working directory and then rejected with a misleading "outside all allowed folders" message.

## Root cause
`realpathOrNearestExisting()` called `path.resolve()` on the raw input without checking it was already absolute, so a relative path from the LLM (e.g. a bare folder name) resolved against `process.cwd()` rather than any user-granted folder.

## Testing
- Unit/integration: passed 1553 (142 files) — added a regression test reproducing the exact relative-path scenario
- E2E: not configured for this change (backend guard clause, no UI surface)
- Manual: live-verified via the sandboxed run-openorbit driver — onboarded a fresh instance, granted `/tmp/orbit-test-folder`, forced Atlas to call the tool with the literal relative string `orbit-test-folder`, confirmed the exact new error in the debug log (`Path must be absolute, got: "orbit-test-folder"`), then confirmed the real absolute path still resolves and lists file contents correctly

## Notes
Also observed the model sometimes auto-corrects an obviously-relative path itself before calling the tool — the fix protects the cases where it doesn't. Separately: Atlas currently has no file-*write* tool, only read (`list_folder_contents`/`read_folder_file`) — out of scope here, flagged as a follow-up if wanted.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>