### PR TITLE
Add dev-only settings/connector seeding via --env

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,46 @@ npm run lint      # eslint
 On first run you'll be asked to name the orchestrator, introduce yourself, and enter an
 API key. Nothing else is required — there are no environment variables to set.
 
+### Skipping onboarding for faster dev loops
+
+`npm run dev` accepts extra flags after `--`:
+
+```bash
+npm run dev -- --user-data-dir=/tmp/openorbit-dev --env=.env.dev
+```
+
+- `--user-data-dir=<path>` points the app at a throwaway profile instead of your real
+  `~/Library/Application Support/OpenOrbit` (or platform equivalent) — a plain Electron/Chromium
+  flag, nothing OpenOrbit-specific.
+- `--env=<path>` seeds that profile's Settings from a `KEY=VALUE` file before the window opens,
+  so you don't have to click through onboarding by hand on every throwaway profile. Dev-only —
+  compiled out of packaged builds — and it never overwrites a profile that has already
+  completed onboarding or already has connector settings saved.
+
+```bash
+# .env.dev — gitignored (.env.* is ignored except .env.example)
+agentName=Orbit
+userName=Dev Tester
+onboardingDone=true
+
+# Either a registry provider id (goes through the providers table)...
+chatProviderId=openrouter
+chatApiKey=sk-or-...
+chatApiUrl=https://openrouter.ai/api/v1
+
+# ...or the legacy pair alone, leaving chatProviderId unset
+
+# Google connectors (Gmail/Calendar/Drive/Contacts share one Client ID/Secret)
+googleClientId=...
+googleClientSecret=...
+```
+
+Any key in [`SETTINGS_SCHEMA`](electron/main/settingsSchema.ts) can go in the file — booleans
+and numbers are coerced from their string form, everything else is validated exactly like a
+Settings UI save. Seeding the Google connector only pre-fills the Client ID/Secret fields — a
+real OAuth connection still needs one manual click per service, since consent happens in your
+system browser and nothing in the dev process can drive that.
+
 ## End-to-end tests
 
 `e2e/` holds Playwright specs that drive the real Electron app — currently onboarding, with

--- a/electron/main/devSeed.ts
+++ b/electron/main/devSeed.ts
@@ -1,0 +1,152 @@
+/**
+ * Dev-only convenience: `npm run dev -- --user-data-dir=<path> --env=<path>` seeds Settings from
+ * a plain KEY=VALUE file before the window opens, so a throwaway `--user-data-dir` profile
+ * doesn't need onboarding driven by hand on every run. `--user-data-dir` itself needs no code
+ * here — it's a Chromium switch Electron already honors; this module only handles `--env`.
+ *
+ * Never wired into a packaged build (the `is.dev` guard in index.ts), and never overwrites a
+ * profile that has already completed onboarding, so pointing a stale --env file at a real dev
+ * profile with its own configured settings is a no-op rather than a silent overwrite.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { getSetting, setSetting } from "./db/settingsStore";
+import { saveProvider } from "./db/providersStore";
+import { saveConnectorSettings, getDecryptedSettings as getConnectorSettings } from "./db/connectorsStore";
+import { getConnectorDefinition } from "./connectors/registry";
+import { encryptSecret } from "./security/secretStorage";
+import { validateSettingsPatch, SETTINGS_SCHEMA, type SettingKey } from "./settingsSchema";
+import { devLog } from "./devLog";
+
+const NAMESPACE = "appSettings.";
+const SENSITIVE_KEYS = ["chatApiKey", "voiceApiKey"];
+
+function parseEnvArg(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--env=")) return arg.slice("--env=".length);
+    if (arg === "--env") return argv[i + 1];
+  }
+  return undefined;
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of contents.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function isSettingKey(key: string): key is SettingKey {
+  return key in SETTINGS_SCHEMA;
+}
+
+/** The seed file only has strings; boolean/number settings need coercion before validation,
+ * which otherwise requires the real type (see settingsSchema.validateSettingValue). */
+function coerce(key: string, raw: string): unknown {
+  if (!isSettingKey(key)) return raw;
+  const kind = SETTINGS_SCHEMA[key].type;
+  if (kind === "boolean") return raw.toLowerCase() === "true";
+  if (kind === "number") return Number(raw);
+  if (kind === "stringArray") return raw.split(",").map((entry) => entry.trim());
+  return raw;
+}
+
+const GOOGLE_ACCOUNT_CONNECTOR_ID = "google-account";
+
+/**
+ * Seeds the Google Account connector's shared OAuth Client ID/Secret from
+ * `googleClientId`/`googleClientSecret` in the env file — every Google connector (Gmail,
+ * Calendar, Drive, Contacts) reads credentials from this one connector id
+ * (googleAccountConnector.ts), so seeding it here unblocks all four at once.
+ *
+ * This only pre-fills the Settings → Connectors fields; it cannot complete a connection.
+ * The OAuth consent screen opens the real system browser via shell.openExternal, entirely
+ * outside anything this process can drive — connecting still needs one manual click per
+ * service after the app launches.
+ */
+function seedGoogleConnector(raw: Record<string, string>): void {
+  const clientId = raw.googleClientId;
+  const clientSecret = raw.googleClientSecret;
+  if (!clientId && !clientSecret) return;
+
+  const definition = getConnectorDefinition(GOOGLE_ACCOUNT_CONNECTOR_ID);
+  if (!definition) return; // should be unreachable — registry always has this entry
+
+  if (getConnectorSettings(GOOGLE_ACCOUNT_CONNECTOR_ID)) {
+    devLog(`[devSeed] ${GOOGLE_ACCOUNT_CONNECTOR_ID} already has settings — skipping seed`);
+    return;
+  }
+
+  // Same mutable-field filter connectors:saveSettings applies — readonly fields (redirectUri)
+  // are display-only and must never be persisted.
+  const mutableKeys = new Set(definition.settingsFields.filter((f) => f.type !== "readonly").map((f) => f.key));
+  const settings: Record<string, string> = {};
+  if (clientId !== undefined && mutableKeys.has("clientId")) settings.clientId = clientId;
+  if (clientSecret !== undefined && mutableKeys.has("clientSecret")) settings.clientSecret = clientSecret;
+
+  saveConnectorSettings(GOOGLE_ACCOUNT_CONNECTOR_ID, GOOGLE_ACCOUNT_CONNECTOR_ID, settings);
+  devLog(`[devSeed] seeded ${GOOGLE_ACCOUNT_CONNECTOR_ID} connector settings`);
+}
+
+export function applyDevEnvSeed(argv: string[]): void {
+  const envPath = parseEnvArg(argv);
+  if (!envPath) return;
+  if (!existsSync(envPath)) {
+    devLog(`[devSeed] --env file not found: ${envPath}`);
+    return;
+  }
+  const raw = parseEnvFile(readFileSync(envPath, "utf8"));
+
+  // Connector settings have their own lifecycle, independent of onboarding — seeded (and
+  // guarded against overwrite) regardless of whether Settings onboarding already ran.
+  seedGoogleConnector(raw);
+
+  if (getSetting(NAMESPACE + "onboardingDone", false)) {
+    devLog(`[devSeed] onboarding already completed on this profile — skipping settings seed`);
+    return;
+  }
+
+  // googleClientId/googleClientSecret are handled by seedGoogleConnector above; left in `rest`
+  // here, they're simply refused by validateSettingsPatch as unknown settings keys (logged, not
+  // persisted) since neither is in SETTINGS_SCHEMA.
+  const { chatProviderId, chatApiKey, chatApiUrl, ...rest } = raw;
+  const settingsRaw: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rest)) {
+    settingsRaw[key] = coerce(key, value);
+  }
+
+  // A non-empty chatProviderId routes credentials through the providers table instead of the
+  // legacy chatApiKey/chatApiUrl settings pair — see provider.ts's resolveSlot. Mirroring that
+  // split here so a seeded provider id actually resolves to a working chat slot.
+  if (chatProviderId) {
+    saveProvider(chatProviderId, { apiUrl: chatApiUrl, apiKey: chatApiKey });
+    settingsRaw.chatProviderId = chatProviderId;
+  } else {
+    if (chatApiKey !== undefined) settingsRaw.chatApiKey = chatApiKey;
+    if (chatApiUrl !== undefined) settingsRaw.chatApiUrl = chatApiUrl;
+  }
+
+  const { accepted, rejected } = validateSettingsPatch(settingsRaw);
+  for (const failure of rejected) {
+    devLog(`[devSeed] refused ${NAMESPACE}${failure.key}: ${failure.reason}`);
+  }
+  for (const [key, value] of Object.entries(accepted)) {
+    if (SENSITIVE_KEYS.includes(key) && typeof value === "string" && value.length > 0) {
+      setSetting(NAMESPACE + key, encryptSecret(value));
+    } else {
+      setSetting(NAMESPACE + key, value);
+    }
+    devLog(`[devSeed] ${NAMESPACE}${key} seeded from ${envPath}`);
+  }
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -27,6 +27,7 @@ import { registerUserInfoHandlers } from "./ipc/userInfo";
 import { registerAppInfoHandlers } from "./ipc/appInfo";
 import { registerUpdateCheckHandlers } from "./ipc/updateCheck";
 import { ensureAppDirectories, migrateLegacyUserData } from "./appDirs";
+import { applyDevEnvSeed } from "./devSeed";
 import { startExplorerDaemon, stopExplorerDaemon } from "./ai/webSearchDaemon";
 import { startTaskScheduler, stopTaskScheduler, waitForInFlightPoll } from "./tasks/scheduler";
 
@@ -102,6 +103,9 @@ app.whenReady().then(() => {
   // Before ensureAppDirectories(): empty directories at the new root would block the move.
   migrateLegacyUserData();
   ensureAppDirectories();
+  // Before the IPC handlers below: it writes settings/providers rows directly, the same way
+  // onboarding would, so anything reading settings afterward sees the seeded values.
+  if (is.dev) applyDevEnvSeed(process.argv);
   registerAppPingHandler();
   registerProviderHandlers();
   registerFilesystemHandlers();

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist-electron/main/index.js",
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
-    "dev": "rm -rf dist-electron && electron-vite dev",
+    "dev": "rm -rf dist-electron && electron-vite dev --",
     "dev:web": "rm -rf dist && vite",
     "build": "tsc -b && electron-vite build",
     "build:web": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- `npm run dev -- --user-data-dir=<path> --env=<path>` seeds a fresh profile's Settings and Google connector fields from a plain `KEY=VALUE` file before the window opens, so a throwaway `--user-data-dir` test profile doesn't need onboarding driven by hand every run.
- Dev-only (`is.dev`-gated), validated/encrypted through the same `settingsSchema`/`connectorsStore` paths the real Settings UI uses, and never overwrites a profile that already completed onboarding or already has connector settings saved.
- README documents the new flags and seed file format.

## Test plan
- [x] `npx eslint src electron` — 0
- [x] `npx tsc -b` — 0
- [x] `npm run build` — 0
- [x] `npm test` — 1552/142 passed
- [x] Manually launched the built app against a throwaway `--user-data-dir` + `.env.dev` seed file (via a scratch Playwright script, not committed) — confirmed onboarding was skipped, `settings` table has `agentName`/`userName`/`onboardingDone`/`chatApiKey` (encrypted)/`chatApiUrl`, and a `connectors` row for `google-account` with an encrypted settings blob was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)