### PR TITLE
Release v0.1.3: finalize CHANGELOG and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] — 2026-08-22
+
+### Added
+
+- **A Stop button on the chat input** — an in-flight agent run had no cancel
+  mechanism anywhere in the pipeline, only the configured run timeout (up to an
+  hour by default). The send button now swaps to Stop for the run's whole
+  duration, including any tool-approval or `ask_user` pause, and aborting
+  settles those the same way an abandoned run already did.
+
+### Fixed
+
+- A cancelled run showed "(no response)" when nothing had streamed yet; it now
+  shows "Stopped." instead.
+
 ## [0.1.2] — 2026-08-06
 
 ### Added
@@ -491,7 +506,8 @@ build from source.
   low), `fast-csv` (denial of service, low), and `exceljs` 3.4.0 → 3.10.0.
   ([#5](https://github.com/maneja81/OpenOrbit/pull/5))
 
-[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.2...develop
+[Unreleased]: https://github.com/maneja81/OpenOrbit/compare/v0.1.3...develop
+[0.1.3]: https://github.com/maneja81/OpenOrbit/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/maneja81/OpenOrbit/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/maneja81/OpenOrbit/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/maneja81/OpenOrbit/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ SmartScreen warning on Windows the first time you run one.
 
 | Platform | Download |
 | --- | --- |
-| macOS (Apple Silicon) | [OpenOrbit-0.1.2-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2-arm64.dmg) |
-| macOS (Intel) | [OpenOrbit-0.1.2-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2-x64.dmg) |
-| Windows | [OpenOrbit.Setup.0.1.2.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit.Setup.0.1.2.exe) |
-| Linux | [OpenOrbit-0.1.2.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.2/OpenOrbit-0.1.2.AppImage) |
+| macOS (Apple Silicon) | [OpenOrbit-0.1.3-arm64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.3/OpenOrbit-0.1.3-arm64.dmg) |
+| macOS (Intel) | [OpenOrbit-0.1.3-x64.dmg](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.3/OpenOrbit-0.1.3-x64.dmg) |
+| Windows | [OpenOrbit.Setup.0.1.3.exe](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.3/OpenOrbit.Setup.0.1.3.exe) |
+| Linux | [OpenOrbit-0.1.3.AppImage](https://github.com/maneja81/OpenOrbit/releases/download/v0.1.3/OpenOrbit-0.1.3.AppImage) |
 
-These links are for **v0.1.2** specifically — the filenames carry the version, so they'll
+These links are for **v0.1.3** specifically — the filenames carry the version, so they'll
 change on the next release. [Releases](https://github.com/maneja81/OpenOrbit/releases)
 always has the current set.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openorbit",
   "productName": "OpenOrbit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenOrbit — a multi-agent orchestrator desktop app",
   "author": "Mohit Aneja",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Relabels the `[Unreleased]` CHANGELOG section (PR #122: agent-run stop button) as `[0.1.3] — 2026-08-22`
- Bumps `package.json` version to `0.1.3` to match the upcoming tag
- Updates the README download table from v0.1.2 to v0.1.3 links

## Test plan
- [x] `npx eslint src electron` — 0
- [x] `npx tsc -b` — 0
- [x] `npm run build` — 0
- [x] `npm test` — 142 files / 1553 tests passing

🤖 Generated with Claude Code