### PR TITLE
Add a way to stop an in-flight agent run

### DIFF
--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -104,4 +104,23 @@ test.describe("Core chat flow", () => {
     const toggle = page.locator(".thinking-toggle").last();
     await expect(toggle.locator(".thinking-steps")).toBeVisible();
   });
+
+  test("stop button cancels an in-flight run", async () => {
+    // Real, billed call (a run has to actually be in flight to cancel) — kept minimal:
+    // stopped as soon as the button appears, so this bills only the tokens generated before
+    // abort, not a full reply. A prompt nudging a slower/longer reply gives the click a
+    // realistic window to land before the run would have finished on its own anyway.
+    await typeIntoField(page, "#inp", "Count from 1 to 20, one number per line, nothing else.");
+    await page.keyboard.press("Enter");
+
+    const stopButton = page.locator("#sbtn");
+    await expect(stopButton).toHaveAttribute("aria-label", /^Stop /, { timeout: 15_000 });
+    await stopButton.click();
+
+    // The run resolves (not rejects) on a user-initiated stop — see agent:runStream's catch
+    // handler in electron/main/ipc/agent.ts — so the send button/textarea return to their
+    // idle state well before the app's own agentRunTimeoutSeconds would have forced it.
+    await expect(page.locator("#inp")).toBeEnabled({ timeout: 20_000 });
+    await expect(stopButton).not.toHaveAttribute("aria-label", /^Stop /);
+  });
 });

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -128,5 +128,18 @@ test.describe("Core chat flow", () => {
     // there's text to send.
     await expect(page.locator("#inp")).toBeEnabled({ timeout: 20_000 });
     await expect(stopButton).toHaveCount(0);
+
+    // The stopped turn must never fall back to "(no response)" — that copy is for a genuine
+    // empty reply, and reads as a bug when what actually happened is the user stopped it.
+    // Not asserting the exact "Stopped." text: if a chunk or two streamed before the click
+    // landed, finalText falls back to that partial text instead (see AgentsApp.tsx's
+    // finalText derivation) — real, model-timing-dependent, and not something this test
+    // should pin down to an exact string.
+    const db = openDb(userData);
+    const lastAssistant = db
+      .prepare("SELECT text FROM messages WHERE role = 'assistant' ORDER BY id DESC LIMIT 1")
+      .get() as { text: string } | undefined;
+    db.close();
+    expect(lastAssistant?.text).not.toBe("(no response)");
   });
 });

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { resolveE2EProvider } from "./providerConfig";
-import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, openDb, pollUntil } from "./helpers";
+import { launchSandboxedApp, launchApp, completeOnboarding, typeIntoField, clickSelector, openDb, pollUntil } from "./helpers";
 
 // The only spec in this suite that makes a real, billed AI provider call — see
 // 0-cowork/plans/active/e2e-full-coverage.md Phase 4. Cost is whatever E2E_PROVIDER/.env.test
@@ -115,12 +115,18 @@ test.describe("Core chat flow", () => {
 
     const stopButton = page.locator("#sbtn");
     await expect(stopButton).toHaveAttribute("aria-label", /^Stop /, { timeout: 15_000 });
-    await stopButton.click();
+    // Locator clicks time out on "element is not stable" against this app's continuous
+    // framer-motion animation (and a driver.js tour overlay can intercept pointer events
+    // entirely) — see helpers.ts's clickSelector comment.
+    await clickSelector(page, "#sbtn");
 
     // The run resolves (not rejects) on a user-initiated stop — see agent:runStream's catch
-    // handler in electron/main/ipc/agent.ts — so the send button/textarea return to their
-    // idle state well before the app's own agentRunTimeoutSeconds would have forced it.
+    // handler in electron/main/ipc/agent.ts — so the textarea returns to its idle state well
+    // before the app's own agentRunTimeoutSeconds would have forced it. #sbtn itself
+    // disappears rather than reverting to "Send" — the field's text was already cleared when
+    // the turn was sent, and ChatInputBar only renders the button while responding or while
+    // there's text to send.
     await expect(page.locator("#inp")).toBeEnabled({ timeout: 20_000 });
-    await expect(stopButton).not.toHaveAttribute("aria-label", /^Stop /);
+    await expect(stopButton).toHaveCount(0);
   });
 });

--- a/electron/main/ipc/agent.ts
+++ b/electron/main/ipc/agent.ts
@@ -277,6 +277,13 @@ function abandonQuestionsFor(requestId: string): void {
   }
 }
 
+/** Aborters for every run currently in flight, keyed by the renderer-supplied requestId —
+ * how agent:stop reaches into a specific run to cancel it. `cancel` both flips the run's own
+ * `cancelled` closure flag (so its catch handler can resolve "" instead of rethrowing) and
+ * aborts the signal passed into the SDK's run() call. Entries are removed once the run
+ * settles (Promise.race's finally below), so a stale requestId is a harmless no-op. */
+const activeRuns = new Map<string, { cancel: () => void }>();
+
 export function registerAgentHandlers() {
   // The non-streaming "agent:run" channel was unreachable from the renderer — no hook or
   // component called it, ChatInputBar/AgentsApp only ever use agent:runStream below — and
@@ -329,6 +336,18 @@ export function registerAgentHandlers() {
       // settles. Instead `timedOut` lets the background run notice it lost the race and
       // skip all of that, closing MCP servers itself exactly once when it actually stops.
       let timedOut = false;
+      // Set by agent:stop below. Distinct from timedOut (a different reason a run stops
+      // early) so the eventual return value can tell the two apart: a stop returns "" and
+      // lets the renderer keep whatever text had already streamed, while a timeout still
+      // rejects the runStream promise the way it always has.
+      let cancelled = false;
+      const abortController = new AbortController();
+      activeRuns.set(requestId, {
+        cancel: () => {
+          cancelled = true;
+          abortController.abort();
+        },
+      });
       const timeoutMs = getAgentRunTimeoutMs();
       const deadline = createPausableDeadline(timeoutMs, `Agent run timed out after ${timeoutMs / 1000}s`);
 
@@ -416,7 +435,7 @@ export function registerAgentHandlers() {
        * have to reach the same subscriptions. */
       const forwardStreamEvents = async (segment: AsyncIterable<RunStreamEvent>): Promise<void> => {
         for await (const ev of segment) {
-          if (timedOut) break;
+          if (timedOut || cancelled) break;
           if (ev.type === "raw_model_stream_event") {
             const e = ev as RunRawModelStreamEvent;
             if (e.data.type === "output_text_delta") {
@@ -476,14 +495,15 @@ export function registerAgentHandlers() {
           const segment = await run(target, segmentInput as Parameters<typeof run>[1], {
             stream: true,
             maxTurns: MAX_TURNS_PER_RUN,
+            signal: abortController.signal,
           });
           await forwardStreamEvents(segment);
           await segment.completed;
-          if (!timedOut) logTokenUsage(segment, traceId);
+          if (!timedOut && !cancelled) logTokenUsage(segment, traceId);
           return segment;
         };
         devLog(`[agent:runStream] requestId=${requestId} running ${label}`);
-        return resolveApprovalsAndRun(runOnce, input, requestApproval, () => timedOut);
+        return resolveApprovalsAndRun(runOnce, input, requestApproval, () => timedOut || cancelled);
       };
 
       // Passed into buildOrchestrator so every specialist agent gets wrapped as a tool the
@@ -569,7 +589,6 @@ export function registerAgentHandlers() {
       // an approval pause — see its class comment.
       return await Promise.race([runPromise, deadline.promise])
         .catch((err) => {
-          timedOut = true;
           // A dialog waiting on a run that just died would otherwise hang until its own
           // 5-minute timeout.
           abandonApprovalsFor(requestId);
@@ -578,11 +597,36 @@ export function registerAgentHandlers() {
           // Same reasoning, for the checklist widget: a run that dies mid-plan must not
           // leave an item stuck showing "in progress" forever.
           cancelPendingForTrace(traceId);
+          // A user-initiated stop resolves rather than rejects — the caller (AgentsApp)
+          // falls back to whatever text had already streamed instead of showing an error
+          // toast for something the user asked for. A genuine timeout/failure still throws.
+          if (cancelled) return "";
+          timedOut = true;
           throw err;
         })
-        .finally(() => deadline.clear());
+        .finally(() => {
+          deadline.clear();
+          activeRuns.delete(requestId);
+        });
     }
   );
+
+  /** Cancels an in-flight run by requestId. Unknown/already-settled requestId is a silent
+   * no-op — same reasoning as agent:approveTool: a double-click, or a stop that lands just
+   * after the run finished on its own, must not surface as an error to the user. Aborting
+   * the SDK's run() only stops a segment actually in flight — a run paused waiting on an
+   * approval or ask_user answer isn't inside run() at all, so its pending prompt is settled
+   * here too (same "abandoned" path a timed-out run already uses), which is what actually
+   * unblocks resolveApprovalsAndRun's isAborted check and lets the run's catch handler see
+   * `cancelled` and resolve "" instead of hanging until the 5-minute approval timeout. */
+  ipcMain.handle("agent:stop", (_event, requestId: string) => {
+    if (typeof requestId !== "string" || requestId.length === 0) {
+      throw new Error("agent:stop requires a non-empty requestId");
+    }
+    activeRuns.get(requestId)?.cancel();
+    abandonApprovalsFor(requestId);
+    abandonQuestionsFor(requestId);
+  });
 
   /** The renderer's answer to an agent:stream-approval prompt. An unknown or already-settled
    * approvalId is a no-op rather than an error — a double-click on Approve, or a reply that

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -153,6 +153,10 @@ const agentsAPI = {
   agent: {
     runStream: (input: string, requestId: string, targetAgentName?: string, persistInput?: boolean): Promise<string> =>
       ipcRenderer.invoke("agent:runStream", input, requestId, targetAgentName, persistInput),
+    /** Aborts an in-flight run started by runStream, identified by the same requestId. The
+     * runStream call still resolves normally afterward (with whatever text had streamed so
+     * far, or "" if none) rather than rejecting — see agent:stop's handler comment. */
+    stop: (requestId: string): Promise<void> => ipcRenderer.invoke("agent:stop", requestId),
     onStreamChunk: (callback: (payload: { requestId: string; chunk: string }) => void): (() => void) =>
       subscribeWithPayload("agent:stream-chunk", callback),
     onStreamAgent: (callback: (payload: { requestId: string; agentName: string }) => void): (() => void) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openorbit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openorbit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/molecules/ChatInputBar.test.tsx
+++ b/src/components/molecules/ChatInputBar.test.tsx
@@ -21,6 +21,7 @@ function renderBar(overrides: Partial<Parameters<typeof ChatInputBar>[0]> = {}) 
     voiceEnabled: true,
     agents: [],
     onSend: vi.fn(),
+    onStop: vi.fn(),
     onStartVoice: vi.fn(),
     onStopVoice: vi.fn(),
     ...overrides,

--- a/src/components/molecules/ChatInputBar.tsx
+++ b/src/components/molecules/ChatInputBar.tsx
@@ -34,7 +34,12 @@ interface ChatInputBarProps {
    * thing — "approve or decline" is wrong (and was shown, misleadingly) while an ask_user
    * card is actually what's waiting for input. Ignored when sendDisabled is false. */
   sendDisabledReason?: "approval" | "question" | "responding";
+  /** True for the whole span of an in-flight run, including its approval/question pauses —
+   * swaps the send button for a Stop button so a run can be cancelled mid-response instead
+   * of only ever waited out. */
+  responding?: boolean;
   onSend: () => void;
+  onStop: () => void;
   onStartVoice: () => void;
   onStopVoice: () => void;
 }
@@ -68,7 +73,9 @@ export default function ChatInputBar({
   agents,
   sendDisabled,
   sendDisabledReason,
+  responding,
   onSend,
+  onStop,
   onStartVoice,
   onStopVoice,
 }: ChatInputBarProps) {
@@ -358,21 +365,21 @@ export default function ChatInputBar({
                   <TablerIcon name={transcribing ? "ti-loader-2" : "ti-microphone"} />
                 </IconButton>
               )}
-              {hasText && (
-                <IconButton
-                  id="sbtn"
-                  aria-label={
-                    sendDisabled
-                      ? sendDisabledReason === "responding"
-                        ? `Waiting for ${agentName} to finish`
-                        : "Waiting for your approval"
-                      : "Send"
-                  }
-                  disabled={sendDisabled}
-                  onClick={handleSendClick}
-                >
-                  <TablerIcon name="ti-arrow-up" />
+              {responding ? (
+                <IconButton id="sbtn" aria-label={`Stop ${agentName}`} onClick={onStop}>
+                  <TablerIcon name="ti-player-stop" />
                 </IconButton>
+              ) : (
+                hasText && (
+                  <IconButton
+                    id="sbtn"
+                    aria-label={sendDisabled ? "Waiting for your approval" : "Send"}
+                    disabled={sendDisabled}
+                    onClick={handleSendClick}
+                  >
+                    <TablerIcon name="ti-arrow-up" />
+                  </IconButton>
+                )
               )}
             </div>
           </div>

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -103,6 +103,12 @@ export default function AgentsApp() {
   // handleSend's own .finally() alongside orchestratorResponding, so it never outlives the
   // run it names.
   const activeRequestIdRef = useRef<string | null>(null);
+  // Set by handleStop, read by handleSend's runStream resolution to tell "the user stopped
+  // this" apart from "the model genuinely returned nothing" — main resolves both the same
+  // way (empty string), since it has no notion of the user-facing copy either case should
+  // show. Not cleared on the next send: handleSend's own .then() clears it once read, so a
+  // stale value can only ever match its own requestId.
+  const cancelledRequestIdRef = useRef<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection | undefined>(undefined);
   const [kbModalOpen, setKbModalOpen] = useState(false);
@@ -667,10 +673,15 @@ export default function AgentsApp() {
       window.agentsAPI.agent
         .runStream(directedAgent?.rest ?? value, requestId, directedAgent?.agent.name)
         .then((result) => {
+          const wasCancelled = cancelledRequestIdRef.current === requestId;
+          if (wasCancelled) cancelledRequestIdRef.current = null;
           // finalOutput is authoritative (covers handoffs/tool calls where the streamed
           // deltas might not perfectly equal the final text) — falls back to whatever
-          // streamed in if it's somehow empty.
-          const finalText = result || streamedText || "(no response)";
+          // streamed in if it's somehow empty. A user-initiated stop resolves the same way a
+          // genuinely empty reply does (both "" from main — see agent:runStream's catch
+          // handler), so the fallback copy has to come from wasCancelled, not from result
+          // itself.
+          const finalText = result || streamedText || (wasCancelled ? "Stopped." : "(no response)");
           turnSteps = [...turnSteps, { type: "responded", label: `${settings.agentName} responded` }];
           setSteps(turnSteps);
           // The live orbit-scene feed already shows the generic bookkeeping steps
@@ -759,6 +770,7 @@ export default function AgentsApp() {
   const handleStop = useCallback(() => {
     const requestId = activeRequestIdRef.current;
     if (!requestId || !hasAgentsAPI()) return;
+    cancelledRequestIdRef.current = requestId;
     window.agentsAPI.agent.stop(requestId);
   }, []);
 

--- a/src/components/organisms/AgentsApp.tsx
+++ b/src/components/organisms/AgentsApp.tsx
@@ -98,6 +98,11 @@ export default function AgentsApp() {
   const communicatingClearTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const [steps, setSteps] = useState<StepEvent[]>([{ type: "waiting", label: "Waiting for message…" }]);
   const [orchestratorResponding, setOrchestratorResponding] = useState(false);
+  // The requestId of the run currently in flight, if any — read by handleStop, which has no
+  // other way to reach the requestId scoped inside handleSend's closure. Cleared in
+  // handleSend's own .finally() alongside orchestratorResponding, so it never outlives the
+  // run it names.
+  const activeRequestIdRef = useRef<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection | undefined>(undefined);
   const [kbModalOpen, setKbModalOpen] = useState(false);
@@ -532,6 +537,7 @@ export default function AgentsApp() {
       }
 
       const requestId = crypto.randomUUID();
+      activeRequestIdRef.current = requestId;
       let streamedText = "";
       let respondingLogged = false;
       let assistantMessageId: string | null = null;
@@ -728,6 +734,7 @@ export default function AgentsApp() {
           setOrchestratorResponding(false);
           setThinking(false);
           setRunStartedAt(null);
+          if (activeRequestIdRef.current === requestId) activeRequestIdRef.current = null;
           playSfx("complete");
         });
     },
@@ -748,6 +755,12 @@ export default function AgentsApp() {
       startTour,
     ]
   );
+
+  const handleStop = useCallback(() => {
+    const requestId = activeRequestIdRef.current;
+    if (!requestId || !hasAgentsAPI()) return;
+    window.agentsAPI.agent.stop(requestId);
+  }, []);
 
   // A tool marked "ask before running" pauses its agent run in the main process and waits
   // here. Queued rather than kept as a single value: one turn can interrupt on several
@@ -1150,10 +1163,12 @@ export default function AgentsApp() {
                   ? "responding"
                   : undefined
           }
+          responding={orchestratorResponding}
           onShowFullHistory={() => setChatHistoryOpen(true)}
           visibleConversationCount={settings.chatVisibleConversations}
           autoLoadRemoteImages={settings.remoteImagesAutoLoad}
           onSend={() => handleSend()}
+          onStop={handleStop}
           onStartVoice={startVoice}
           onStopVoice={stopVoice}
         />

--- a/src/components/organisms/ChatPanel.test.tsx
+++ b/src/components/organisms/ChatPanel.test.tsx
@@ -49,6 +49,7 @@ function renderPanel(messages: ChatMessage[], overrides = {}) {
       // below (written for that flat cap) still assert against.
       visibleConversationCount={5}
       onSend={vi.fn()}
+      onStop={vi.fn()}
       onStartVoice={vi.fn()}
       onStopVoice={vi.fn()}
       {...overrides}

--- a/src/components/organisms/ChatPanel.tsx
+++ b/src/components/organisms/ChatPanel.tsx
@@ -62,6 +62,9 @@ interface ChatPanelProps {
   /** KI-3: which kind blocked it, forwarded to ChatInputBar so its placeholder describes
    * the actual pause instead of always assuming an approval gate. */
   sendDisabledReason?: "approval" | "question" | "responding";
+  /** True for the whole span of an in-flight run — forwarded to ChatInputBar so it can swap
+   * the send button for a Stop button. */
+  responding?: boolean;
   /** Opens the full paged archive (ChatHistoryModal) — the log itself only keeps the last
    * visibleConversationCount conversations on screen. */
   onShowFullHistory: () => void;
@@ -72,6 +75,7 @@ interface ChatPanelProps {
   /** Forwarded to every bubble — see AgentsSettings.remoteImagesAutoLoad. */
   autoLoadRemoteImages?: boolean;
   onSend: () => void;
+  onStop: () => void;
   onStartVoice: () => void;
   onStopVoice: () => void;
 }
@@ -177,10 +181,12 @@ export default function ChatPanel({
   liveSteps,
   sendDisabled,
   sendDisabledReason,
+  responding,
   onShowFullHistory,
   visibleConversationCount,
   autoLoadRemoteImages,
   onSend,
+  onStop,
   onStartVoice,
   onStopVoice,
 }: ChatPanelProps) {
@@ -278,7 +284,9 @@ export default function ChatPanel({
         agents={agents}
         sendDisabled={sendDisabled}
         sendDisabledReason={sendDisabledReason}
+        responding={responding}
         onSend={onSend}
+        onStop={onStop}
         onStartVoice={onStartVoice}
         onStopVoice={onStopVoice}
       />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -475,6 +475,7 @@ interface Window {
     };
     agent: {
       runStream: (input: string, requestId: string, targetAgentName?: string, persistInput?: boolean) => Promise<string>;
+      stop: (requestId: string) => Promise<void>;
       onStreamChunk: (callback: (payload: { requestId: string; chunk: string }) => void) => () => void;
       onStreamAgent: (callback: (payload: { requestId: string; agentName: string }) => void) => () => void;
       onStreamStep: (


### PR DESCRIPTION
## What changed
There was no cancel mechanism anywhere in the run pipeline — no `AbortSignal` into the `@openai/agents` SDK's `run()` call, no stop IPC channel, no UI affordance. A run could only be waited out or left to hit the configured timeout, silently burning tokens in the background either way.

Threads an `AbortController` per `requestId` into `run()`'s `signal` option, adds an `agent:stop` IPC channel that aborts it and settles any pending approval/question the run was paused on, and swaps the chat input's send button for a Stop button for the run's whole duration. A user-initiated stop resolves the `runStream` call (falling back to whatever text had already streamed, or "Stopped." if nothing had) rather than rejecting it, so it reads as a normal turn ending, not an error.

## Root cause
No `AbortController`/`AbortSignal` existed anywhere in `electron/main/ai/agents.ts` or `electron/main/ipc/agent.ts`, and no stop/cancel IPC channel or UI control existed to trigger one.

## Testing
- Unit/integration: 1553 passed / 142 files — `npm test`
- E2E: `e2e/chat-flow.spec.ts` — both specs pass against a live provider (real routed reply unaffected; new stop-button spec confirms the run cancels, the input re-enables well inside the timeout window, and the assistant bubble never falls back to "(no response)")
- Manual: verified live via `npm run test:e2e:local` against a real provider, including the follow-up "Stopped." copy fix

## Notes
Also syncs `package-lock.json`'s stale `version` field (0.1.1 → 0.1.2, matching `package.json`), noticed while reinstalling `@playwright/test` for the e2e run.

🤖 Generated with Claude Code