### PR TITLE
Fix tool-activity trace vanishing from the chat panel after a turn

### DIFF
--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -94,5 +94,14 @@ test.describe("Core chat flow", () => {
     checklistDb.close();
 
     expect(checklistRows.length, "no checklist_items row was written for this turn's trace_id").toBeGreaterThan(0);
+
+    // Reuses the same turn again — no second billed call. This turn's write_checklist call
+    // gives it a real tool-call step, so its assistant bubble renders an expandable
+    // ThinkingToggle (not the plain static duration line). Asserting the toggle starts open
+    // is the structural, model-wording-independent check for the "thinking trace shown then
+    // collapsed/disappeared" fix: it must render its activity rows immediately, not require a
+    // click to reveal them.
+    const toggle = page.locator(".thinking-toggle").last();
+    await expect(toggle.locator(".thinking-steps")).toBeVisible();
   });
 });

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -79,7 +79,6 @@ export default function AgentsApp() {
   const orchestratorRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const agentRefs = useRef<Record<AgentId, HTMLDivElement | null>>({});
-  const resetStepsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Wall-clock start of the turn currently in flight, read by the live "thinking" indicator
    * (via ChatPanel's liveStartedAt prop) to tick its own elapsed timer. handleSend's own
    * closure keeps its own `startedAt` local for computing elapsedMs — this state exists only
@@ -522,12 +521,6 @@ export default function AgentsApp() {
       setThinking(true);
       setOrchestratorResponding(true);
 
-      // A new send supersedes any pending "back to waiting" reset from a prior run.
-      if (resetStepsTimerRef.current) {
-        clearTimeout(resetStepsTimerRef.current);
-        resetStepsTimerRef.current = null;
-      }
-
       if (!hasAgentsAPI()) {
         setTimeout(() => {
           setOrchestratorResponding(false);
@@ -706,11 +699,11 @@ export default function AgentsApp() {
           } else {
             revealMessage();
           }
-          // Hold the "responded" entry for 10s, then return the feed to its idle state.
-          resetStepsTimerRef.current = setTimeout(() => {
-            setSteps([{ type: "waiting", label: "Waiting for message…" }]);
-            resetStepsTimerRef.current = null;
-          }, 10000);
+          // The feed stays on the turn's final state ("... responded") until the next send
+          // overwrites it at the top of this handler — no timed reset back to idle. A timed
+          // reset here previously wiped the just-shown tool activity out from under the user
+          // a few seconds after it appeared, which read as the response disappearing rather
+          // than the feed going idle.
           // Cipher's create_agent tool (and any future agent-mutating tool) writes
           // directly to the agents table from the main process — this hook's local
           // state has no other way to learn a row appeared, so resync after every run.
@@ -755,12 +748,6 @@ export default function AgentsApp() {
       startTour,
     ]
   );
-
-  useEffect(() => {
-    return () => {
-      if (resetStepsTimerRef.current) clearTimeout(resetStepsTimerRef.current);
-    };
-  }, []);
 
   // A tool marked "ask before running" pauses its agent run in the main process and waits
   // here. Queued rather than kept as a single value: one turn can interrupt on several

--- a/src/components/organisms/ChatPanel.test.tsx
+++ b/src/components/organisms/ChatPanel.test.tsx
@@ -223,15 +223,17 @@ describe("ChatPanel", () => {
     expect(container.querySelector(".thinking-toggle button")).toBeNull();
   });
 
-  it("shows an expandable duration toggle once a finished turn has tool-call steps", () => {
+  it("shows an expandable duration toggle open by default once a finished turn has tool-call steps", () => {
     const { container } = renderPanel([
       msg(1, { elapsedMs: 12000, steps: [{ type: "tool_called", label: "get_settings" }] }),
     ]);
     const btn = container.querySelector(".thinking-toggle-btn") as HTMLButtonElement;
     expect(btn.textContent).toBe("Thought for 12s");
-    expect(container.querySelector(".thinking-steps")).toBeNull();
-    fireEvent.click(btn);
+    // Open by default — this mounts right as the live indicator it replaces unmounts, so
+    // the activity trace stays visible instead of collapsing the instant the turn finishes.
     expect(container.querySelector(".thinking-steps")?.textContent).toContain("get_settings");
+    fireEvent.click(btn);
+    expect(container.querySelector(".thinking-steps")).toBeNull();
   });
 
   it("renders the live indicator while a turn is in flight, not a completed toggle", () => {

--- a/src/components/organisms/ChatPanel.tsx
+++ b/src/components/organisms/ChatPanel.tsx
@@ -98,11 +98,14 @@ function ActivityRows({ steps }: { steps: StepEvent[] }) {
 /** Minimal text+chevron toggle for a finished turn's hand-off narration and how long it
  * took — deliberately not the full WidgetCard glass-panel shell (title bar, padding,
  * border) used elsewhere, since this is meant to read as a small inline disclosure, not
- * another panel. Collapsed by default. Renders as a plain (non-interactive) line, with no
+ * another panel. Open by default: this mounts the instant `LiveThinking` unmounts (the
+ * turn just finished), so the activity it shows is the same content the user was already
+ * watching live — starting collapsed made that handoff read as the tool trace vanishing
+ * rather than settling into place. Renders as a plain (non-interactive) line, with no
  * chevron, when there's nothing substantive to expand into — a turn with no tool calls
  * still took real time, but there's no activity list behind the disclosure arrow. */
 function ThinkingToggle({ steps, elapsedMs }: { steps: StepEvent[]; elapsedMs: number }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const label = `Thought for ${formatThoughtSeconds(elapsedMs)}`;
   if (steps.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- Removes the 10s timer in `AgentsApp.tsx` that force-reset the live orbit-scene step feed back to an idle placeholder after every turn — it was wiping out the just-shown tool activity a few seconds after it appeared.
- Defaults `ThinkingToggle` (`ChatPanel.tsx`) to open instead of collapsed, so the persisted tool-activity trace that replaces the live indicator doesn't visibly vanish the instant the turn completes.
- Extends `e2e/chat-flow.spec.ts` to assert the toggle renders its activity rows open by default on a real completed turn with a tool call (reuses the existing billed call, no extra provider cost).
- Updates `ChatPanel.test.tsx` for the new default-open behavior.

## Test plan
- [x] `npx eslint src electron` — exit 0
- [x] `npx tsc -b` — exit 0
- [x] `npm run build` — exit 0
- [x] `npm test` — 142 files / 1553 tests passed
- [x] `npm run test:e2e:local` (E2E_PROVIDER=openrouter) — 33 passed, 3 pre-existing failures unrelated to this change (about-tab live release-check network timeout, general-tab voice-toggle, slash-commands `/usage` state bleed) — none touch the files this PR modifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)